### PR TITLE
RR-1471 - Added data store interfaces and In Memory implementations

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -15,12 +15,18 @@ import { createRedisClient } from './redisClient'
 import config from '../config'
 import HmppsAuditClient from './hmppsAuditClient'
 import logger from '../../logger'
-import JourneyDataStore from './journeyDataStore/journeyDataStore'
-import PrisonRegisterStore from './prisonRegisterStore/prisonRegisterStore'
 import PrisonRegisterClient from './prisonRegisterClient'
 import ManageUsersApiClient from './manageUsersApiClient'
-import UserCaseloadDetailStore from './userCaseloadDetailStore/userCaseloadDetailStore'
 import SupportAdditionalNeedsApiClient from './supportAdditionalNeedsApiClient'
+import JourneyDataStore from './journeyDataStore/journeyDataStore'
+import InMemoryJourneyDataStore from './journeyDataStore/inMemoryJourneyDataStore'
+import RedisJourneyDataStore from './journeyDataStore/redisJourneyDataStore'
+import PrisonRegisterStore from './prisonRegisterStore/prisonRegisterStore'
+import InMemoryPrisonRegisterStore from './prisonRegisterStore/inMemoryPrisonRegisterStore'
+import RedisPrisonRegisterStore from './prisonRegisterStore/redisPrisonRegisterStore'
+import UserCaseloadDetailStore from './userCaseloadDetailStore/userCaseloadDetailStore'
+import InMemoryUserCaseloadDetailStore from './userCaseloadDetailStore/inMemoryUserCaseloadDetailStore'
+import RedisUserCaseloadDetailStore from './userCaseloadDetailStore/redisUserCaseloadDetailStore'
 
 export const dataAccess = () => {
   const hmppsAuthClient = new AuthenticationClient(
@@ -33,11 +39,17 @@ export const dataAccess = () => {
     applicationInfo,
     hmppsAuthClient,
     hmppsAuditClient: new HmppsAuditClient(config.sqs.audit),
-    journeyDataStore: new JourneyDataStore(createRedisClient('journeyData:')),
+    journeyDataStore: config.redis.enabled
+      ? new RedisJourneyDataStore(createRedisClient('journeyData:'))
+      : new InMemoryJourneyDataStore(),
     prisonRegisterClient: new PrisonRegisterClient(hmppsAuthClient),
-    prisonRegisterStore: new PrisonRegisterStore(createRedisClient('prisonRegister:')),
+    prisonRegisterStore: config.redis.enabled
+      ? new RedisPrisonRegisterStore(createRedisClient('prisonRegister:'))
+      : new InMemoryPrisonRegisterStore(),
     managedUsersApiClient: new ManageUsersApiClient(hmppsAuthClient),
-    userCaseLoadDetailStore: new UserCaseloadDetailStore(createRedisClient('userCaseloadDetail:')),
+    userCaseLoadDetailStore: config.redis.enabled
+      ? new RedisUserCaseloadDetailStore(createRedisClient('userCaseloadDetail:'))
+      : new InMemoryUserCaseloadDetailStore(),
     supportAdditionalNeedsApiClient: new SupportAdditionalNeedsApiClient(hmppsAuthClient),
   }
 }
@@ -47,10 +59,10 @@ export type DataAccess = ReturnType<typeof dataAccess>
 export {
   AuthenticationClient,
   HmppsAuditClient,
-  JourneyDataStore,
+  type JourneyDataStore,
   ManageUsersApiClient,
   PrisonRegisterClient,
-  PrisonRegisterStore,
+  type PrisonRegisterStore,
   SupportAdditionalNeedsApiClient,
-  UserCaseloadDetailStore,
+  type UserCaseloadDetailStore,
 }

--- a/server/data/journeyDataStore/inMemoryJourneyDataStore.ts
+++ b/server/data/journeyDataStore/inMemoryJourneyDataStore.ts
@@ -1,0 +1,24 @@
+import JourneyDataStore from './journeyDataStore'
+
+export default class InMemoryJourneyDataStore implements JourneyDataStore {
+  private data: Map<string, Express.JourneyData> = new Map()
+
+  setJourneyData(
+    username: string,
+    journeyId: string,
+    journeyData: Express.JourneyData,
+    _durationHours: number,
+  ): Promise<string> {
+    this.data.set(`journey.${username}.${journeyId}`, journeyData)
+    return Promise.resolve('OK')
+  }
+
+  getJourneyData(username: string, journeyId: string): Promise<Express.JourneyData> {
+    return Promise.resolve(this.data.get(`journey.${username}.${journeyId}`))
+  }
+
+  deleteJourneyData(username: string, journeyId: string): Promise<void> {
+    this.data.delete(`journey.${username}.${journeyId}`)
+    return Promise.resolve()
+  }
+}

--- a/server/data/journeyDataStore/journeyDataStore.ts
+++ b/server/data/journeyDataStore/journeyDataStore.ts
@@ -1,57 +1,12 @@
-import { isValid, parseISO } from 'date-fns'
-import { RedisClient } from '../redisClient'
-import logger from '../../../logger'
-
-const DATE_FIELDS = ['createdAt', 'updatedAt']
-
-export default class JourneyDataStore {
-  constructor(private readonly client: RedisClient) {
-    client.on('error', error => {
-      logger.error(error, `Redis error`)
-    })
-  }
-
-  private async ensureConnected() {
-    if (!this.client.isOpen) {
-      await this.client.connect()
-    }
-  }
-
-  async setJourneyData(
+export default interface JourneyDataStore {
+  setJourneyData(
     username: string,
     journeyId: string,
     journeyData: Express.JourneyData,
-    durationHours = 1,
-  ): Promise<string> {
-    await this.ensureConnected()
-    return this.client.set(`journey.${username}.${journeyId}`, JSON.stringify(journeyData), {
-      EX: durationHours * 60 * 60,
-    })
-  }
+    durationHours: number,
+  ): Promise<string>
 
-  async getJourneyData(username: string, journeyId: string): Promise<Express.JourneyData> {
-    await this.ensureConnected()
-    const serializedJourneyData = await this.client.get(`journey.${username}.${journeyId}`)
-    return JSON.parse(serializedJourneyData ?? '{}', dataParsingReviver(DATE_FIELDS))
-  }
+  getJourneyData(username: string, journeyId: string): Promise<Express.JourneyData>
 
-  async deleteJourneyData(username: string, journeyId: string): Promise<void> {
-    await this.ensureConnected()
-    await this.client.del(`journey.${username}.${journeyId}`)
-  }
-}
-
-/**
- * JSON Parse reviver function that identifies fields that should be parsed as real Date objects rather than string
- * values. (The JSON parse function does not natively parse values into Date objects, so it needs help via a function
- * such as this)
- */
-const dataParsingReviver = (dateFields: Array<string>) => {
-  return (key: string, value: never) => {
-    if (typeof value !== 'string') {
-      return value
-    }
-    const dateObj = parseISO(value)
-    return dateFields.includes(key) && isValid(dateObj) ? dateObj : value
-  }
+  deleteJourneyData(username: string, journeyId: string): Promise<void>
 }

--- a/server/data/journeyDataStore/redisJourneyDataStore.test.ts
+++ b/server/data/journeyDataStore/redisJourneyDataStore.test.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidV4 } from 'uuid'
 import JourneyDataStore from './journeyDataStore'
+import RedisJourneyDataStore from './redisJourneyDataStore'
 import { RedisClient } from '../redisClient'
 
 const redisClient = {
@@ -15,11 +16,11 @@ const journeyId = uuidV4()
 const expectedCacheKey = `journey.${username}.${journeyId}`
 const journeyData: Express.JourneyData = { someDto: { test: 'test' } }
 
-describe('journeyDataStore', () => {
+describe('redisJourneyDataStore', () => {
   let journeyDataStore: JourneyDataStore
 
   beforeEach(() => {
-    journeyDataStore = new JourneyDataStore(redisClient as unknown as RedisClient)
+    journeyDataStore = new RedisJourneyDataStore(redisClient as unknown as RedisClient)
   })
 
   afterEach(() => {

--- a/server/data/journeyDataStore/redisJourneyDataStore.ts
+++ b/server/data/journeyDataStore/redisJourneyDataStore.ts
@@ -1,0 +1,58 @@
+import { isValid, parseISO } from 'date-fns'
+import { RedisClient } from '../redisClient'
+import logger from '../../../logger'
+import JourneyDataStore from './journeyDataStore'
+
+const DATE_FIELDS = ['createdAt', 'updatedAt']
+
+export default class RedisJourneyDataStore implements JourneyDataStore {
+  constructor(private readonly client: RedisClient) {
+    client.on('error', error => {
+      logger.error(error, `Redis error`)
+    })
+  }
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  async setJourneyData(
+    username: string,
+    journeyId: string,
+    journeyData: Express.JourneyData,
+    durationHours = 1,
+  ): Promise<string> {
+    await this.ensureConnected()
+    return this.client.set(`journey.${username}.${journeyId}`, JSON.stringify(journeyData), {
+      EX: durationHours * 60 * 60,
+    })
+  }
+
+  async getJourneyData(username: string, journeyId: string): Promise<Express.JourneyData> {
+    await this.ensureConnected()
+    const serializedJourneyData = await this.client.get(`journey.${username}.${journeyId}`)
+    return JSON.parse(serializedJourneyData ?? '{}', dataParsingReviver(DATE_FIELDS))
+  }
+
+  async deleteJourneyData(username: string, journeyId: string): Promise<void> {
+    await this.ensureConnected()
+    await this.client.del(`journey.${username}.${journeyId}`)
+  }
+}
+
+/**
+ * JSON Parse reviver function that identifies fields that should be parsed as real Date objects rather than string
+ * values. (The JSON parse function does not natively parse values into Date objects, so it needs help via a function
+ * such as this)
+ */
+const dataParsingReviver = (dateFields: Array<string>) => {
+  return (key: string, value: never) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+    const dateObj = parseISO(value)
+    return dateFields.includes(key) && isValid(dateObj) ? dateObj : value
+  }
+}

--- a/server/data/prisonRegisterStore/inMemoryPrisonRegisterStore.ts
+++ b/server/data/prisonRegisterStore/inMemoryPrisonRegisterStore.ts
@@ -1,0 +1,15 @@
+import type { PrisonResponse } from 'prisonRegisterApiClient'
+import PrisonRegisterStore from './prisonRegisterStore'
+
+export default class InMemoryPrisonRegisterStore implements PrisonRegisterStore {
+  private activePrisons: Array<PrisonResponse> = []
+
+  async setActivePrisons(activePrisons: Array<PrisonResponse>, _durationDays: number): Promise<string> {
+    this.activePrisons = activePrisons
+    return Promise.resolve('OK')
+  }
+
+  async getActivePrisons(): Promise<Array<PrisonResponse>> {
+    return Promise.resolve(this.activePrisons)
+  }
+}

--- a/server/data/prisonRegisterStore/prisonRegisterStore.ts
+++ b/server/data/prisonRegisterStore/prisonRegisterStore.ts
@@ -1,30 +1,7 @@
 import type { PrisonResponse } from 'prisonRegisterApiClient'
-import { RedisClient } from '../redisClient'
-import logger from '../../../logger'
 
-const ACTIVE_PRISONS = 'activePrisons'
+export default interface PrisonRegisterStore {
+  setActivePrisons(activePrisons: Array<PrisonResponse>, durationDays: number): Promise<string>
 
-export default class PrisonRegisterStore {
-  constructor(private readonly client: RedisClient) {
-    client.on('error', error => {
-      logger.error(error, `Redis error`)
-    })
-  }
-
-  private async ensureConnected() {
-    if (!this.client.isOpen) {
-      await this.client.connect()
-    }
-  }
-
-  async setActivePrisons(activePrisons: Array<PrisonResponse>, durationDays = 1): Promise<string> {
-    await this.ensureConnected()
-    return this.client.set(ACTIVE_PRISONS, JSON.stringify(activePrisons), { EX: durationDays * 24 * 60 * 60 })
-  }
-
-  async getActivePrisons(): Promise<Array<PrisonResponse>> {
-    await this.ensureConnected()
-    const serializedActivePrisons = await this.client.get(ACTIVE_PRISONS)
-    return serializedActivePrisons ? (JSON.parse(serializedActivePrisons) as Array<PrisonResponse>) : []
-  }
+  getActivePrisons(): Promise<Array<PrisonResponse>>
 }

--- a/server/data/prisonRegisterStore/redisPrisonRegisterStore.test.ts
+++ b/server/data/prisonRegisterStore/redisPrisonRegisterStore.test.ts
@@ -1,5 +1,6 @@
 import type { PrisonResponse } from 'prisonRegisterApiClient'
 import PrisonRegisterStore from './prisonRegisterStore'
+import RedisPrisonRegisterStore from './redisPrisonRegisterStore'
 import { RedisClient } from '../redisClient'
 import aValidPrisonResponse from '../../testsupport/prisonResponseTestDataBuilder'
 
@@ -23,11 +24,11 @@ const activePrisons: Array<PrisonResponse> = [
   }),
 ]
 
-describe('prisonRegisterStore', () => {
+describe('redisPrisonRegisterStore', () => {
   let prisonRegisterStore: PrisonRegisterStore
 
   beforeEach(() => {
-    prisonRegisterStore = new PrisonRegisterStore(redisClient as unknown as RedisClient)
+    prisonRegisterStore = new RedisPrisonRegisterStore(redisClient as unknown as RedisClient)
   })
 
   afterEach(() => {

--- a/server/data/prisonRegisterStore/redisPrisonRegisterStore.ts
+++ b/server/data/prisonRegisterStore/redisPrisonRegisterStore.ts
@@ -1,0 +1,31 @@
+import type { PrisonResponse } from 'prisonRegisterApiClient'
+import { RedisClient } from '../redisClient'
+import logger from '../../../logger'
+import PrisonRegisterStore from './prisonRegisterStore'
+
+const ACTIVE_PRISONS = 'activePrisons'
+
+export default class RedisPrisonRegisterStore implements PrisonRegisterStore {
+  constructor(private readonly client: RedisClient) {
+    client.on('error', error => {
+      logger.error(error, `Redis error`)
+    })
+  }
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  async setActivePrisons(activePrisons: Array<PrisonResponse>, durationDays = 1): Promise<string> {
+    await this.ensureConnected()
+    return this.client.set(ACTIVE_PRISONS, JSON.stringify(activePrisons), { EX: durationDays * 24 * 60 * 60 })
+  }
+
+  async getActivePrisons(): Promise<Array<PrisonResponse>> {
+    await this.ensureConnected()
+    const serializedActivePrisons = await this.client.get(ACTIVE_PRISONS)
+    return serializedActivePrisons ? (JSON.parse(serializedActivePrisons) as Array<PrisonResponse>) : []
+  }
+}

--- a/server/data/userCaseloadDetailStore/inMemoryUserCaseloadDetailStore.ts
+++ b/server/data/userCaseloadDetailStore/inMemoryUserCaseloadDetailStore.ts
@@ -1,0 +1,15 @@
+import type { UserCaseloadDetail } from 'manageUsersApiClient'
+import UserCaseloadDetailStore from './userCaseloadDetailStore'
+
+export default class InMemoryUserCaseloadDetailStore implements UserCaseloadDetailStore {
+  private data: Map<string, UserCaseloadDetail> = new Map()
+
+  async setUserCaseloadDetail(userCaseloadDetail: UserCaseloadDetail, _durationHours: number): Promise<string> {
+    this.data.set(`userCaseloadDetail.${userCaseloadDetail.username}`, userCaseloadDetail)
+    return Promise.resolve('OK')
+  }
+
+  async getUserCaseloadDetail(username: string): Promise<UserCaseloadDetail> {
+    return Promise.resolve(this.data.get(`userCaseloadDetail.${username}`))
+  }
+}

--- a/server/data/userCaseloadDetailStore/redisUserCaseloadDetailStore.test.ts
+++ b/server/data/userCaseloadDetailStore/redisUserCaseloadDetailStore.test.ts
@@ -1,5 +1,6 @@
 import type { UserCaseloadDetail } from 'manageUsersApiClient'
 import UserCaseloadDetailStore from './userCaseloadDetailStore'
+import RedisUserCaseloadDetailStore from './redisUserCaseloadDetailStore'
 import { RedisClient } from '../redisClient'
 
 const redisClient = {
@@ -9,10 +10,11 @@ const redisClient = {
   connect: jest.fn(),
 }
 
-describe('userCaseloadDetailStore', () => {
-  const userCaseloadDetailStore = new UserCaseloadDetailStore(redisClient as unknown as RedisClient)
+describe('redisUserCaseloadDetailStore', () => {
+  let userCaseloadDetailStore: UserCaseloadDetailStore
 
   beforeEach(() => {
+    userCaseloadDetailStore = new RedisUserCaseloadDetailStore(redisClient as unknown as RedisClient)
     jest.resetAllMocks()
   })
 

--- a/server/data/userCaseloadDetailStore/redisUserCaseloadDetailStore.ts
+++ b/server/data/userCaseloadDetailStore/redisUserCaseloadDetailStore.ts
@@ -1,0 +1,31 @@
+import type { UserCaseloadDetail } from 'manageUsersApiClient'
+import { RedisClient } from '../redisClient'
+import logger from '../../../logger'
+import UserCaseloadDetailStore from './userCaseloadDetailStore'
+
+export default class RedisUserCaseloadDetailStore implements UserCaseloadDetailStore {
+  constructor(private readonly client: RedisClient) {
+    client.on('error', error => {
+      logger.error(error, `Redis error`)
+    })
+  }
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  async setUserCaseloadDetail(userCaseloadDetail: UserCaseloadDetail, durationHours = 1): Promise<string> {
+    await this.ensureConnected()
+    return this.client.set(`userCaseloadDetail.${userCaseloadDetail.username}`, JSON.stringify(userCaseloadDetail), {
+      EX: durationHours * 60 * 60,
+    })
+  }
+
+  async getUserCaseloadDetail(username: string): Promise<UserCaseloadDetail> {
+    await this.ensureConnected()
+    const serializedUserCaseloadDetail = await this.client.get(`userCaseloadDetail.${username}`)
+    return serializedUserCaseloadDetail ? JSON.parse(serializedUserCaseloadDetail) : null
+  }
+}

--- a/server/data/userCaseloadDetailStore/userCaseloadDetailStore.ts
+++ b/server/data/userCaseloadDetailStore/userCaseloadDetailStore.ts
@@ -1,30 +1,7 @@
 import type { UserCaseloadDetail } from 'manageUsersApiClient'
-import { RedisClient } from '../redisClient'
-import logger from '../../../logger'
 
-export default class UserCaseloadDetailStore {
-  constructor(private readonly client: RedisClient) {
-    client.on('error', error => {
-      logger.error(error, `Redis error`)
-    })
-  }
+export default interface UserCaseloadDetailStore {
+  setUserCaseloadDetail(userCaseloadDetail: UserCaseloadDetail, durationHours: number): Promise<string>
 
-  private async ensureConnected() {
-    if (!this.client.isOpen) {
-      await this.client.connect()
-    }
-  }
-
-  async setUserCaseloadDetail(userCaseloadDetail: UserCaseloadDetail, durationHours = 1): Promise<string> {
-    await this.ensureConnected()
-    return this.client.set(`userCaseloadDetail.${userCaseloadDetail.username}`, JSON.stringify(userCaseloadDetail), {
-      EX: durationHours * 60 * 60,
-    })
-  }
-
-  async getUserCaseloadDetail(username: string): Promise<UserCaseloadDetail> {
-    await this.ensureConnected()
-    const serializedUserCaseloadDetail = await this.client.get(`userCaseloadDetail.${username}`)
-    return serializedUserCaseloadDetail ? JSON.parse(serializedUserCaseloadDetail) : null
-  }
+  getUserCaseloadDetail(username: string): Promise<UserCaseloadDetail>
 }

--- a/server/services/journeyDataService.ts
+++ b/server/services/journeyDataService.ts
@@ -1,4 +1,4 @@
-import { JourneyDataStore } from '../data'
+import JourneyDataStore from '../data/journeyDataStore/journeyDataStore'
 
 export default class JourneyDataService {
   constructor(private readonly journeyDataStore: JourneyDataStore) {}

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,14 +1,14 @@
 import type { PrisonResponse } from 'prisonRegisterApiClient'
 import PrisonService from './prisonService'
-import PrisonRegisterStore from '../data/prisonRegisterStore/prisonRegisterStore'
+import RedisPrisonRegisterStore from '../data/prisonRegisterStore/redisPrisonRegisterStore'
 import PrisonRegisterClient from '../data/prisonRegisterClient'
 import aValidPrisonResponse from '../testsupport/prisonResponseTestDataBuilder'
 
-jest.mock('../data/prisonRegisterStore/prisonRegisterStore')
+jest.mock('../data/prisonRegisterStore/redisPrisonRegisterStore')
 jest.mock('../data/prisonRegisterClient')
 
 describe('prisonService', () => {
-  const prisonRegisterStore = new PrisonRegisterStore(null) as jest.Mocked<PrisonRegisterStore>
+  const prisonRegisterStore = new RedisPrisonRegisterStore(null) as jest.Mocked<RedisPrisonRegisterStore>
   const prisonRegisterClient = new PrisonRegisterClient(null) as jest.Mocked<PrisonRegisterClient>
   const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient)
 

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,7 +1,7 @@
 import type { PrisonResponse } from 'prisonRegisterApiClient'
-import PrisonRegisterStore from '../data/prisonRegisterStore/prisonRegisterStore'
 import PrisonRegisterClient from '../data/prisonRegisterClient'
 import logger from '../../logger'
+import { PrisonRegisterStore } from '../data'
 
 const PRISON_CACHE_TTL_DAYS = 1
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,14 +1,14 @@
 import type { UserCaseloadDetail } from 'manageUsersApiClient'
 import UserService from './userService'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
-import UserCaseloadDetailStore from '../data/userCaseloadDetailStore/userCaseloadDetailStore'
+import RedisUserCaseloadDetailStore from '../data/userCaseloadDetailStore/redisUserCaseloadDetailStore'
 
 jest.mock('../data/manageUsersApiClient')
-jest.mock('../data/userCaseloadDetailStore/userCaseloadDetailStore')
+jest.mock('../data/userCaseloadDetailStore/redisUserCaseloadDetailStore')
 
 describe('userService', () => {
   const manageUsersApiClient = new ManageUsersApiClient(null) as jest.Mocked<ManageUsersApiClient>
-  const userCaseloadDetailStore = new UserCaseloadDetailStore(null) as jest.Mocked<UserCaseloadDetailStore>
+  const userCaseloadDetailStore = new RedisUserCaseloadDetailStore(null) as jest.Mocked<RedisUserCaseloadDetailStore>
   const userService = new UserService(manageUsersApiClient, userCaseloadDetailStore)
 
   const username = 'some-username'

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,5 +1,6 @@
 import type { UserCaseloadDetail } from 'manageUsersApiClient'
-import { ManageUsersApiClient, UserCaseloadDetailStore } from '../data'
+import { ManageUsersApiClient } from '../data'
+import UserCaseloadDetailStore from '../data/userCaseloadDetailStore/userCaseloadDetailStore'
 import logger from '../../logger'
 
 const USER_CASELOAD_DETAIL_CACHE_TTL_HOURS = 1


### PR DESCRIPTION
Within our project we have 3 "store" classes, where a store is basically an abstraction around a cache - JourneyDataStore, PrisonRegisterStore and UserCaseloadDetailStore.
At the moment these 3 are all concrete classes that take a redisClient as part of the constructor call, and require it on order to operate properly.

This has caused a problem ([in a different PR](https://github.com/ministryofjustice/hmpps-support-additional-needs-ui/pull/27)) where in order to use any of these 3 data stores, there needs to be a valid redis instance running in the environment. The other PR implements some cypress tests, where the journey involves these data stores being used. The cypress tests fail on CI (GHA) because there is no redis environment provisioned.

There is a 4th data store (TokenStore) that does not suffer with this problem because it is an interface with 2 implementations - RedisTokenStore and InMemoryTokenStore. (we get these classes and this pattern for free from the typescript template)

I have taken this approach and applied it to the 3 data stores in question here. I have turned them into interfaces, then created a Redis and InMemory implementation of each. The Redis implementations are essentially just a rename of the previous class (eg: rename JourneyDataStore to RedisJourneyDataStore). The original class was then turned into an interface (eg: JourneyDataStore becomes an interface). And I have created an InMemory implementation where the internal data store is a simple Map or Array (eg: InMemoryJourneyDataStore)

Finally I have added a little logic to where these 3 are instantiated, and instantiate the Redis backed impls if redis is enabled in the env; else we instantiate the InMemory impls (exactly the same way the TokenStore is instantiated)

