### PR TITLE
RR-1543 - Support for removing previously added people

### DIFF
--- a/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
@@ -1,0 +1,60 @@
+import WhoCreatedThePlanPage from '../../../pages/education-support-plan/whoCreatedThePlanPage'
+import Page from '../../../pages/page'
+import PlanCreatedByValue from '../../../../server/enums/planCreatedByValue'
+import OtherPeopleConsultedPage from '../../../pages/education-support-plan/otherPeopleConsultedPage'
+import OtherPeopleConsultedAddPersonPage from '../../../pages/education-support-plan/otherPeopleConsultedAddPersonPage'
+import OtherPeopleConsultedListPage from '../../../pages/education-support-plan/otherPeopleConsultedListPage'
+
+context('Add and remove Other People Consulted during creation of Education Support Plan journey', () => {
+  const prisonNumber = 'A00001A'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+  })
+
+  it('should be able to add and remove other people consulted', () => {
+    // Given
+    cy.visit(`/education-support-plan/${prisonNumber}/create/who-created-the-plan`)
+
+    Page.verifyOnPage(WhoCreatedThePlanPage)
+      .selectWhoCreatedThePlan(PlanCreatedByValue.MYSELF)
+      .submitPageTo(OtherPeopleConsultedPage)
+      .selectOtherPeopleWereConsulted()
+      .submitPageTo(OtherPeopleConsultedAddPersonPage)
+      // Add person 1
+      .enterFullName('Person 1')
+      .submitPageTo(OtherPeopleConsultedListPage)
+      // Add person 2
+      .clickToAddAnotherPerson()
+      .enterFullName('Person 2')
+      .submitPageTo(OtherPeopleConsultedListPage)
+      // Add person 3
+      .clickToAddAnotherPerson()
+      .enterFullName('Person 3')
+      .submitPageTo(OtherPeopleConsultedListPage)
+      .numberOfPeopleConsultedIs(3)
+      .personAtRowIs(1, 'Person 1')
+      .personAtRowIs(2, 'Person 2')
+      .personAtRowIs(3, 'Person 3')
+
+    // When
+    Page.verifyOnPage(OtherPeopleConsultedListPage)
+      // remove person 2
+      .removePerson(2, OtherPeopleConsultedListPage)
+      .numberOfPeopleConsultedIs(2)
+      .personAtRowIs(1, 'Person 1')
+      .personAtRowIs(2, 'Person 3')
+      // remove person 1
+      .removePerson(1, OtherPeopleConsultedListPage)
+      .numberOfPeopleConsultedIs(1)
+      .personAtRowIs(1, 'Person 3')
+      // remove person 3 (who is now at row 1); expect to be on the OtherPeopleConsulted page because we have removed everyone
+      .removePerson(1, OtherPeopleConsultedPage)
+
+    // Then
+    Page.verifyOnPage(OtherPeopleConsultedPage)
+  })
+})

--- a/integration_tests/pages/education-support-plan/otherPeopleConsultedListPage.ts
+++ b/integration_tests/pages/education-support-plan/otherPeopleConsultedListPage.ts
@@ -25,6 +25,13 @@ export default class OtherPeopleConsultedListPage extends Page {
     return Page.verifyOnPage(OtherPeopleConsultedAddPersonPage)
   }
 
+  removePerson<T extends Page>(row: number, expected: new () => T): T {
+    this.peopleConsultedListTable()
+      .find(`button[name=removePerson][value=${zeroIndexed(row)}]`)
+      .click()
+    return Page.verifyOnPage(expected)
+  }
+
   private peopleConsultedListTable = (): PageElement => cy.get('[data-qa=people-consulted-table')
 
   private addAnotherPersonButton = (): PageElement => cy.get('#addPerson')

--- a/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.test.ts
+++ b/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.test.ts
@@ -72,4 +72,47 @@ describe('otherPeopleConsultedListController', () => {
     // Then
     expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
   })
+
+  it('should submit form and redirect to next route given Remove button was pressed and there are 1 or more people left on the DTO', async () => {
+    // Given
+    req.journeyData = {
+      educationSupportPlanDto: {
+        ...educationSupportPlanDto,
+        otherPeopleConsulted: [
+          { name: 'Person 1', jobRole: 'N/A' },
+          { name: 'Person 2', jobRole: 'N/A' },
+        ],
+      },
+    }
+    req.body = { removePerson: '0' } // remove Person 1 (zero indexed), expect just Person 2 to be left
+
+    const expectedNextRoute = 'list'
+
+    // When
+    await controller.submitOtherPeopleConsultedListForm(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
+    expect(req.journeyData.educationSupportPlanDto.otherPeopleConsulted).toEqual([{ name: 'Person 2', jobRole: 'N/A' }])
+  })
+
+  it('should submit form and redirect to next route given Remove button was pressed and there are 0 people left on the DTO', async () => {
+    // Given
+    req.journeyData = {
+      educationSupportPlanDto: {
+        ...educationSupportPlanDto,
+        otherPeopleConsulted: [{ name: 'Person 1', jobRole: 'N/A' }],
+      },
+    }
+    req.body = { removePerson: '0' } // remove Person 1 (zero indexed)
+
+    const expectedNextRoute = '../other-people-consulted'
+
+    // When
+    await controller.submitOtherPeopleConsultedListForm(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
+    expect(req.journeyData.educationSupportPlanDto.otherPeopleConsulted).toEqual([])
+  })
 })

--- a/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.ts
+++ b/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.ts
@@ -14,6 +14,19 @@ export default class OtherPeopleConsultedListController {
       return res.redirect('add-person')
     }
 
+    if (req.userClickedOnButton('removePerson')) {
+      const personIndexToRemove = req.body.removePerson as number
+      const numberOfPeopleOnDto = this.updateDtoWithRemovedPerson(req, personIndexToRemove)
+      return res.redirect(numberOfPeopleOnDto >= 1 ? 'list' : '../other-people-consulted')
+    }
+
     return res.redirect('../review-needs-conditions-and-strengths')
+  }
+
+  private updateDtoWithRemovedPerson = (req: Request, personIndexToRemove: number): number => {
+    const { educationSupportPlanDto } = req.journeyData
+    educationSupportPlanDto.otherPeopleConsulted.splice(personIndexToRemove, 1)
+    req.journeyData.educationSupportPlanDto = educationSupportPlanDto
+    return educationSupportPlanDto.otherPeopleConsulted.length
   }
 }

--- a/server/views/pages/education-support-plan/other-people-consulted/people-consulted-list/index.njk
+++ b/server/views/pages/education-support-plan/other-people-consulted/people-consulted-list/index.njk
@@ -28,7 +28,7 @@
                   <button type="submit"
                           class="app-u-button-as-link"
                           value="{{ loop.index0 }}"
-                          name="removeQualification"
+                          name="removePerson"
                           data-prevent-double-click="true"
                           data-module="govuk-button">
                     Remove <span class="govuk-visually-hidden"> {{ person.name }}</span>


### PR DESCRIPTION
PR to add support for removing previously added people from the Support Plan (Other People Consulted or Involved)
As per the ticket requirements, when the last person is removed the user is taken back to the question about whether anyone else was involved.


https://github.com/user-attachments/assets/81c44b2e-ed1c-4ffb-abe7-dcbf4b4ca464

