### PR TITLE
RR-1626 - Render Support Plan Actions only when the schedule status is scheduled

### DIFF
--- a/integration_tests/e2e/profile/overview.cy.ts
+++ b/integration_tests/e2e/profile/overview.cy.ts
@@ -5,6 +5,7 @@
 import OverviewPage from '../../pages/profile/overview/overviewPage'
 import Page from '../../pages/page'
 import Error404Page from '../../pages/error404'
+import PlanCreationScheduleStatus from '../../../server/enums/planCreationScheduleStatus'
 
 context('Profile Overview Page', () => {
   beforeEach(() => {
@@ -28,6 +29,41 @@ context('Profile Overview Page', () => {
       .hasNoConditionsRecorded()
       .hasNoStrengthsRecorded()
       .hasNoSupportRecommendationsRecorded()
+      .actionsCardContainsEducationSupportPlanActions()
+      .apiErrorBannerIsNotDisplayed()
+  })
+
+  it('should display overview page given prisoner already has an Education Support Plan', () => {
+    // Given
+    const prisonNumber = 'H4115SD'
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', {
+      prisonNumber,
+      status: PlanCreationScheduleStatus.COMPLETED,
+    })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/overview`)
+
+    // Then
+    Page.verifyOnPage(OverviewPage) //
+      .actionsCardIsNotPresent()
+      .apiErrorBannerIsNotDisplayed()
+  })
+
+  it('should display overview page given retrieving the prisoners plan creation schedule returns an error', () => {
+    // Given
+    const prisonNumber = 'H4115SD'
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules500Error', { prisonNumber })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/overview`)
+
+    // Then
+    Page.verifyOnPage(OverviewPage) //
+      .actionsCardIsNotPresent()
+      .apiErrorBannerIsDisplayed()
   })
 
   it('should display 404 page given requesting the overview page for a prisoner that does not exist', () => {

--- a/integration_tests/mockApis/supportAdditionalNeedsApi.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi.ts
@@ -215,9 +215,11 @@ const stubUpdateEducationSupportPlanCreationStatus500Error = (prisonNumber = 'G6
 const stubGetEducationSupportPlanCreationSchedules = (options?: {
   prisonNumber?: string
   includeAllHistory?: boolean
+  status?: PlanCreationScheduleStatus
 }): SuperAgentRequest => {
   const prisonNumber = options?.prisonNumber || 'G6115VJ'
   const includeAllHistory = options?.includeAllHistory || false
+  const status = options?.status || PlanCreationScheduleStatus.SCHEDULED
 
   return stubFor({
     request: {
@@ -235,9 +237,13 @@ const stubGetEducationSupportPlanCreationSchedules = (options?: {
           {
             reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
             deadlineDate: format(addMonths(startOfToday(), 2), 'yyyy-MM-dd'),
-            status: PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY,
-            exemptionReason: 'EXEMPT_REFUSED_TO_ENGAGE',
-            exemptionDetail: 'Chris would not engage or cooperate with me today',
+            status,
+            exemptionReason:
+              status === PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY ? 'EXEMPT_REFUSED_TO_ENGAGE' : undefined,
+            exemptionDetail:
+              status === PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY
+                ? 'Chris would not engage or cooperate with me today'
+                : undefined,
             version: 1,
             createdBy: 'asmith_gen',
             createdByDisplayName: 'Alex Smith',

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -1,4 +1,5 @@
 declare module 'viewModels' {
+  import type { PlanCreationScheduleDto } from 'dto'
   import SentenceType from '../../enums/sentenceType'
 
   export interface PrisonerSummary {
@@ -51,5 +52,6 @@ declare module 'viewModels' {
   export interface ActionsCardParams {
     prisonerSummary: PrisonerSummary
     userHasPermissionTo: () => boolean
+    educationSupportPlanCreationSchedule?: PlanCreationScheduleDto
   }
 }

--- a/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.test.ts
+++ b/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.test.ts
@@ -14,6 +14,7 @@ describe('retrieveCurrentEducationSupportPlanCreationSchedule', () => {
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
 
+  const apiErrorCallback = jest.fn()
   const req = {
     user: { username },
     params: { prisonNumber },
@@ -26,7 +27,7 @@ describe('retrieveCurrentEducationSupportPlanCreationSchedule', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    res.locals = { user: undefined }
+    res.locals = { user: undefined, apiErrorCallback }
   })
 
   it('should retrieve current ELSP creation schedule and store on res.locals', async () => {
@@ -40,15 +41,17 @@ describe('retrieveCurrentEducationSupportPlanCreationSchedule', () => {
     await requestHandler(req, res, next)
 
     // Then
-    expect(res.locals.educationSupportPlanCreationSchedule).toEqual(expectedPlanCreationSchedule)
+    expect(res.locals.educationSupportPlanCreationSchedule.isFulfilled()).toEqual(true)
+    expect(res.locals.educationSupportPlanCreationSchedule.value).toEqual(expectedPlanCreationSchedule)
     expect(educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule).toHaveBeenCalledWith(
       prisonNumber,
       username,
     )
     expect(next).toHaveBeenCalled()
+    expect(apiErrorCallback).not.toHaveBeenCalled()
   })
 
-  it('should store on res.locals given service returns no current ELSP creation schedule for the prisoner', async () => {
+  it('should null store on res.locals given service returns no current ELSP creation schedule for the prisoner', async () => {
     // Given
     educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule.mockResolvedValue(null)
 
@@ -56,11 +59,31 @@ describe('retrieveCurrentEducationSupportPlanCreationSchedule', () => {
     await requestHandler(req, res, next)
 
     // Then
-    expect(res.locals.educationSupportPlanCreationSchedule).toBeNull()
+    expect(res.locals.educationSupportPlanCreationSchedule.isFulfilled()).toEqual(true)
+    expect(res.locals.educationSupportPlanCreationSchedule.value).toBeNull()
     expect(educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule).toHaveBeenCalledWith(
       prisonNumber,
       username,
     )
     expect(next).toHaveBeenCalled()
+    expect(apiErrorCallback).not.toHaveBeenCalled()
+  })
+
+  it('should store null on res.locals given service returns an error', async () => {
+    // Given
+    const error = new Error('An error occurred')
+    educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule.mockRejectedValue(error)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.educationSupportPlanCreationSchedule.isFulfilled()).toEqual(false)
+    expect(educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule).toHaveBeenCalledWith(
+      prisonNumber,
+      username,
+    )
+    expect(next).toHaveBeenCalled()
+    expect(apiErrorCallback).toHaveBeenCalledWith(error)
   })
 })

--- a/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.ts
+++ b/server/routes/profile/middleware/retrieveCurrentEducationSupportPlanCreationSchedule.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import { EducationSupportPlanScheduleService } from '../../../services'
-import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import { Result } from '../../../utils/result/result'
 
 /**
  *  Function that returns a middleware function to retrieve the prisoner's current Education Support Plan Creation Schedule and store in res.locals
@@ -8,18 +8,21 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 const retrieveCurrentEducationSupportPlanCreationSchedule = (
   educationSupportPlanScheduleService: EducationSupportPlanScheduleService,
 ): RequestHandler => {
-  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
     // Lookup the prisoner's ELSP Creation Schedule and store in res.locals
-    res.locals.educationSupportPlanCreationSchedule =
-      await educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule(
+    const { apiErrorCallback } = res.locals
+    res.locals.educationSupportPlanCreationSchedule = await Result.wrap(
+      educationSupportPlanScheduleService.getCurrentEducationSupportPlanCreationSchedule(
         prisonNumber,
         req.user.username,
-      )
+      ),
+      apiErrorCallback,
+    )
 
     next()
-  })
+  }
 }
 
 export default retrieveCurrentEducationSupportPlanCreationSchedule

--- a/server/routes/profile/overview/overviewController.test.ts
+++ b/server/routes/profile/overview/overviewController.test.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+import OverviewController from './overviewController'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
+import { Result } from '../../../utils/result/result'
+
+describe('overviewController', () => {
+  const controller = new OverviewController()
+
+  const prisonerSummary = aValidPrisonerSummary()
+  const educationSupportPlanCreationSchedule = Result.fulfilled(aValidPlanCreationScheduleDto())
+
+  const req = {} as unknown as Request
+  const res = {
+    render: jest.fn(),
+    locals: { prisonerSummary, educationSupportPlanCreationSchedule },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the view', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+    const expectedViewModel = {
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      tab: 'overview',
+    }
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+})

--- a/server/routes/profile/overview/overviewController.ts
+++ b/server/routes/profile/overview/overviewController.ts
@@ -2,8 +2,8 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default class OverviewController {
   getOverviewView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary } = res.locals
-    const viewRenderArgs = { prisonerSummary, tab: 'overview' }
+    const { prisonerSummary, educationSupportPlanCreationSchedule } = res.locals
+    const viewRenderArgs = { prisonerSummary, educationSupportPlanCreationSchedule, tab: 'overview' }
     return res.render('pages/profile/overview/index', viewRenderArgs)
   }
 }

--- a/server/views/components/actions-card/_educationSupportPlanActions.njk
+++ b/server/views/components/actions-card/_educationSupportPlanActions.njk
@@ -1,4 +1,6 @@
 {# Education Support Plan based actions #}
+{% set planCreationScheduleStatus = params.educationSupportPlanCreationSchedule.status %}
+
 <div class="govuk-summary-card__content govuk-!-padding-bottom-0 govuk-!-padding-top-2" data-qa="education-support-plan-actions">
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Education support plan</h3>
 
@@ -6,25 +8,29 @@
 
     {# TODO - enable this if logic when RBAC is implemented #}
     {# if params.userHasPermissionTo('RECORD_EDUCATION_LEARNER_SUPPORT_PLAN') #}
-      <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
-        <a class="govuk-link" data-qa="create-education-support-plan-button" href="/education-support-plan/{{ params.prisonerSummary.prisonNumber }}/create/who-created-the-plan">
-            <span>
-              <img src="/assets/images/icon-document.svg" role="presentation" alt="" class="action-icon" />
-              Create education support plan
-            </span>
-        </a>
-      </li>
+      {% if planCreationScheduleStatus === 'SCHEDULED' %}
+        <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
+          <a class="govuk-link" data-qa="create-education-support-plan-button" href="/education-support-plan/{{ params.prisonerSummary.prisonNumber }}/create/who-created-the-plan">
+              <span>
+                <img src="/assets/images/icon-document.svg" role="presentation" alt="" class="action-icon" />
+                Create education support plan
+              </span>
+          </a>
+        </li>
+      {% endif %}
     {# endif #}
 
     {# if params.userHasPermissionTo('EXEMPT_EDUCATION_LEARNER_SUPPORT_PLAN') #}
-      <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
-        <a class="govuk-link" data-qa="refuse-education-support-plan-button" href="/education-support-plan/{{ params.prisonerSummary.prisonNumber }}/refuse-plan/reason">
-            <span>
-              <img src="/assets/images/icon-document.svg" role="presentation" alt="" class="action-icon" />
-              Record refusal of education support plan
-            </span>
-        </a>
-      </li>
+      {% if planCreationScheduleStatus === 'SCHEDULED' %}
+        <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
+          <a class="govuk-link" data-qa="refuse-education-support-plan-button" href="/education-support-plan/{{ params.prisonerSummary.prisonNumber }}/refuse-plan/reason">
+              <span>
+                <img src="/assets/images/icon-document.svg" role="presentation" alt="" class="action-icon" />
+                Record refusal of education support plan
+              </span>
+          </a>
+        </li>
+      {% endif %}
     {# endif #}
 
   </ul>

--- a/server/views/components/actions-card/_educationSupportPlanActions.test.ts
+++ b/server/views/components/actions-card/_educationSupportPlanActions.test.ts
@@ -1,0 +1,92 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import type { PlanCreationScheduleDto } from 'dto'
+import type { ActionsCardParams } from 'viewModels'
+import formatDateFilter from '../../../filters/formatDateFilter'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
+import PlanCreationScheduleStatus from '../../../enums/planCreationScheduleStatus'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv.addFilter('formatDate', formatDateFilter)
+
+const userHasPermissionTo = jest.fn()
+const templateParams: ActionsCardParams = {
+  prisonerSummary: aValidPrisonerSummary(),
+  userHasPermissionTo,
+  educationSupportPlanCreationSchedule: aValidPlanCreationScheduleDto(),
+}
+
+describe('_educationSupportPlanActions', () => {
+  it('should render support plan actions section given plan creation schedule status is SCHEDULED', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      educationSupportPlanCreationSchedule: aValidPlanCreationScheduleDto({
+        status: PlanCreationScheduleStatus.SCHEDULED,
+      }),
+    }
+
+    // When
+    const content = nunjucks.render('_educationSupportPlanActions.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=education-support-plan-actions]').length).toEqual(1) // expect the containing div to be present
+    expect($('[data-qa=education-support-plan-action-items] li').length).toEqual(2) // expect there to be 2 actions within
+    expect($('[data-qa=education-support-plan-action-items] li:nth-of-type(1) a').attr('data-qa')).toEqual(
+      'create-education-support-plan-button',
+    ) // expect the 1st action to be Create ELSP
+    expect($('[data-qa=education-support-plan-action-items] li:nth-of-type(2) a').attr('data-qa')).toEqual(
+      'refuse-education-support-plan-button',
+    ) // expect the 2nd action to be Refuse ELSP
+  })
+
+  it.each([
+    PlanCreationScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
+    PlanCreationScheduleStatus.EXEMPT_PRISONER_TRANSFER,
+    PlanCreationScheduleStatus.EXEMPT_PRISONER_RELEASE,
+    PlanCreationScheduleStatus.EXEMPT_PRISONER_DEATH,
+    PlanCreationScheduleStatus.EXEMPT_PRISONER_MERGE,
+    PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY,
+    PlanCreationScheduleStatus.EXEMPT_NOT_IN_EDUCATION,
+    PlanCreationScheduleStatus.EXEMPT_UNKNOWN,
+    PlanCreationScheduleStatus.COMPLETED,
+  ])('should render support plan actions section given plan creation schedule status is %s', status => {
+    // Given
+    const params = {
+      ...templateParams,
+      educationSupportPlanCreationSchedule: aValidPlanCreationScheduleDto({ status }),
+    }
+
+    // When
+    const content = nunjucks.render('_educationSupportPlanActions.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=education-support-plan-actions]').length).toEqual(1) // expect the containing div to be present
+    expect($('[data-qa=education-support-plan-action-items] li').length).toEqual(0) // expect there to be 0 actions within
+  })
+
+  it('should render support plan actions section given plan creation schedule is null', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      educationSupportPlanCreationSchedule: null as PlanCreationScheduleDto,
+    }
+
+    // When
+    const content = nunjucks.render('_educationSupportPlanActions.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=education-support-plan-actions]').length).toEqual(1) // expect the containing div to be present
+    expect($('[data-qa=education-support-plan-action-items] li').length).toEqual(0) // expect there to be 0 actions within
+  })
+})

--- a/server/views/components/actions-card/actionCards.test.njk
+++ b/server/views/components/actions-card/actionCards.test.njk
@@ -1,0 +1,7 @@
+{% from "./macro.njk" import actionsCard %}
+
+{{ actionsCard({
+  prisonerSummary: prisonerSummary,
+  userHasPermissionTo: userHasPermissionTo,
+  educationSupportPlanCreationStatus: educationSupportPlanCreationStatus
+}) }}

--- a/server/views/components/actions-card/actionsCard.test.ts
+++ b/server/views/components/actions-card/actionsCard.test.ts
@@ -1,0 +1,43 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import type { ActionsCardParams } from 'viewModels'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import formatDateFilter from '../../../filters/formatDateFilter'
+import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv.addFilter('formatDate', formatDateFilter)
+
+const userHasPermissionTo = jest.fn()
+const templateParams: ActionsCardParams = {
+  prisonerSummary: aValidPrisonerSummary(),
+  userHasPermissionTo,
+  educationSupportPlanCreationSchedule: aValidPlanCreationScheduleDto(),
+}
+
+describe('Tests for actions card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the actions card component', () => {
+    // Given
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render('actionCards.test.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=education-support-plan-actions]').length).toEqual(1)
+  })
+})

--- a/server/views/pages/profile/overview/index.njk
+++ b/server/views/pages/profile/overview/index.njk
@@ -17,7 +17,8 @@
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
         prisonerSummary: prisonerSummary,
-        userHasPermissionTo: userHasPermissionTo
+        userHasPermissionTo: userHasPermissionTo,
+        educationSupportPlanCreationSchedule: educationSupportPlanCreationSchedule.value if educationSupportPlanCreationSchedule.isFulfilled()
       }) }}
     </div>
   </div>

--- a/server/views/pages/search/index.njk
+++ b/server/views/pages/search/index.njk
@@ -20,7 +20,7 @@
       <h1 class="govuk-heading-l">Prisoners with support for additional needs</h1>
       {% include './_searchBox.njk' %}
 
-      {% if searchResults.status === 'fulfilled' %}
+      {% if searchResults.isFulfilled() %}
         {% include './_searchResults.njk' %}
       {% else %}
         <h2 class="govuk-heading-m" data-qa="search-unavailable-message">We cannot show these details right now</h2>


### PR DESCRIPTION
This PR ties up the work for the Refuse Plan epic (and Create Plan epic), in that it uses the previously retrieved ELSP Plan Creation Schedule to determine whether to show the links to Create and Refuse the plan in the Actions menu (ie. only show these 2 links if the status is SCHEDULED)