### PR TITLE
RR-1588 - Reimport swagger spec, DTO and mappers to get new `detail` field from API request/response objects

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -22,5 +22,6 @@ declare module 'dto' {
     lnspSupportNeeded?: boolean
     lnspSupport?: string
     reviewDate?: Date
+    additionalInformation?: string
   }
 }

--- a/server/@types/supportAdditionalNeedsApi/index.d.ts
+++ b/server/@types/supportAdditionalNeedsApi/index.d.ts
@@ -148,6 +148,22 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/reference-data/{domain}/categories': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getReferenceDataCategories']
+    put: operations['getReferenceDataCategories_2']
+    post: operations['getReferenceDataCategories_1']
+    delete: operations['getReferenceDataCategories_3']
+    options: operations['getReferenceDataCategories_6']
+    head: operations['getReferenceDataCategories_5']
+    patch: operations['getReferenceDataCategories_4']
+    trace?: never
+  }
 }
 export type webhooks = Record<string, never>
 export interface components {
@@ -416,6 +432,11 @@ export interface components {
        * @example An LNSP is required for approx 1 hour per week to read and explain passages of text to Chris.
        */
       lnspSupport?: string
+      /**
+       * @description Optional Additional information about the plan that is not covered in the other questions.
+       * @example Chris is very open about his issues and is a pleasure to talk to.
+       */
+      detail?: string
     }
     PlanContributor: {
       /** @example Joe Bloggs */
@@ -506,6 +527,11 @@ export interface components {
        * @example An LNSP is required for approx 1 hour per week to read and explain passages of text to Chris.
        */
       lnspSupport?: string
+      /**
+       * @description Optional Additional information about the plan that is not covered in the other questions.
+       * @example Chris is very open about his issues and is a pleasure to talk to.
+       */
+      detail?: string
     }
     ConditionRequest: {
       /**
@@ -1095,10 +1121,10 @@ export interface operations {
   }
   searchByPrison: {
     parameters: {
-      query: {
+      query?: {
         prisonerNameOrNumber?: string
-        sortBy: 'PRISONER_NAME' | 'PRISON_NUMBER' | 'CELL_LOCATION' | 'RELEASE_DATE'
-        sortDirection: 'ASC' | 'DESC'
+        sortBy?: 'PRISONER_NAME' | 'PRISON_NUMBER' | 'CELL_LOCATION' | 'RELEASE_DATE'
+        sortDirection?: 'ASC' | 'DESC'
         page?: number
         pageSize?: number
       }
@@ -1187,6 +1213,188 @@ export interface operations {
         }
         content: {
           '*/*': components['schemas']['PlanCreationSchedulesResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_2: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_1: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_3: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_6: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_5: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
+        }
+      }
+    }
+  }
+  getReferenceDataCategories_4: {
+    parameters: {
+      query?: {
+        /** @description Include inactive reference data. Defaults to false */
+        includeInactive?: boolean
+      }
+      header?: never
+      path: {
+        /** @description Reference data domain. */
+        domain: 'CONDITION' | 'CHALLENGE' | 'STRENGTH'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ReferenceDataListResponse']
         }
       }
     }

--- a/server/data/mappers/createEducationSupportPlanRequestMapper.test.ts
+++ b/server/data/mappers/createEducationSupportPlanRequestMapper.test.ts
@@ -55,6 +55,7 @@ describe('createEducationSupportPlanRequestMapper', () => {
         examArrangements: null,
         lnspSupport: null,
         reviewDate: addMonths(startOfToday(), 2),
+        additionalInformation: null,
       })
 
       const expected = aValidCreateEducationSupportPlanRequest({
@@ -68,6 +69,7 @@ describe('createEducationSupportPlanRequestMapper', () => {
         examAccessArrangements: null,
         lnspSupport: null,
         reviewDate: addMonths(startOfToday(), 2),
+        detail: null,
       })
 
       // When

--- a/server/data/mappers/createEducationSupportPlanRequestMapper.ts
+++ b/server/data/mappers/createEducationSupportPlanRequestMapper.ts
@@ -15,6 +15,7 @@ const toCreateEducationSupportPlanRequest = (dto: EducationSupportPlanDto): Crea
   specificTeachingSkills: dto.specificTeachingSkillsNeeded ? dto.specificTeachingSkills : null,
   examAccessArrangements: dto.examArrangementsNeeded ? dto.examArrangements : null,
   lnspSupport: dto.lnspSupportNeeded ? dto.lnspSupport : null,
+  detail: dto.additionalInformation ? dto.additionalInformation : null,
 })
 
 export default toCreateEducationSupportPlanRequest

--- a/server/data/mappers/educationSupportPlanDtoMapper.test.ts
+++ b/server/data/mappers/educationSupportPlanDtoMapper.test.ts
@@ -51,6 +51,7 @@ describe('educationSupportPlanDtoMapper', () => {
         specificTeachingSkills: null,
         examAccessArrangements: null,
         lnspSupport: null,
+        detail: null,
       })
 
       const expected = aValidEducationSupportPlanDto({
@@ -63,6 +64,7 @@ describe('educationSupportPlanDtoMapper', () => {
         specificTeachingSkills: null,
         examArrangements: null,
         lnspSupport: null,
+        additionalInformation: null,
         prisonId: null,
         reviewDate: null,
       })

--- a/server/data/mappers/educationSupportPlanDtoMapper.ts
+++ b/server/data/mappers/educationSupportPlanDtoMapper.ts
@@ -26,6 +26,7 @@ const toEducationSupportPlanDto = (
   examArrangements: educationSupportPlanResponse.examAccessArrangements,
   lnspSupportNeeded: educationSupportPlanResponse.lnspSupport != null,
   lnspSupport: educationSupportPlanResponse.lnspSupport,
+  additionalInformation: educationSupportPlanResponse.detail,
   prisonId: null,
   reviewDate: null,
 })

--- a/server/testsupport/createEducationSupportPlanRequestTestDataBuilder.ts
+++ b/server/testsupport/createEducationSupportPlanRequestTestDataBuilder.ts
@@ -13,6 +13,7 @@ const aValidCreateEducationSupportPlanRequest = (options?: {
   specificTeachingSkills?: string
   examAccessArrangements?: string
   lnspSupport?: string
+  detail?: string
 }): CreateEducationSupportPlanRequest => ({
   prisonId: options?.prisonId || 'BXI',
   hasCurrentEhcp: options?.hasCurrentEhcp ?? false,
@@ -42,6 +43,10 @@ const aValidCreateEducationSupportPlanRequest = (options?: {
     options?.lnspSupport === null
       ? null
       : options?.lnspSupport || 'Chris will need text reading to him as he cannot read himself',
+  detail:
+    options?.detail === null
+      ? null
+      : options?.detail || 'Chris is very open about his issues and is a pleasure to talk to.',
 })
 
 export default aValidCreateEducationSupportPlanRequest

--- a/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
@@ -20,6 +20,7 @@ const aValidEducationSupportPlanDto = (options?: {
   examArrangements?: string
   lnspSupport?: string
   reviewDate?: Date
+  additionalInformation?: string
 }): EducationSupportPlanDto => ({
   prisonNumber: options?.prisonNumber ?? 'A1234BC',
   prisonId: options?.prisonId === null ? null : options?.prisonId || 'BXI',
@@ -57,6 +58,10 @@ const aValidEducationSupportPlanDto = (options?: {
       ? null
       : options?.lnspSupport || 'Chris will need text reading to him as he cannot read himself',
   reviewDate: options?.reviewDate === null ? null : options?.reviewDate || addMonths(startOfToday(), 2),
+  additionalInformation:
+    options?.additionalInformation === null
+      ? null
+      : options?.additionalInformation || 'Chris is very open about his issues and is a pleasure to talk to.',
 })
 
 export default aValidEducationSupportPlanDto

--- a/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
@@ -19,6 +19,7 @@ const aValidEducationSupportPlanResponse = (options?: {
   specificTeachingSkills?: string
   examAccessArrangements?: string
   lnspSupport?: string
+  detail?: string
 }): EducationSupportPlanResponse => ({
   hasCurrentEhcp: options?.hasCurrentEhcp ?? false,
   planCreatedBy: options?.planCreatedBy === null ? null : options?.planCreatedBy || aValidPlanContributor(),
@@ -46,6 +47,10 @@ const aValidEducationSupportPlanResponse = (options?: {
     options?.lnspSupport === null
       ? null
       : options?.lnspSupport || 'Chris will need text reading to him as he cannot read himself',
+  detail:
+    options?.detail === null
+      ? null
+      : options?.detail || 'Chris is very open about his issues and is a pleasure to talk to.',
   ...validAuditFields(options),
 })
 


### PR DESCRIPTION
This PR is part of the story RR-1588 to add a new screen (Additional Information) to the Create Education Support Plan journey.
The API already supports this extra question (as an optional field in the API request), so this PR re-imports the swagger spec to build the model classes, updates the DTO, and updates the mappers.
The API models this extra field as a field called `detail`. I have added it to the DTO as a field called `additionalInformation` as this is a better reflection of the UI screen (to be added in my next PR); and the mapper handles the mapping between the API naming and DTO naming 👍 

The next PR will add the route, screen etc and start wiring it all up