### PR TITLE
RR-1684 - Define the StrengthDto and journey middleware functions

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -57,6 +57,13 @@ declare module 'dto' {
     detail?: string
   }
 
+  export interface StrengthDto {
+    prisonNumber: string
+    prisonId: string
+    strengthTypeCode: string
+    detail?: string
+  }
+
   export interface ReferenceDataItemDto {
     code: string
     areaCode?: string

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import type { EducationSupportPlanDto, RefuseEducationSupportPlanDto } from 'dto'
+import type { ChallengeDto, EducationSupportPlanDto, RefuseEducationSupportPlanDto } from 'dto'
 import { HmppsUser } from '../../interfaces/hmppsUser'
 
 export declare module 'express-session' {
@@ -20,6 +20,9 @@ export declare global {
     interface JourneyData {
       educationSupportPlanDto?: EducationSupportPlanDto
       refuseEducationSupportPlanDto?: RefuseEducationSupportPlanDto
+      challengeDto?: ChallengeDto
+      conditionDto?: ConditionDto
+      strengthDto?: StrengthDto
     }
 
     interface Response {

--- a/server/routes/strengths/create/index.ts
+++ b/server/routes/strengths/create/index.ts
@@ -4,6 +4,8 @@ import insertJourneyIdentifier from '../../../middleware/insertJourneyIdentifier
 import setupJourneyData from '../../../middleware/setupJourneyData'
 import SelectCategoryController from './select-category/selectCategoryController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import createEmptyStrengthDtoIfNotInJourneyData from './middleware/createEmptyStrengthDtoIfNotInJourneyData'
+import checkStrengthDtoExistsInJourneyData from './middleware/checkStrengthDtoExistsInJourneyData'
 
 const createStrengthRoutes = (services: Services): Router => {
   const { journeyDataService } = services
@@ -19,12 +21,12 @@ const createStrengthRoutes = (services: Services): Router => {
   router.use('/:journeyId', [setupJourneyData(journeyDataService)])
 
   router.get('/:journeyId/select-category', [
-    // TODO write createEmptyStrengthsDtoIfNotInJourneyData middleware
+    createEmptyStrengthDtoIfNotInJourneyData,
     asyncMiddleware(selectCategoryController.getSelectCategoryView),
   ])
 
   router.get('/:journeyId/detail', [
-    // TODO write checkStrengthsDtoExistsInJourneyData middleware
+    checkStrengthDtoExistsInJourneyData,
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       res.send('Add Strength - Enter strength details page')
     },

--- a/server/routes/strengths/create/middleware/checkStrengthDtoExistsInJourneyData.test.ts
+++ b/server/routes/strengths/create/middleware/checkStrengthDtoExistsInJourneyData.test.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from 'express'
+import checkStrengthDtoExistsInJourneyData from './checkStrengthDtoExistsInJourneyData'
+import aValidStrengthDto from '../../../../testsupport/strengthDtoTestDataBuilder'
+
+describe('checkStrengthDtoExistsInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+
+  const req = {
+    journeyData: {},
+    params: {},
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+    req.params = { prisonNumber }
+  })
+
+  it(`should invoke next handler given StrengthDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.strengthDto = aValidStrengthDto()
+
+    // When
+    await checkStrengthDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no StrengthDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.strengthDto = undefined
+
+    // When
+    await checkStrengthDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no journeyData exists`, async () => {
+    // Given
+    req.journeyData = undefined
+
+    // When
+    await checkStrengthDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/strengths/create/middleware/checkStrengthDtoExistsInJourneyData.ts
+++ b/server/routes/strengths/create/middleware/checkStrengthDtoExistsInJourneyData.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from 'express'
+import logger from '../../../../../logger'
+
+/**
+ * Middleware function to check that the [StrengthDto] exists in the journeyData.
+ */
+const checkStrengthDtoExistsInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.journeyData?.strengthDto) {
+    logger.warn(
+      `No StrengthDto in journeyData - user attempting to navigate to path ${req.originalUrl} out of sequence. Redirecting to Profile Overview page.`,
+    )
+    return res.redirect(`/profile/${req.params.prisonNumber}/overview`)
+  }
+  return next()
+}
+
+export default checkStrengthDtoExistsInJourneyData

--- a/server/routes/strengths/create/middleware/createEmptyStrengthDtoIfNotInJourneyData.test.ts
+++ b/server/routes/strengths/create/middleware/createEmptyStrengthDtoIfNotInJourneyData.test.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import type { StrengthDto } from 'dto'
+import createEmptyStrengthDtoIfNotInJourneyData from './createEmptyStrengthDtoIfNotInJourneyData'
+
+describe('createEmptyStrengthDtoIfNotInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const prisonId = 'MDI'
+
+  const req = {
+    params: { prisonNumber },
+  } as unknown as Request
+  const res = {
+    locals: {
+      user: { activeCaseLoadId: prisonId },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+  })
+
+  it('should create an empty StrengthDto for the prisoner given there is no StrengthDto in the journeyData', async () => {
+    // Given
+    req.journeyData.strengthDto = undefined
+
+    const expectedStrengthDto = {
+      prisonNumber,
+      prisonId,
+    } as StrengthDto
+
+    // When
+    await createEmptyStrengthDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.strengthDto).toEqual(expectedStrengthDto)
+  })
+
+  it('should create an empty StrengthDto for a prisoner given there is an StrengthDto in the journeyData for a different prisoner', async () => {
+    // Given
+    req.journeyData.strengthDto = { prisonNumber: 'Z1234ZZ', prisonId } as StrengthDto
+
+    const expectedStrengthDto = {
+      prisonNumber,
+      prisonId,
+    } as StrengthDto
+
+    // When
+    await createEmptyStrengthDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.strengthDto).toEqual(expectedStrengthDto)
+  })
+
+  it('should not create an empty StrengthDto for the prisoner given there is already an StrengthDto in the journeyData for the prisoner', async () => {
+    // Given
+    const expectedStrengthDto = {
+      prisonNumber,
+      prisonId,
+    } as StrengthDto
+
+    req.journeyData.strengthDto = expectedStrengthDto
+
+    // When
+    await createEmptyStrengthDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.strengthDto).toEqual(expectedStrengthDto)
+  })
+})

--- a/server/routes/strengths/create/middleware/createEmptyStrengthDtoIfNotInJourneyData.ts
+++ b/server/routes/strengths/create/middleware/createEmptyStrengthDtoIfNotInJourneyData.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express'
+import type { StrengthDto } from 'dto'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+/**
+ * Middleware function to check whether a [StrengthDto] exists in the journeyData for the prisoner referenced in the request URL.
+ * If one does not exist, or it is for a different prisoner, create a new empty [StrengthDto] for the prisoner.
+ */
+const createEmptyStrengthDtoIfNotInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  const { prisonNumber } = req.params
+  const { activeCaseLoadId } = res.locals.user as PrisonUser
+
+  // Either no StrengthDto in the journeyData, or it's for a different prisoner. Create a new one.
+  if (req.journeyData?.strengthDto?.prisonNumber !== prisonNumber) {
+    req.journeyData = {
+      strengthDto: {
+        prisonNumber,
+        prisonId: activeCaseLoadId,
+      } as StrengthDto,
+    }
+  }
+
+  next()
+}
+
+export default createEmptyStrengthDtoIfNotInJourneyData

--- a/server/testsupport/strengthDtoTestDataBuilder.ts
+++ b/server/testsupport/strengthDtoTestDataBuilder.ts
@@ -1,0 +1,15 @@
+import type { StrengthDto } from 'dto'
+
+const aValidStrengthDto = (options?: {
+  prisonNumber?: string
+  prisonId?: string
+  strengthTypeCode?: string
+  detail?: string
+}): StrengthDto => ({
+  prisonNumber: options?.prisonNumber || 'A1234BC',
+  prisonId: options?.prisonId || 'BXI',
+  strengthTypeCode: options?.strengthTypeCode || 'READING',
+  detail: options?.detail === null ? null : options?.detail || 'John is a very accomplished reader.',
+})
+
+export default aValidStrengthDto


### PR DESCRIPTION
PR to create the StrengthDto , which we'll use to carry the data from page to page in the Create Strength journey

And also to create the 2 middlewares we need for the Create Strength journey (the first is to create an empty StrengthDto in the journeyData at the beginning of the journey; the 2nd is to check it has been created and exists in the journeyData on each subsequent page in the journey)