### PR TITLE
RR-1570 - Define basic DTO and wire into routes

### DIFF
--- a/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
@@ -1,0 +1,37 @@
+import { v4 as uuidV4 } from 'uuid'
+import Page from '../../../pages/page'
+import OverviewPage from '../../../pages/profile/overview/overviewPage'
+
+context('Prevent out of sequence navigation to pages in the Create Education Support Plan journey', () => {
+  const prisonNumber = 'A00001A'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+  })
+  ;[
+    'other-people-consulted',
+    'review-needs-conditions-and-strengths',
+    'learning-environment-adjustments',
+    'teaching-adjustments',
+    'specific-teaching-skills',
+    'exam-arrangements',
+    'education-health-care-plan',
+    'lnsp-support',
+    'next-review-date',
+    'check-your-answers',
+  ].forEach(page => {
+    it(`should prevent direct navigation to ${page} page when the user has not started the Create Education Support Plan journey`, () => {
+      // Given
+      const journeyId = uuidV4()
+
+      // When
+      cy.visit(`/education-support-plan/${prisonNumber}/create/${journeyId}/${page}`)
+
+      // Then
+      Page.verifyOnPage(OverviewPage)
+    })
+  })
+})

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'dto' {
+  export interface EducationSupportPlanDto {
+    prisonNumber: string
+    prisonId: string
+  }
+}

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,3 +1,4 @@
+import type { EducationSupportPlanDto } from 'dto'
 import { HmppsUser } from '../../interfaces/hmppsUser'
 
 export declare module 'express-session' {
@@ -16,8 +17,9 @@ export declare global {
       authSource: string
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    interface JourneyData {}
+    interface JourneyData {
+      educationSupportPlanDto?: EducationSupportPlanDto
+    }
 
     interface Response {
       redirectWithSuccess?(path: string, message: string): void

--- a/server/data/journeyDataStore/redisJourneyDataStore.test.ts
+++ b/server/data/journeyDataStore/redisJourneyDataStore.test.ts
@@ -2,6 +2,7 @@ import { v4 as uuidV4 } from 'uuid'
 import JourneyDataStore from './journeyDataStore'
 import RedisJourneyDataStore from './redisJourneyDataStore'
 import { RedisClient } from '../redisClient'
+import aValidEducationSupportPlanDto from '../../testsupport/educationSupportPlanDtoTestDataBuilder'
 
 const redisClient = {
   on: jest.fn(),
@@ -14,7 +15,7 @@ const redisClient = {
 const username = 'AUSER_GEN'
 const journeyId = uuidV4()
 const expectedCacheKey = `journey.${username}.${journeyId}`
-const journeyData: Express.JourneyData = { someDto: { test: 'test' } }
+const journeyData: Express.JourneyData = { educationSupportPlanDto: aValidEducationSupportPlanDto() }
 
 describe('redisJourneyDataStore', () => {
   let journeyDataStore: JourneyDataStore

--- a/server/middleware/setupJourneyData.test.ts
+++ b/server/middleware/setupJourneyData.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import JourneyDataService from '../services/journeyDataService'
 import setupJourneyData from './setupJourneyData'
+import aValidEducationSupportPlanDto from '../testsupport/educationSupportPlanDtoTestDataBuilder'
 
 jest.mock('../services/journeyDataService')
 
@@ -30,7 +31,7 @@ describe('setupJourneyData', () => {
 
   it('should retrieve journey data given journeyData is returned by JourneyDataService', async () => {
     // Given
-    const expectedJourneyData = { someDto: { test: 'test' } }
+    const expectedJourneyData = { educationSupportPlanDto: aValidEducationSupportPlanDto() }
     journeyDataService.getJourneyData.mockResolvedValue(expectedJourneyData)
 
     // When
@@ -57,7 +58,7 @@ describe('setupJourneyData', () => {
 
   it('should add response callback function that sets journey data given the request contains journeyData', async () => {
     // Given
-    req.journeyData = { someDto: { test: 'test' } }
+    req.journeyData = { educationSupportPlanDto: aValidEducationSupportPlanDto() }
 
     await requestHandler(req, res, next)
     const responseCallbackFunction = prependOnceListener.mock.calls[0][1]

--- a/server/routes/education-support-plan/create/index.ts
+++ b/server/routes/education-support-plan/create/index.ts
@@ -22,6 +22,8 @@ import examArrangementsSchema from '../validationSchemas/examArrangementsSchema'
 import educationHealthCarePlanSchema from '../validationSchemas/educationHealthCarePlanSchema'
 import learningNeedsSupportPractitionerSupportSchema from '../validationSchemas/learningNeedsSupportPractitionerSupportSchema'
 import reviewSupportPlanSchema from '../validationSchemas/reviewSupportPlanSchema'
+import checkEducationSupportPlanDtoExistsInJourneyData from './middleware/checkEducationSupportPlanDtoExistsInJourneyData'
+import createEmptyEducationSupportPlanDtoIfNotInJourneyData from './middleware/createEmptyEducationSupportPlanDtoIfNotInJourneyData'
 
 const createEducationSupportPlanRoutes = (services: Services): Router => {
   const { journeyDataService } = services
@@ -46,76 +48,105 @@ const createEducationSupportPlanRoutes = (services: Services): Router => {
   router.use('/:journeyId', [setupJourneyData(journeyDataService)])
 
   router.get('/:journeyId/who-created-the-plan', [
+    createEmptyEducationSupportPlanDtoIfNotInJourneyData,
     asyncMiddleware(whoCreatedThePlanController.getWhoCreatedThePlanView),
   ])
   router.post('/:journeyId/who-created-the-plan', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(whoCompletedThePlanSchema),
     asyncMiddleware(whoCreatedThePlanController.submitWhoCreatedThePlanForm),
   ])
 
   router.get('/:journeyId/other-people-consulted', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(otherPeopleConsultedController.getOtherPeopleConsultedView),
   ])
   router.post('/:journeyId/other-people-consulted', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(otherPeopleConsultedController.submitOtherPeopleConsultedForm),
   ])
 
   router.get('/:journeyId/review-needs-conditions-and-strengths', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(reviewNeedsConditionsStrengthsController.getReviewNeedsConditionsStrengthsView),
   ])
   router.post('/:journeyId/review-needs-conditions-and-strengths', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(reviewNeedsConditionsStrengthsController.submitReviewNeedsConditionsStrengthsForm),
   ])
 
   router.get('/:journeyId/learning-environment-adjustments', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(learningEnvironmentAdjustmentsController.getLearningEnvironmentAdjustmentsView),
   ])
   router.post('/:journeyId/learning-environment-adjustments', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(learningEnvironmentAdjustmentsSchema),
     asyncMiddleware(learningEnvironmentAdjustmentsController.submitLearningEnvironmentAdjustmentsForm),
   ])
 
   router.get('/:journeyId/teaching-adjustments', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(teachingAdjustmentsController.getTeachingAdjustmentsView),
   ])
   router.post('/:journeyId/teaching-adjustments', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(teachingAdjustmentsSchema),
     asyncMiddleware(teachingAdjustmentsController.submitTeachingAdjustmentsForm),
   ])
 
   router.get('/:journeyId/specific-teaching-skills', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(specificTeachingSkillsController.getSpecificTeachingSkillsView),
   ])
   router.post('/:journeyId/specific-teaching-skills', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(specificTeachingSkillsSchema),
     asyncMiddleware(specificTeachingSkillsController.submitSpecificTeachingSkillsForm),
   ])
 
-  router.get('/:journeyId/exam-arrangements', [asyncMiddleware(examArrangementsController.getExamArrangementsView)])
+  router.get('/:journeyId/exam-arrangements', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
+    asyncMiddleware(examArrangementsController.getExamArrangementsView),
+  ])
   router.post('/:journeyId/exam-arrangements', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(examArrangementsSchema),
     asyncMiddleware(examArrangementsController.submitExamArrangementsForm),
   ])
 
-  router.get('/:journeyId/education-health-care-plan', [asyncMiddleware(educationHealthCarePlanController.getEhcpView)])
+  router.get('/:journeyId/education-health-care-plan', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
+    asyncMiddleware(educationHealthCarePlanController.getEhcpView),
+  ])
   router.post('/:journeyId/education-health-care-plan', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(educationHealthCarePlanSchema),
     asyncMiddleware(educationHealthCarePlanController.submitEhcpForm),
   ])
 
-  router.get('/:journeyId/lnsp-support', [asyncMiddleware(lnspController.getLnspSupportView)])
+  router.get('/:journeyId/lnsp-support', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
+    asyncMiddleware(lnspController.getLnspSupportView),
+  ])
   router.post('/:journeyId/lnsp-support', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(learningNeedsSupportPractitionerSupportSchema),
     asyncMiddleware(lnspController.submitLnspSupportForm),
   ])
 
-  router.get('/:journeyId/next-review-date', [asyncMiddleware(reviewSupportPlanController.getReviewSupportPlanView)])
+  router.get('/:journeyId/next-review-date', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
+    asyncMiddleware(reviewSupportPlanController.getReviewSupportPlanView),
+  ])
   router.post('/:journeyId/next-review-date', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     validate(reviewSupportPlanSchema),
     asyncMiddleware(reviewSupportPlanController.submitReviewSupportPlanForm),
   ])
 
   router.get('/:journeyId/check-your-answers', [
+    checkEducationSupportPlanDtoExistsInJourneyData,
     asyncMiddleware(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       res.send('Check your answers page')
     }),

--- a/server/routes/education-support-plan/create/middleware/checkEducationSupportPlanDtoExistsInJourneyData.test.ts
+++ b/server/routes/education-support-plan/create/middleware/checkEducationSupportPlanDtoExistsInJourneyData.test.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
+import checkEducationSupportPlanDtoExistsInJourneyData from './checkEducationSupportPlanDtoExistsInJourneyData'
+import aValidEducationSupportPlanDto from '../../../../testsupport/educationSupportPlanDtoTestDataBuilder'
+
+describe('checkEducationSupportPlanDtoInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const journeyId = uuidV4()
+
+  const req = {
+    journeyData: {},
+    params: {},
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+    req.params = { prisonNumber }
+    req.originalUrl = `/education-support-plan/${prisonNumber}/create/${journeyId}/check-your-answers`
+  })
+
+  it(`should invoke next handler given EducationSupportPlanDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.educationSupportPlanDto = aValidEducationSupportPlanDto()
+
+    // When
+    await checkEducationSupportPlanDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no EducationSupportPlanDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.educationSupportPlanDto = undefined
+
+    // When
+    await checkEducationSupportPlanDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no journeyData exists`, async () => {
+    // Given
+    req.journeyData = undefined
+
+    // When
+    await checkEducationSupportPlanDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/education-support-plan/create/middleware/checkEducationSupportPlanDtoExistsInJourneyData.ts
+++ b/server/routes/education-support-plan/create/middleware/checkEducationSupportPlanDtoExistsInJourneyData.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from 'express'
+import logger from '../../../../../logger'
+
+/**
+ * Request handler function to check the [EducationSupportPlanDto] exists in the journeyData.
+ */
+const checkEducationSupportPlanDtoExistsInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.journeyData?.educationSupportPlanDto) {
+    logger.warn(
+      `No EducationSupportPlanDto in journeyData - user attempting to navigate to path ${req.originalUrl} out of sequence. Redirecting to Profile Overview page.`,
+    )
+    return res.redirect(`/profile/${req.params.prisonNumber}/overview`)
+  }
+  return next()
+}
+
+export default checkEducationSupportPlanDtoExistsInJourneyData

--- a/server/routes/education-support-plan/create/middleware/createEmptyEducationSupportPlanDtoIfNotInJourneyData.test.ts
+++ b/server/routes/education-support-plan/create/middleware/createEmptyEducationSupportPlanDtoIfNotInJourneyData.test.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import type { EducationSupportPlanDto } from 'dto'
+import createEmptyEducationSupportPlanDtoIfNotInJourneyData from './createEmptyEducationSupportPlanDtoIfNotInJourneyData'
+
+describe('createEmptyEducationSupportPlanDtoIfNotInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const prisonId = 'MDI'
+
+  const req = {
+    params: { prisonNumber },
+  } as unknown as Request
+  const res = {
+    locals: {
+      user: { activeCaseLoadId: prisonId },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+  })
+
+  it('should create an empty EducationSupportPlanDto for the prisoner given there is no EducationSupportPlanDto in the journeyData', async () => {
+    // Given
+    req.journeyData.educationSupportPlanDto = undefined
+
+    const expectedEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as EducationSupportPlanDto
+
+    // When
+    await createEmptyEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.educationSupportPlanDto).toEqual(expectedEducationSupportPlanDto)
+  })
+
+  it('should create an empty EducationSupportPlanDto for a prisoner given there is an EducationSupportPlanDto in the journeyData for a different prisoner', async () => {
+    // Given
+    req.journeyData.educationSupportPlanDto = { prisonNumber: 'Z1234ZZ', prisonId } as EducationSupportPlanDto
+
+    const expectedEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as EducationSupportPlanDto
+
+    // When
+    await createEmptyEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.educationSupportPlanDto).toEqual(expectedEducationSupportPlanDto)
+  })
+
+  it('should not create an empty EducationSupportPlanDto for the prisoner given there is already an EducationSupportPlanDto in the journeyData for the prisoner', async () => {
+    // Given
+    const expectedEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as EducationSupportPlanDto
+
+    req.journeyData.educationSupportPlanDto = expectedEducationSupportPlanDto
+
+    // When
+    await createEmptyEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.educationSupportPlanDto).toEqual(expectedEducationSupportPlanDto)
+  })
+})

--- a/server/routes/education-support-plan/create/middleware/createEmptyEducationSupportPlanDtoIfNotInJourneyData.ts
+++ b/server/routes/education-support-plan/create/middleware/createEmptyEducationSupportPlanDtoIfNotInJourneyData.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from 'express'
+import type { EducationSupportPlanDto } from 'dto'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+/**
+ * Middleware function that returns a request handler function to check whether a [EducationSupportPlanDto] exists in the journeyData for
+ * the prisoner referenced in the request URL.
+ * If one does not exist, or it is for a different prisoner, create a new empty [EducationSupportPlanDto] for the prisoner.
+ */
+const createEmptyEducationSupportPlanDtoIfNotInJourneyData = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { prisonNumber } = req.params
+  const { activeCaseLoadId } = res.locals.user as PrisonUser
+
+  // Either no EducationSupportPlanDto in the journeyData, or it's for a different prisoner. Create a new one.
+  if (req.journeyData?.educationSupportPlanDto?.prisonNumber !== prisonNumber) {
+    req.journeyData = {
+      educationSupportPlanDto: {
+        prisonNumber,
+        prisonId: activeCaseLoadId,
+      } as EducationSupportPlanDto,
+    }
+  }
+
+  next()
+}
+
+export default createEmptyEducationSupportPlanDtoIfNotInJourneyData

--- a/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
@@ -1,0 +1,11 @@
+import type { EducationSupportPlanDto } from 'dto'
+
+const aValidEducationSupportPlanDto = (options?: {
+  prisonNumber?: string
+  prisonId?: string
+}): EducationSupportPlanDto => ({
+  prisonNumber: options?.prisonNumber || 'A1234BC',
+  prisonId: options?.prisonId || 'BXI',
+})
+
+export default aValidEducationSupportPlanDto


### PR DESCRIPTION
PR to define a very basic DTO for the Create Education Support Plan and wire it into the journey.

In this PR:
* The DTO is defined with only prisonNumber and prisonId fields
* The DTO is created when starting the journey and added to the `journeyData`
* The existence of the DTO in `journeyData` is checked on every page in the journey - if it is not present redirect the user to the Overview page (ie. user is trying to navigate to pages out of sequence). Cypress tests to prove

The next PRs will start to flesh out the required fields on the DTO and populate them with data submitted on each page.