### PR TITLE
RR-1626 - Middleware and basic wiring to get prisoner ELSP creation schedule

### DIFF
--- a/integration_tests/e2e/education-support-plan/create/checkYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/checkYourAnswersChangeLinks.cy.ts
@@ -20,6 +20,7 @@ context(`Change links on the Check Your Answers page when creating an Education 
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubCreateEducationSupportPlan', prisonNumber)
   })
 

--- a/integration_tests/e2e/education-support-plan/create/createEducationSupportPlan.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/createEducationSupportPlan.cy.ts
@@ -28,6 +28,7 @@ context('Create an Education Support Plan', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubCreateEducationSupportPlan', prisonNumber)
   })
 

--- a/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
@@ -10,6 +10,7 @@ context('Prevent out of sequence navigation to pages in the Create Education Sup
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
   })
   ;[
     'other-people-consulted',

--- a/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
@@ -13,6 +13,7 @@ context('Add and remove Other People Consulted during creation of Education Supp
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
   })
 
   it('should be able to add and remove other people consulted', () => {

--- a/integration_tests/e2e/education-support-plan/refuse-plan/refuseEducationSupportPlan.cy.ts
+++ b/integration_tests/e2e/education-support-plan/refuse-plan/refuseEducationSupportPlan.cy.ts
@@ -14,6 +14,7 @@ context('Refuse an Education Support Plan', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubUpdateEducationSupportPlanCreationStatus', prisonNumber)
   })
 

--- a/integration_tests/e2e/profile/overview.cy.ts
+++ b/integration_tests/e2e/profile/overview.cy.ts
@@ -17,6 +17,7 @@ context('Profile Overview Page', () => {
     // Given
     const prisonNumber = 'H4115SD'
     cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
 
     // When
     cy.visit(`/profile/${prisonNumber}/overview`)

--- a/integration_tests/e2e/search/search.cy.ts
+++ b/integration_tests/e2e/search/search.cy.ts
@@ -115,7 +115,7 @@ context(`Display the Search screen`, () => {
     // Given
     const firstPersonOnFirstPage: Person = peopleGroupedByPageRequest[0][0]
     cy.task('getPrisonerById', firstPersonOnFirstPage.prisonNumber)
-
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber: firstPersonOnFirstPage.prisonNumber })
     cy.visit('/search')
 
     // Then

--- a/integration_tests/mockApis/supportAdditionalNeedsApi.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi.ts
@@ -212,6 +212,103 @@ const stubUpdateEducationSupportPlanCreationStatus500Error = (prisonNumber = 'G6
     },
   })
 
+const stubGetEducationSupportPlanCreationSchedules = (options?: {
+  prisonNumber?: string
+  includeAllHistory?: boolean
+}): SuperAgentRequest => {
+  const prisonNumber = options?.prisonNumber || 'G6115VJ'
+  const includeAllHistory = options?.includeAllHistory || false
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/support-additional-needs-api/profile/${prisonNumber}/plan-creation-schedule`,
+      queryParameters: {
+        includeAllHistory: { equalTo: `${includeAllHistory}` },
+      },
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        planCreationSchedules: [
+          {
+            reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+            deadlineDate: format(addMonths(startOfToday(), 2), 'yyyy-MM-dd'),
+            status: PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY,
+            exemptionReason: 'EXEMPT_REFUSED_TO_ENGAGE',
+            exemptionDetail: 'Chris would not engage or cooperate with me today',
+            version: 1,
+            createdBy: 'asmith_gen',
+            createdByDisplayName: 'Alex Smith',
+            createdAt: '2023-06-19T09:39:44Z',
+            createdAtPrison: 'MDI',
+            updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
+            updatedAt: '2023-06-19T09:39:44Z',
+            updatedAtPrison: 'MDI',
+          },
+        ],
+      },
+    },
+  })
+}
+
+const stubGetEducationSupportPlanCreationSchedules404Error = (options?: {
+  prisonNumber?: string
+  includeAllHistory?: boolean
+}): SuperAgentRequest => {
+  const prisonNumber = options?.prisonNumber || 'G6115VJ'
+  const includeAllHistory = options?.includeAllHistory || false
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/support-additional-needs-api/profile/${prisonNumber}/plan-creation-schedule`,
+      queryParameters: {
+        includeAllHistory: { equalTo: `${includeAllHistory}` },
+      },
+    },
+    response: {
+      status: 404,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 404,
+        developerMessage: `Plan Creation Schedules for ${prisonNumber} not found`,
+      },
+    },
+  })
+}
+
+const stubGetEducationSupportPlanCreationSchedules500Error = (options?: {
+  prisonNumber?: string
+  includeAllHistory?: boolean
+}): SuperAgentRequest => {
+  const prisonNumber = options?.prisonNumber || 'G6115VJ'
+  const includeAllHistory = options?.includeAllHistory || false
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/support-additional-needs-api/profile/${prisonNumber}/plan-creation-schedule`,
+      queryParameters: {
+        includeAllHistory: { equalTo: `${includeAllHistory}` },
+      },
+    },
+    response: {
+      status: 500,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 500,
+        errorCode: null,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+        moreInfo: null,
+      },
+    },
+  })
+}
+
 export default {
   stubSearchByPrison,
   stubSearchByPrison500Error,
@@ -219,5 +316,8 @@ export default {
   stubCreateEducationSupportPlan500Error,
   stubUpdateEducationSupportPlanCreationStatus,
   stubUpdateEducationSupportPlanCreationStatus500Error,
+  stubGetEducationSupportPlanCreationSchedules,
+  stubGetEducationSupportPlanCreationSchedules404Error,
+  stubGetEducationSupportPlanCreationSchedules500Error,
   stubSupportAdditionalNeedsApiPing: stubPing('support-additional-needs-api'),
 }

--- a/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.test.ts
+++ b/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.test.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from 'express'
+import EducationSupportPlanScheduleService from '../../../services/educationSupportPlanScheduleService'
+import retrieveCurrentEducationSupportPlanCreationSchedule from './retrieveCurrentEducationSupportPlanCreationSchedule'
+import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
+
+jest.mock('../../../services/educationSupportPlanScheduleService')
+
+describe('retrieveCurrentEducationSupportPlanCreationSchedule', () => {
+  const educationSupportPlanScheduleService = new EducationSupportPlanScheduleService(
+    null,
+  ) as jest.Mocked<EducationSupportPlanScheduleService>
+  const requestHandler = retrieveCurrentEducationSupportPlanCreationSchedule(educationSupportPlanScheduleService)
+
+  const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
+
+  const req = {
+    user: { username },
+    params: { prisonNumber },
+  } as unknown as Request
+  const res = {
+    render: jest.fn(),
+    locals: {},
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    res.locals = { user: undefined }
+  })
+
+  it('should retrieve current ELSP creation schedule and store on res.locals', async () => {
+    // Given
+    const expectedPlanCreationSchedule = aValidPlanCreationScheduleDto({ prisonNumber })
+    educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule.mockResolvedValue(
+      expectedPlanCreationSchedule,
+    )
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.educationSupportPlanCreationSchedule).toEqual(expectedPlanCreationSchedule)
+    expect(educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule).toHaveBeenCalledWith(
+      prisonNumber,
+      username,
+    )
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should store on res.locals given service returns no current ELSP creation schedule for the prisoner', async () => {
+    // Given
+    educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule.mockResolvedValue(null)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.educationSupportPlanCreationSchedule).toBeNull()
+    expect(educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule).toHaveBeenCalledWith(
+      prisonNumber,
+      username,
+    )
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.ts
+++ b/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.ts
@@ -1,0 +1,25 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { EducationSupportPlanScheduleService } from '../../../services'
+import asyncMiddleware from '../../../middleware/asyncMiddleware'
+
+/**
+ *  Function that returns a middleware function to retrieve the prisoner's current Education Support Plan Creation Schedule and store in res.locals
+ */
+const retrieveCurrentEducationSupportPlanCreationSchedule = (
+  educationSupportPlanScheduleService: EducationSupportPlanScheduleService,
+): RequestHandler => {
+  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+    const { prisonNumber } = req.params
+
+    // Lookup the prisoner's ELSP Creation Schedule and store in res.locals
+    res.locals.educationSupportPlanCreationSchedule =
+      await educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule(
+        prisonNumber,
+        req.user.username,
+      )
+
+    next()
+  })
+}
+
+export default retrieveCurrentEducationSupportPlanCreationSchedule

--- a/server/routes/profile/overview/index.ts
+++ b/server/routes/profile/overview/index.ts
@@ -2,11 +2,17 @@ import { Router } from 'express'
 import { Services } from '../../../services'
 import OverviewController from './overviewController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import retrieveCurrentEducationSupportPlanCreationSchedule from '../middleware/retrieveCurrentEducationSupportPlanCreationSchedule'
 
-const overviewRoute = (_services: Services): Router => {
+const overviewRoute = (services: Services): Router => {
+  const { educationSupportPlanScheduleService } = services
   const controller = new OverviewController()
+
   return Router({ mergeParams: true }) //
-    .get('/', [asyncMiddleware(controller.getOverviewView)])
+    .get('/', [
+      retrieveCurrentEducationSupportPlanCreationSchedule(educationSupportPlanScheduleService),
+      asyncMiddleware(controller.getOverviewView),
+    ])
 }
 
 export default overviewRoute

--- a/server/services/educationSupportPlanScheduleService.ts
+++ b/server/services/educationSupportPlanScheduleService.ts
@@ -29,6 +29,7 @@ export default class EducationSupportPlanScheduleService {
 
       const planCreationSchedules: Array<PlanCreationScheduleResponse> = apiResponse?.planCreationSchedules || []
       if (planCreationSchedules.length === 0) {
+        logger.debug(`Prisoner ${prisonNumber} has no Education Support Plan Creation Schedule. Returning null.`)
         return null
       }
 


### PR DESCRIPTION
This PR adds the new middleware that retrieves the prisoner's current ELSP Creation Schedule , and wires it into the Overview page route (because we will need it on the Overview page to determine whether to show the "Refuse Plan" and "Create Plan" action links - not in this PR)

Because I've wired the middleware into the route, I've had to setup the wiremock stub for the cypress tests and wire it into the relevant tests (because otherwise the cypress tests are not doing quite what they should do because they'll be getting a 404 from wiremock when trying to get the prisoner's ESLP Creation Schedule)