### PR TITLE
RR-1699 - Basic controller and view

### DIFF
--- a/assets/scss/components/_additional-learning-needs-form.scss
+++ b/assets/scss/components/_additional-learning-needs-form.scss
@@ -1,0 +1,8 @@
+.additional-learning-needs-form {
+  .govuk-fieldset {
+    section {
+      column-count: 3;
+      @include govuk-responsive-margin(6, 'bottom');
+    }
+  }
+}

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -13,5 +13,6 @@ $govuk-page-width: $moj-page-width;
 @import './components/api-error';
 @import './components/search';
 @import './components/prisoner-summary-banner';
+@import './components/additional-learning-needs-form';
 @import './overrides/local';
 @import './overrides/print';

--- a/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.ts
+++ b/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express'
+import type { AlnScreenerDto } from 'dto'
+
+export default class AddChallengesController {
+  getAddChallengesView = async (req: Request, res: Response, next: NextFunction) => {
+    const { invalidForm } = res.locals
+    const { alnScreenerDto } = req.journeyData
+
+    const screenerDateForm = invalidForm ?? this.populateFormFromDto(alnScreenerDto)
+
+    const viewRenderArgs = { form: screenerDateForm }
+    return res.render('pages/additional-learning-needs-screener/add-challenges/index', viewRenderArgs)
+  }
+
+  private populateFormFromDto = (_dto: AlnScreenerDto) => {
+    return {}
+  }
+}

--- a/server/routes/additional-learning-needs-screener/create/index.ts
+++ b/server/routes/additional-learning-needs-screener/create/index.ts
@@ -8,12 +8,16 @@ import checkAlnScreenerDtoExistsInJourneyData from './middleware/checkAlnScreene
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { validate } from '../../../middleware/validationMiddleware'
 import screenerDateSchema from '../validationSchemas/screenerDateSchema'
+import retrieveReferenceData from '../../middleware/retrieveReferenceData'
+import ReferenceDataDomain from '../../../enums/referenceDataDomain'
+import AddChallengesController from './add-challenges/addChallengesController'
 
 const createAlnRoutes = (services: Services): Router => {
-  const { journeyDataService } = services
+  const { journeyDataService, referenceDataService } = services
   const router = Router({ mergeParams: true })
 
   const screenerDateController = new ScreenerDateController()
+  const addChallengesController = new AddChallengesController()
 
   router.use('/', [
     // TODO - enable this line when we understand the RBAC roles and permissions
@@ -34,9 +38,8 @@ const createAlnRoutes = (services: Services): Router => {
 
   router.get('/:journeyId/add-challenges', [
     checkAlnScreenerDtoExistsInJourneyData,
-    async (req: Request, res: Response) => {
-      res.send('ALN Screener - Add Challenges page')
-    },
+    retrieveReferenceData(ReferenceDataDomain.CHALLENGE, referenceDataService),
+    asyncMiddleware(addChallengesController.getAddChallengesView),
   ])
 
   router.get('/:journeyId/add-strengths', [

--- a/server/views/pages/additional-learning-needs-screener/add-challenges/index.njk
+++ b/server/views/pages/additional-learning-needs-screener/add-challenges/index.njk
@@ -1,0 +1,61 @@
+{% extends "../layout.njk" %}
+
+{% set pageId = 'record-aln-add-challenges' %}
+{% set pageTitle = "Additional learning needs screener - Add challenges" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width govuk-!-padding-left-3 govuk-!-padding-right-3">
+
+      <h1 class="govuk-heading-l">Select the challenges identified by the screener</h1>
+
+      <form class="form additional-learning-needs-form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          <div class="govuk-form-group">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+
+              {% for challengeCategory, challengeTypes in challengesReferenceData %}
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">{{ challengeCategory }}</legend>
+                  <section>
+                    {% for challengeType in challengeTypes %}
+                      <div class="govuk-checkboxes__item">
+                        <input class="govuk-checkboxes__input" id="{{ challengeCategory ~ loop.index0 }}" name="challengeTypeCode" type="checkbox" value="{{ challengeType.code }}">
+                        <label class="govuk-label govuk-checkboxes__label" for="{{ challengeCategory ~ loop.index0 }}">
+                          {{ challengeType.code }}
+                        </label>
+                      </div>
+                    {% endfor %}
+                  </section>
+                </fieldset>
+
+              {% endfor %}
+
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Or</legend>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="no-challenges" name="challengeTypeCode" type="checkbox" value="NONE" data-behaviour="exclusive">
+                  <label class="govuk-label govuk-checkboxes__label" for="no-challenges">
+                    No challenges identified
+                  </label>
+                </div>
+              </fieldset>
+
+            </div>
+          </div>
+
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Continue",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Basic controller and view for the "Add challenges" screen.

The route calls the reference data middleware in order to get the challenges grouped by challenge category; and then the view loops through the challenge categories and challenges in order to dynamically layout the form.
At the moment the screen labels are the underlying challenge type codes; this will be addressed in my next PR

<img width="635" height="1159" alt="Screenshot 2025-07-21 at 09 27 23" src="https://github.com/user-attachments/assets/ef7c7c3d-a588-435b-8479-e5376185ee27" />
