### PR TITLE
RR-1700 - Initial DTO & middlewares

### DIFF
--- a/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreenerPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreenerPreventOutOfSequenceNavigation.cy.ts
@@ -1,0 +1,27 @@
+import { v4 as uuidV4 } from 'uuid'
+import Page from '../../../pages/page'
+import OverviewPage from '../../../pages/profile/overviewPage'
+
+context('Prevent out of sequence navigation to pages in the Record ALN Screener journey', () => {
+  const prisonNumber = 'A00001A'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+  })
+  ;['add-challenges', 'add-strengths', 'check-your-answers'].forEach(page => {
+    it(`should prevent direct navigation to ${page} page when the user has not started the Record ALN Screener journey`, () => {
+      // Given
+      const journeyId = uuidV4()
+
+      // When
+      cy.visit(`/aln-screener/${prisonNumber}/create/${journeyId}/${page}`)
+
+      // Then
+      Page.verifyOnPage(OverviewPage)
+    })
+  })
+})

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -73,4 +73,10 @@ declare module 'dto' {
     code: string
     areaCode?: string
   }
+
+  export interface AlnScreenerDto {
+    prisonNumber: string
+    prisonId: string
+    screenerDate?: Date
+  }
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,10 @@
-import type { ChallengeDto, EducationSupportPlanDto, StrengthDto, RefuseEducationSupportPlanDto } from 'dto'
+import type {
+  ChallengeDto,
+  EducationSupportPlanDto,
+  StrengthDto,
+  RefuseEducationSupportPlanDto,
+  AlnScreenerDto,
+} from 'dto'
 import { HmppsUser } from '../../interfaces/hmppsUser'
 
 export declare module 'express-session' {
@@ -23,6 +29,7 @@ export declare global {
       challengeDto?: ChallengeDto
       conditionDto?: ConditionDto
       strengthDto?: StrengthDto
+      alnScreenerDto?: AlnScreenerDto
     }
 
     interface Response {

--- a/server/routes/additional-learning-needs-screener/create/index.ts
+++ b/server/routes/additional-learning-needs-screener/create/index.ts
@@ -2,6 +2,8 @@ import { Request, Response, Router } from 'express'
 import { Services } from '../../../services'
 import insertJourneyIdentifier from '../../../middleware/insertJourneyIdentifier'
 import setupJourneyData from '../../../middleware/setupJourneyData'
+import createEmptyAlnScreenerDtoIfNotInJourneyData from './middleware/createEmptyAlnScreenerDtoIfNotInJourneyData'
+import checkAlnScreenerDtoExistsInJourneyData from './middleware/checkAlnScreenerDtoExistsInJourneyData'
 
 const createAlnRoutes = (services: Services): Router => {
   const { journeyDataService } = services
@@ -15,24 +17,28 @@ const createAlnRoutes = (services: Services): Router => {
   router.use('/:journeyId', [setupJourneyData(journeyDataService)])
 
   router.get('/:journeyId/screener-date', [
+    createEmptyAlnScreenerDtoIfNotInJourneyData,
     async (req: Request, res: Response) => {
       res.send('ALN Screener - Add Date page')
     },
   ])
 
   router.get('/:journeyId/add-challenges', [
+    checkAlnScreenerDtoExistsInJourneyData,
     async (req: Request, res: Response) => {
       res.send('ALN Screener - Add Challenges page')
     },
   ])
 
   router.get('/:journeyId/add-strengths', [
+    checkAlnScreenerDtoExistsInJourneyData,
     async (req: Request, res: Response) => {
       res.send('ALN Screener - Add Strengths page')
     },
   ])
 
   router.get('/:journeyId/check-your-answers', [
+    checkAlnScreenerDtoExistsInJourneyData,
     async (req: Request, res: Response) => {
       res.send('ALN Screener - Check Your Answers page')
     },

--- a/server/routes/additional-learning-needs-screener/create/middleware/checkAlnScreenerDtoExistsInJourneyData.test.ts
+++ b/server/routes/additional-learning-needs-screener/create/middleware/checkAlnScreenerDtoExistsInJourneyData.test.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from 'express'
+import checkAlnScreenerDtoExistsInJourneyData from './checkAlnScreenerDtoExistsInJourneyData'
+import aValidAlnScreenerDto from '../../../../testsupport/alnScreenerDtoTestDataBuilder'
+
+describe('checkAlnScreenerDtoExistsInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+
+  const req = {
+    journeyData: {},
+    params: {},
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+    req.params = { prisonNumber }
+  })
+
+  it(`should invoke next handler given AlnScreenerDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.alnScreenerDto = aValidAlnScreenerDto()
+
+    // When
+    await checkAlnScreenerDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no AlnScreenerDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.alnScreenerDto = undefined
+
+    // When
+    await checkAlnScreenerDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Profile Overview page given no journeyData exists`, async () => {
+    // Given
+    req.journeyData = undefined
+
+    // When
+    await checkAlnScreenerDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/additional-learning-needs-screener/create/middleware/checkAlnScreenerDtoExistsInJourneyData.ts
+++ b/server/routes/additional-learning-needs-screener/create/middleware/checkAlnScreenerDtoExistsInJourneyData.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from 'express'
+import logger from '../../../../../logger'
+
+/**
+ * Middleware function to check that the [AlnScreenDto] exists in the journeyData.
+ */
+const checkAlnScreenerDtoExistsInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.journeyData?.alnScreenerDto) {
+    logger.warn(
+      `No AlnScreenDto in journeyData - user attempting to navigate to path ${req.originalUrl} out of sequence. Redirecting to Profile Overview page.`,
+    )
+    return res.redirect(`/profile/${req.params.prisonNumber}/overview`)
+  }
+  return next()
+}
+
+export default checkAlnScreenerDtoExistsInJourneyData

--- a/server/routes/additional-learning-needs-screener/create/middleware/createEmptyAlnScreenerDtoIfNotInJourneyData.test.ts
+++ b/server/routes/additional-learning-needs-screener/create/middleware/createEmptyAlnScreenerDtoIfNotInJourneyData.test.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import type { AlnScreenerDto } from 'dto'
+import createEmptyAlnScreenerDtoIfNotInJourneyData from './createEmptyAlnScreenerDtoIfNotInJourneyData'
+
+describe('createEmptyAlnScreenerDtoIfNotInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const prisonId = 'MDI'
+
+  const req = {
+    params: { prisonNumber },
+  } as unknown as Request
+  const res = {
+    locals: {
+      user: { activeCaseLoadId: prisonId },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+  })
+
+  it('should create an empty AlnScreenerDto for the prisoner given there is no AlnScreenerDto in the journeyData', async () => {
+    // Given
+    req.journeyData.alnScreenerDto = undefined
+
+    const expectedAlnScreenerDto = {
+      prisonNumber,
+      prisonId,
+    } as AlnScreenerDto
+
+    // When
+    await createEmptyAlnScreenerDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.alnScreenerDto).toEqual(expectedAlnScreenerDto)
+  })
+
+  it('should create an empty AlnScreenerDto for a prisoner given there is an AlnScreenerDto in the journeyData for a different prisoner', async () => {
+    // Given
+    req.journeyData.alnScreenerDto = { prisonNumber: 'Z1234ZZ', prisonId } as AlnScreenerDto
+
+    const expectedAlnScreenerDto = {
+      prisonNumber,
+      prisonId,
+    } as AlnScreenerDto
+
+    // When
+    await createEmptyAlnScreenerDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.alnScreenerDto).toEqual(expectedAlnScreenerDto)
+  })
+
+  it('should not create an empty AlnScreenerDto for the prisoner given there is already an AlnScreenerDto in the journeyData for the prisoner', async () => {
+    // Given
+    const expectedAlnScreenerDto = {
+      prisonNumber,
+      prisonId,
+    } as AlnScreenerDto
+
+    req.journeyData.alnScreenerDto = expectedAlnScreenerDto
+
+    // When
+    await createEmptyAlnScreenerDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.alnScreenerDto).toEqual(expectedAlnScreenerDto)
+  })
+})

--- a/server/routes/additional-learning-needs-screener/create/middleware/createEmptyAlnScreenerDtoIfNotInJourneyData.ts
+++ b/server/routes/additional-learning-needs-screener/create/middleware/createEmptyAlnScreenerDtoIfNotInJourneyData.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express'
+import type { AlnScreenerDto } from 'dto'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+/**
+ * Middleware function to check whether a [AlnScreenerDto] exists in the journeyData for the prisoner referenced in the request URL.
+ * If one does not exist, or it is for a different prisoner, create a new empty [AlnScreenerDto] for the prisoner.
+ */
+const createEmptyAlnScreenerDtoIfNotInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  const { prisonNumber } = req.params
+  const { activeCaseLoadId } = res.locals.user as PrisonUser
+
+  // Either no AlnScreenerDto in the journeyData, or it's for a different prisoner. Create a new one.
+  if (req.journeyData?.alnScreenerDto?.prisonNumber !== prisonNumber) {
+    req.journeyData = {
+      alnScreenerDto: {
+        prisonNumber,
+        prisonId: activeCaseLoadId,
+      } as AlnScreenerDto,
+    }
+  }
+
+  next()
+}
+
+export default createEmptyAlnScreenerDtoIfNotInJourneyData

--- a/server/testsupport/alnScreenerDtoTestDataBuilder.ts
+++ b/server/testsupport/alnScreenerDtoTestDataBuilder.ts
@@ -1,0 +1,14 @@
+import { startOfToday, subDays } from 'date-fns'
+import type { AlnScreenerDto } from 'dto'
+
+const aValidAlnScreenerDto = (options?: {
+  prisonNumber?: string
+  prisonId?: string
+  screenerDate?: Date
+}): AlnScreenerDto => ({
+  prisonNumber: options?.prisonNumber || 'A1234BC',
+  prisonId: options?.prisonId || 'BXI',
+  screenerDate: options?.screenerDate === null ? null : options?.screenerDate || subDays(startOfToday(), 1),
+})
+
+export default aValidAlnScreenerDto


### PR DESCRIPTION
PR to add the initial `AlnScreenerDto` (will be fleshed out with additional fields as we progress through the stories), and the 2 middlewares to:
* create the DTO in the journeyData if it doesn't exist at the start of the journey
* check the DTO exists in the journeyData on each screen of the journey

Also added the cypress test to check the user cannot navigate to the ALN Screener journey pages out of sequence (these essentially test the middleware that checks the DTO exists in the journeyData)