### PR TITLE
RR-1471 - Wire SearchService call into /search route

### DIFF
--- a/assets/scss/components/_api-error.scss
+++ b/assets/scss/components/_api-error.scss
@@ -1,0 +1,22 @@
+.hmpps-api-error-banner {
+  padding: 16px 22px;
+  background-color: govuk-colour('light-grey');
+  border-left: 8px solid govuk-colour('red');
+  margin-top: 20px;
+
+  p {
+    font-size: 19px;
+    line-height: 25px;
+    font-weight: 700;
+    color: govuk-colour('black');
+    margin: 5px 0;
+  }
+
+  p + p {
+    font-size: 19px;
+    line-height: 25px;
+    font-weight: 300;
+    color: govuk-colour('black');
+    margin-top: 0;
+  }
+}

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -9,5 +9,6 @@ $govuk-page-width: $moj-page-width;
 @import '@ministryofjustice/hmpps-connect-dps-components/dist/assets/footer';
 @import '@ministryofjustice/hmpps-connect-dps-components/dist/assets/header-bar';
 
+@import './components/api-error';
 @import './components/search';
 @import './overrides/local';

--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -35,7 +35,7 @@ generic-service:
     AUDIT_SQS_REGION: 'eu-west-2'
     AUDIT_SERVICE_NAME: 'DPS124' # Your audit service name
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
-    PRISONER_LIST_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
+    SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
 
     # Comma delimited list of prison IDs that our service is rolled out into (active agencies)
     # Use spaces to aid readability if necessary; these are trimmed when the environment variable is read and processed.

--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import successMessageMiddleware from './middleware/successMessageMiddleware'
 import config from './config'
 import logger from '../logger'
 import auditMiddleware from './middleware/auditMiddleware'
+import apiErrorMiddleware from './middleware/apiErrorMiddleware'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -43,6 +44,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(apiErrorMiddleware())
   app.use(successMessageMiddleware)
   app.use(errorMessageMiddleware)
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -122,6 +122,7 @@ export default {
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   newDpsUrl: get('NEW_DPS_URL', 'http://localhost:3000/', requiredInProduction),
+  searchUiDefaultPaginationPageSize: Number(get('SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE', 50, requiredInProduction)),
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
   },

--- a/server/middleware/apiErrorMiddleware.ts
+++ b/server/middleware/apiErrorMiddleware.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from 'express'
+import asyncMiddleware from './asyncMiddleware'
+import logger from '../../logger'
+
+export default function apiErrorMiddleware(): RequestHandler {
+  return asyncMiddleware((req, res, next) => {
+    res.locals.apiErrorCallback = (error: Error) => {
+      logger.error(error)
+      res.locals.pageHasApiErrors = true
+    }
+
+    return next()
+  })
+}

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -4,15 +4,18 @@ import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AuditService, { Page } from '../services/auditService'
 import PrisonService from '../services/prisonService'
 import JourneyDataService from '../services/journeyDataService'
+import SearchService from '../services/searchService'
 
 jest.mock('../services/auditService')
 jest.mock('../services/prisonService')
 jest.mock('../services/journeyDataService')
+jest.mock('../services/searchService')
 
 let app: Express
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 const journeyDataService = new JourneyDataService(null) as jest.Mocked<JourneyDataService>
+const searchService = new SearchService(null) as jest.Mocked<SearchService>
 
 beforeEach(() => {
   app = appWithAllRoutes({
@@ -20,6 +23,7 @@ beforeEach(() => {
       auditService,
       prisonService,
       journeyDataService,
+      searchService,
     },
   })
 

--- a/server/routes/search/index.ts
+++ b/server/routes/search/index.ts
@@ -1,13 +1,53 @@
-import { Router } from 'express'
+import { NextFunction, Request, Response, Router } from 'express'
 import { Services } from '../../services'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import SearchController from './searchController'
+import SearchSortField from '../../enums/searchSortField'
+import SearchSortDirection from '../../enums/searchSortDirection'
+import config from '../../config'
+import { Result } from '../../utils/result/result'
 
-const searchRoutes = (_services: Services): Router => {
+const DEFAULT_SORT_FIELD = SearchSortField.PRISONER_NAME
+const DEFAULT_SORT_DIRECTION = SearchSortDirection.ASC
+
+const searchRoutes = (services: Services): Router => {
   const router = Router({ mergeParams: true })
+  const { searchService } = services
   const searchController = new SearchController()
 
-  router.get('/', [asyncMiddleware(searchController.getSearchView)])
+  const performSearch = async (req: Request, res: Response, next: NextFunction) => {
+    const searchTerm = (req.query.searchTerm as string) || ''
+    const sortField = (req.query.sortField as SearchSortField) || DEFAULT_SORT_FIELD
+    const sortDirection = (req.query.sortDirection as SearchSortDirection) || DEFAULT_SORT_DIRECTION
+    const page = parseInt((req.query.page as string) || '1', 10)
+    const pageSize = config.searchUiDefaultPaginationPageSize
+    const { activeCaseLoadId, username } = res.locals.user
+
+    res.locals = {
+      ...res.locals,
+      searchResults: await Result.wrap(
+        searchService.searchPrisonersInPrison(
+          activeCaseLoadId,
+          username,
+          page,
+          pageSize,
+          sortField,
+          sortDirection,
+          searchTerm,
+        ),
+      ),
+      searchTerm,
+      sortField,
+      sortDirection,
+    }
+    next()
+  }
+
+  router.get('/', [
+    // comment to aid formatting
+    asyncMiddleware(performSearch),
+    asyncMiddleware(searchController.getSearchView),
+  ])
 
   return router
 }

--- a/server/routes/search/index.ts
+++ b/server/routes/search/index.ts
@@ -23,23 +23,24 @@ const searchRoutes = (services: Services): Router => {
     const pageSize = config.searchUiDefaultPaginationPageSize
     const { activeCaseLoadId, username } = res.locals.user
 
-    res.locals = {
-      ...res.locals,
-      searchResults: await Result.wrap(
-        searchService.searchPrisonersInPrison(
-          activeCaseLoadId,
-          username,
-          page,
-          pageSize,
-          sortField,
-          sortDirection,
-          searchTerm,
-        ),
+    const { apiErrorCallback } = res.locals
+
+    res.locals.searchResults = await Result.wrap(
+      searchService.searchPrisonersInPrison(
+        activeCaseLoadId,
+        username,
+        page,
+        pageSize,
+        sortField,
+        sortDirection,
+        searchTerm,
       ),
-      searchTerm,
-      sortField,
-      sortDirection,
-    }
+      apiErrorCallback,
+    )
+    res.locals.searchTerm = searchTerm
+    res.locals.sortField = sortField
+    res.locals.sortDirection = sortDirection
+
     next()
   }
 

--- a/server/routes/search/searchController.ts
+++ b/server/routes/search/searchController.ts
@@ -1,17 +1,9 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import SearchSortField from '../../enums/searchSortField'
-import SearchSortDirection from '../../enums/searchSortDirection'
-
-const DEFAULT_SORT_FIELD = SearchSortField.PRISONER_NAME
-const DEFAULT_SORT_DIRECTION = SearchSortDirection.ASC
 
 export default class SearchController {
   getSearchView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const searchTerm = (req.query.searchTerm as string) || ''
-    const sortField = (req.query.sortField as string) || DEFAULT_SORT_FIELD
-    const sortDirection = (req.query.sortDirection as string) || DEFAULT_SORT_DIRECTION
-
-    const viewRenderArgs = { searchTerm, sortField, sortDirection }
+    const { searchResults, searchTerm, sortField, sortDirection } = res.locals
+    const viewRenderArgs = { searchResults, searchTerm, sortField, sortDirection }
     return res.render('pages/search/index', viewRenderArgs)
   }
 }

--- a/server/utils/result/result.test.ts
+++ b/server/utils/result/result.test.ts
@@ -1,0 +1,154 @@
+import { Result } from './result'
+
+const error = new Error('Some error!')
+
+describe('result', () => {
+  describe('isFulfilled', () => {
+    it('reports fulfilled', () => {
+      expect(Result.fulfilled(1).isFulfilled()).toBeTruthy()
+    })
+
+    it('reports rejected', () => {
+      expect(Result.rejected(error).isFulfilled()).toBeFalsy()
+    })
+  })
+
+  describe('handle', () => {
+    it('can handle a fulfilled result', () => {
+      expect(Result.fulfilled(1).handle({ fulfilled: i => i + 1, rejected: _e => null as unknown })).toEqual(2)
+      expect(
+        Result.fulfilled('hello').handle({ fulfilled: s => `${s} there`, rejected: _e => null as unknown }),
+      ).toEqual('hello there')
+      expect(
+        Result.fulfilled({ some: 'object' }).handle({
+          fulfilled: o => ({ ...o, another: 'field' }),
+          rejected: _e => null as unknown,
+        }),
+      ).toEqual({ some: 'object', another: 'field' })
+    })
+
+    it('can handle a rejected result', () => {
+      expect(
+        Result.rejected(error).handle({ fulfilled: value => value, rejected: e => ({ handled: e.message }) }),
+      ).toEqual({
+        handled: error.message,
+      })
+    })
+  })
+
+  describe('getOrThrow', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled(value).getOrThrow()).toEqual(value)
+    })
+
+    it('can throw an error from a rejected result', () => {
+      expect(Result.rejected(error).getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('getOrHandle', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled<unknown, Error>(value).getOrHandle(e => e.message)).toEqual(value)
+    })
+
+    it('can handle an error from a rejected result', () => {
+      expect(Result.rejected(error).getOrHandle(e => e.message)).toEqual(error.message)
+    })
+  })
+
+  describe('getOrNull', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled(value).getOrNull()).toEqual(value)
+    })
+
+    it('returns null from a rejected result', () => {
+      expect(Result.rejected(error).getOrNull()).toBeNull()
+    })
+  })
+
+  describe('Result.from', () => {
+    it('converts a PromiseFulfilledResult', async () => {
+      const [promiseResult] = await Promise.allSettled([Promise.resolve(1)])
+      expect(Result.from(promiseResult).getOrThrow()).toEqual(1)
+    })
+
+    it('converts a PromiseRejectedResult', async () => {
+      const [promiseResult] = await Promise.allSettled([Promise.reject(error)])
+      expect(Result.from(promiseResult).getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('Result.all', () => {
+    it('returns results for an array of Promises', async () => {
+      const [a, b, c, d] = await Result.all([
+        Promise.resolve(1),
+        Promise.resolve('hello'),
+        Promise.resolve({ some: 'object' }),
+        Promise.reject(error),
+      ])
+
+      expect(a.getOrThrow()).toEqual(1)
+      expect(b.getOrThrow()).toEqual('hello')
+      expect(c.getOrThrow()).toEqual({ some: 'object' })
+      expect(d.getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('Result.wrap', () => {
+    const functionReturnsAString = () => Promise.resolve('hello')
+    const functionReturnsAnObject = (i: number, s: string) => Promise.resolve({ number: i, string: s })
+
+    it('wraps individual functions in a try catch to return fulfilled results', async () => {
+      // Can opt to only return Result objects for those functions we can handle, for example:
+
+      const [a, b, c, d] = await Promise.all([
+        Promise.resolve(1),
+        Result.wrap(functionReturnsAString()),
+        Result.wrap(functionReturnsAnObject(123, 'abc')),
+        Promise.resolve(1.23),
+      ])
+
+      expect(a).toEqual(1)
+      expect(b.getOrHandle(e => e.message)).toEqual('hello')
+      expect(c.getOrHandle(e => e.message)).toEqual({ number: 123, string: 'abc' })
+      expect(d).toEqual(1.23)
+    })
+
+    it('wraps individual functions in a try catch to safely return rejected results', async () => {
+      const [a, b, c] = await Promise.all([
+        Promise.resolve(1),
+        Result.wrap(Promise.reject(error)),
+        Promise.resolve(1.23),
+      ])
+
+      expect(a).toEqual(1)
+      expect(b.getOrThrow).toThrow(error)
+      expect(c).toEqual(1.23)
+    })
+  })
+
+  describe('Result.map', () => {
+    it('maps a fulfilled result', () => {
+      expect(
+        Result.fulfilled(1)
+          .map(value => value + 1)
+          .getOrThrow(),
+      ).toEqual(2)
+    })
+
+    it('maps a rejected result to itself by default', () => {
+      expect(Result.rejected<number, Error>(error).map(value => value + 1).getOrThrow).toThrowError(error)
+    })
+
+    it('maps a rejected result', () => {
+      expect(
+        Result.rejected<number, Error>(error)
+          .map(
+            value => value + 1,
+            e => ({ mapped: e }),
+          )
+          .getOrHandle(e => e),
+      ).toEqual({ mapped: error })
+    })
+  })
+})

--- a/server/utils/result/result.ts
+++ b/server/utils/result/result.ts
@@ -1,0 +1,95 @@
+/**
+ * `Result` extends the `PromiseSettledResult` type returned from `Promise.allSettled`,
+ * adding some functions that make accessing and handling the result a bit easier,
+ * avoiding the need for if else statements everywhere.
+ */
+export type Result<T, E = Error> = PromiseSettledResult<T> & {
+  isFulfilled: () => boolean
+  map: <R, E2>(map: (value: T) => R, mapError?: (error: E) => E2) => Result<R, E2>
+  handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => R1 | R2
+  getOrThrow: () => T
+  getOrHandle: <R>(handler: (e: E) => R) => T | R
+  getOrNull: () => T
+  toPromiseSettledResult: () => PromiseSettledResult<T>
+}
+
+/**
+ * `ResultHandler` allows two functions to be provided to handle both the success
+ * and error case.
+ */
+interface ResultHandler<T, E, R1, R2> {
+  fulfilled(value: T): R1
+
+  rejected(e: E): R2
+}
+
+export const Result = {
+  /**
+   * `Result.from` converts a `PromiseSettledResult` to a `Result` object
+   */
+  from: <T>(promiseResult: PromiseSettledResult<T>) => {
+    if (promiseResult.status === 'fulfilled') {
+      return Result.fulfilled(promiseResult.value)
+    }
+
+    return Result.rejected(promiseResult.reason) as Result<T>
+  },
+
+  /**
+   * `Result.wrap` wraps a promise evaluation in a try catch and returns a `Result`,
+   *  invoking a supplied callback on error
+   */
+  wrap: async <T>(promise: Promise<T>, onError: (e: Error) => void = () => null): Promise<Result<T>> => {
+    try {
+      return Result.fulfilled(await promise)
+    } catch (e) {
+      onError(e)
+      return Result.rejected(e)
+    }
+  },
+
+  /**
+   * `Result.all` replaces `Promise.allSettled` returning the extended `Result` objects
+   * instead of `PromiseSettledResults`
+   */
+  all: async <T extends readonly unknown[] | []>(
+    values: T,
+  ): Promise<{ -readonly [P in keyof T]: Result<Awaited<T[P]>> }> => {
+    return (await Promise.allSettled(values)).map(Result.from) as {
+      -readonly [P in keyof T]: Result<Awaited<T[P]>>
+    }
+  },
+
+  /**
+   * `Result.fulfilled` takes a value and produces a 'fulfilled' `Result`
+   */
+  fulfilled: <T, E>(value: T): Result<T, E> => ({
+    status: 'fulfilled',
+    value,
+    isFulfilled: () => true,
+    map: <R, E2>(map: (v: T) => R, _: (e: E) => E2) => Result.fulfilled<R, E2>(map(value)),
+    handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => handler.fulfilled(value),
+    getOrThrow: () => value,
+    getOrHandle: () => value,
+    getOrNull: () => value,
+    toPromiseSettledResult: () => ({ status: 'fulfilled', value }),
+  }),
+
+  /**
+   * `Result.rejected` takes a value and produces an 'rejected' `Result`
+   */
+  rejected: <T, E>(error: E): Result<T, E> => ({
+    status: 'rejected',
+    reason: error,
+    isFulfilled: () => false,
+    map: <R, E2>(_m: (v: T) => R, mapError: (e: E) => E2 = e => e as unknown as E2) =>
+      Result.rejected<R, E2>(mapError(error)),
+    handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => handler.rejected(error),
+    getOrThrow: () => {
+      throw error
+    },
+    getOrHandle: <R>(handler: (e: E) => R) => handler(error),
+    getOrNull: () => null as T,
+    toPromiseSettledResult: () => ({ status: 'rejected', reason: error }),
+  }),
+}

--- a/server/views/pages/search/_searchResults.njk
+++ b/server/views/pages/search/_searchResults.njk
@@ -1,0 +1,23 @@
+{% set prisoners = searchResults.value.prisoners %}
+{% set pagination = searchResults.value.pagination %}
+
+<table class="govuk-table" data-qa="search-results-table">
+  <caption><span class="govuk-visually-hidden">column headers with buttons are sortable.</span></caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row" data-qa="sortable-table-headers">
+      <th scope="col" class="govuk-table__header">Prisoner Name</th>
+      <th scope="col" class="govuk-table__header">Prison Number</th>
+      <th scope="col" class="govuk-table__header">Location</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    {% for prisoner in prisoners %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ prisoner.firstName }} {{ prisoner.lastName }}</td>
+        <td class="govuk-table__cell">{{ prisoner.prisonNumber }}</td>
+        <td class="govuk-table__cell">{{ prisoner.location }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/server/views/pages/search/index.njk
+++ b/server/views/pages/search/index.njk
@@ -19,6 +19,13 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">Prisoners with support for additional needs</h1>
       {% include './_searchBox.njk' %}
+
+      {% if searchResults.status === 'fulfilled' %}
+        {% include './_searchResults.njk' %}
+      {% else %}
+        <h2 class="govuk-heading-m" data-qa="search-unavailable-message">We cannot show these details right now</h2>
+        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+      {% endif %}
     </div>
   </div>
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -32,6 +32,13 @@
       }
     }) }}
 
+    {% if pageHasApiErrors %}
+      <div class="hmpps-api-error-banner" data-qa="api-error-banner">
+        <p>Sorry, there is a problem with the service</p>
+        <p>Some information on this page may be unavailable. Try again later.</p>
+      </div>
+    {% endif %}
+
     {% block beforeContent %}{% endblock %}
     <main class="govuk-main-wrapper govuk-!-padding-top-0 {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
       {% if successMessage %}


### PR DESCRIPTION
PR to to the basic wiring of the SearchService (service layer to an API call to our /search API) into the search page route.

The PR introduces the pattern of the Result class to wrap the promise, and allowing basic logic in the nunjucks template to determine whether the promise was resolved or not

This PR is deliberately just a skeleton. This PR is about introducing the pattern/approach, and making sure we have it right.
Tests, fleshing our the view, etc etc, will come later