### PR TITLE
RR-1702 - Add client and service methods to record ALN Screener

### DIFF
--- a/server/@types/supportAdditionalNeedsApiClient/index.d.ts
+++ b/server/@types/supportAdditionalNeedsApiClient/index.d.ts
@@ -30,4 +30,8 @@ declare module 'supportAdditionalNeedsApiClient' {
 
   export type ReferenceDataListResponse = components['schemas']['ReferenceDataListResponse']
   export type ReferenceData = components['schemas']['ReferenceData']
+
+  export type AlnScreenerRequest = components['schemas']['ALNScreenerRequest']
+  export type AlnChallenge = components['schemas']['ALNChallenge']
+  export type AlnStrength = components['schemas']['ALNStrength']
 }

--- a/server/data/mappers/alnScreenerRequestMapper.test.ts
+++ b/server/data/mappers/alnScreenerRequestMapper.test.ts
@@ -1,0 +1,31 @@
+import { startOfToday } from 'date-fns'
+import aValidAlnScreenerDto from '../../testsupport/alnScreenerDtoTestDataBuilder'
+import { aValidAlnScreenerRequest } from '../../testsupport/alnScreenerRequestTestDataBuilder'
+import toAlnScreenerRequest from './alnScreenerRequestMapper'
+import ChallengeType from '../../enums/challengeType'
+import StrengthType from '../../enums/strengthType'
+
+describe('alnScreenerRequestMapper', () => {
+  it('should map an AlnScreenerDto to an AlnScreenerRequest', () => {
+    // Given
+    const alnScreenerDto = aValidAlnScreenerDto({
+      prisonId: 'MDI',
+      screenerDate: startOfToday(),
+      challenges: [ChallengeType.ARITHMETIC, ChallengeType.NUMBER_RECALL],
+      strengths: [StrengthType.READING, StrengthType.LISTENING],
+    })
+
+    const expected = aValidAlnScreenerRequest({
+      prisonId: 'MDI',
+      screenerDate: startOfToday(),
+      challenges: [{ challengeTypeCode: ChallengeType.ARITHMETIC }, { challengeTypeCode: ChallengeType.NUMBER_RECALL }],
+      strengths: [{ strengthTypeCode: StrengthType.READING }, { strengthTypeCode: StrengthType.LISTENING }],
+    })
+
+    // When
+    const actual = toAlnScreenerRequest(alnScreenerDto)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/alnScreenerRequestMapper.ts
+++ b/server/data/mappers/alnScreenerRequestMapper.ts
@@ -1,0 +1,12 @@
+import { format } from 'date-fns'
+import type { AlnScreenerRequest } from 'supportAdditionalNeedsApiClient'
+import type { AlnScreenerDto } from 'dto'
+
+const toAlnScreenerRequest = (alnScreenerDto: AlnScreenerDto): AlnScreenerRequest => ({
+  prisonId: alnScreenerDto.prisonId,
+  screenerDate: format(alnScreenerDto.screenerDate, 'yyyy-MM-dd'),
+  challenges: alnScreenerDto.challenges.map(challengeTypeCode => ({ challengeTypeCode })),
+  strengths: alnScreenerDto.strengths.map(strengthTypeCode => ({ strengthTypeCode })),
+})
+
+export default toAlnScreenerRequest

--- a/server/data/supportAdditionalNeedsApiClient.ts
+++ b/server/data/supportAdditionalNeedsApiClient.ts
@@ -1,6 +1,7 @@
 import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
 import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
 import type {
+  AlnScreenerRequest,
   ChallengeListResponse,
   ConditionListResponse,
   CreateChallengesRequest,
@@ -148,6 +149,20 @@ export default class SupportAdditionalNeedsApiClient extends RestClient {
       {
         path: `/profile/${prisonNumber}/strengths`,
         data: createStrengthsRequest,
+      },
+      asSystem(username),
+    )
+  }
+
+  async createAdditionalLearningNeedsScreener(
+    prisonNumber: string,
+    username: string,
+    alnScreenerRequest: AlnScreenerRequest,
+  ): Promise<void> {
+    return this.post<void>(
+      {
+        path: `/profile/${prisonNumber}/aln-screener`,
+        data: alnScreenerRequest,
       },
       asSystem(username),
     )

--- a/server/services/additionalLearningNeedsScreenerService.test.ts
+++ b/server/services/additionalLearningNeedsScreenerService.test.ts
@@ -1,0 +1,89 @@
+import { startOfToday } from 'date-fns'
+import SupportAdditionalNeedsApiClient from '../data/supportAdditionalNeedsApiClient'
+import AdditionalLearningNeedsScreenerService from './additionalLearningNeedsScreenerService'
+import aValidAlnScreenerDto from '../testsupport/alnScreenerDtoTestDataBuilder'
+import ChallengeType from '../enums/challengeType'
+import StrengthType from '../enums/strengthType'
+import { aValidAlnScreenerRequest } from '../testsupport/alnScreenerRequestTestDataBuilder'
+
+jest.mock('../data/supportAdditionalNeedsApiClient')
+
+describe('additionalLearningNeedsScreenerService', () => {
+  const supportAdditionalNeedsApiClient = new SupportAdditionalNeedsApiClient(
+    null,
+  ) as jest.Mocked<SupportAdditionalNeedsApiClient>
+  const service = new AdditionalLearningNeedsScreenerService(supportAdditionalNeedsApiClient)
+
+  const prisonNumber = 'A1234BC'
+  const username = 'some-username'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('recordAlnScreener', () => {
+    it('should record ALN Screener', async () => {
+      // Given
+      const alnScreenerDto = aValidAlnScreenerDto({
+        prisonId: 'MDI',
+        screenerDate: startOfToday(),
+        challenges: [ChallengeType.ARITHMETIC, ChallengeType.NUMBER_RECALL],
+        strengths: [StrengthType.READING, StrengthType.LISTENING],
+      })
+      const expectedAlnScreenerRequest = aValidAlnScreenerRequest({
+        prisonId: 'MDI',
+        screenerDate: startOfToday(),
+        challenges: [
+          { challengeTypeCode: ChallengeType.ARITHMETIC },
+          { challengeTypeCode: ChallengeType.NUMBER_RECALL },
+        ],
+        strengths: [{ strengthTypeCode: StrengthType.READING }, { strengthTypeCode: StrengthType.LISTENING }],
+      })
+
+      supportAdditionalNeedsApiClient.createAdditionalLearningNeedsScreener.mockResolvedValue(null)
+
+      // When
+      await service.recordAlnScreener(username, alnScreenerDto)
+
+      // Then
+      expect(supportAdditionalNeedsApiClient.createAdditionalLearningNeedsScreener).toHaveBeenCalledWith(
+        prisonNumber,
+        username,
+        expectedAlnScreenerRequest,
+      )
+    })
+
+    it('should rethrow error given API client throws error', async () => {
+      // Given
+      const expectedError = new Error('Internal Server Error')
+      supportAdditionalNeedsApiClient.createAdditionalLearningNeedsScreener.mockRejectedValue(expectedError)
+
+      const alnScreenerDto = aValidAlnScreenerDto({
+        prisonId: 'MDI',
+        screenerDate: startOfToday(),
+        challenges: [ChallengeType.ARITHMETIC, ChallengeType.NUMBER_RECALL],
+        strengths: [StrengthType.READING, StrengthType.LISTENING],
+      })
+      const expectedAlnScreenerRequest = aValidAlnScreenerRequest({
+        prisonId: 'MDI',
+        screenerDate: startOfToday(),
+        challenges: [
+          { challengeTypeCode: ChallengeType.ARITHMETIC },
+          { challengeTypeCode: ChallengeType.NUMBER_RECALL },
+        ],
+        strengths: [{ strengthTypeCode: StrengthType.READING }, { strengthTypeCode: StrengthType.LISTENING }],
+      })
+
+      // When
+      const actual = await service.recordAlnScreener(username, alnScreenerDto).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(supportAdditionalNeedsApiClient.createAdditionalLearningNeedsScreener).toHaveBeenCalledWith(
+        prisonNumber,
+        username,
+        expectedAlnScreenerRequest,
+      )
+    })
+  })
+})

--- a/server/services/additionalLearningNeedsScreenerService.ts
+++ b/server/services/additionalLearningNeedsScreenerService.ts
@@ -1,0 +1,23 @@
+import type { AlnScreenerDto } from 'dto'
+import { SupportAdditionalNeedsApiClient } from '../data'
+import logger from '../../logger'
+import toAlnScreenerRequest from '../data/mappers/alnScreenerRequestMapper'
+
+export default class AdditionalLearningNeedsScreenerService {
+  constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
+
+  async recordAlnScreener(username: string, alnScreenerDto: AlnScreenerDto): Promise<void> {
+    const { prisonNumber } = alnScreenerDto
+    try {
+      const alnScreenerRequest = toAlnScreenerRequest(alnScreenerDto)
+      await this.supportAdditionalNeedsApiClient.createAdditionalLearningNeedsScreener(
+        prisonNumber,
+        username,
+        alnScreenerRequest,
+      )
+    } catch (e) {
+      logger.error(`Error recording ALN Screener for [${prisonNumber}]`, e)
+      throw e
+    }
+  }
+}

--- a/server/services/challengeService.test.ts
+++ b/server/services/challengeService.test.ts
@@ -24,7 +24,7 @@ describe('challengeService', () => {
       const unPersistedChallengeDtos = [aValidChallengeDto()]
       const expectedCreateChallengesRequest = aValidCreateChallengesRequest()
 
-      supportAdditionalNeedsApiClient.createEducationSupportPlan.mockResolvedValue(null)
+      supportAdditionalNeedsApiClient.createChallenges.mockResolvedValue(null)
 
       // When
       await service.createChallenges(username, unPersistedChallengeDtos)

--- a/server/services/conditionService.test.ts
+++ b/server/services/conditionService.test.ts
@@ -24,7 +24,7 @@ describe('conditionService', () => {
       const unPersistedConditionDtos = [aValidConditionDto()]
       const expectedCreateConditionsRequest = aValidCreateConditionsRequest()
 
-      supportAdditionalNeedsApiClient.createEducationSupportPlan.mockResolvedValue(null)
+      supportAdditionalNeedsApiClient.createConditions.mockResolvedValue(null)
 
       // When
       await service.createConditions(username, unPersistedConditionDtos)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -12,6 +12,7 @@ import ChallengeService from './challengeService'
 import ConditionService from './conditionService'
 import ReferenceDataService from './referenceDataService'
 import StrengthService from './strengthService'
+import AdditionalLearningNeedsScreenerService from './additionalLearningNeedsScreenerService'
 
 export const services = () => {
   const {
@@ -43,12 +44,14 @@ export const services = () => {
     conditionService: new ConditionService(supportAdditionalNeedsApiClient),
     referenceDataService: new ReferenceDataService(referenceDataStore, supportAdditionalNeedsApiClient),
     strengthService: new StrengthService(supportAdditionalNeedsApiClient),
+    additionalLearningNeedsService: new AdditionalLearningNeedsScreenerService(supportAdditionalNeedsApiClient),
   }
 }
 
 export type Services = ReturnType<typeof services>
 
 export {
+  AdditionalLearningNeedsScreenerService,
   AuditService,
   ChallengeService,
   ConditionService,

--- a/server/services/strengthService.test.ts
+++ b/server/services/strengthService.test.ts
@@ -24,7 +24,7 @@ describe('strengthService', () => {
       const unPersistedStrengthDtos = [aValidStrengthDto()]
       const expectedCreateStrengthsRequest = aValidCreateStrengthsRequest()
 
-      supportAdditionalNeedsApiClient.createEducationSupportPlan.mockResolvedValue(null)
+      supportAdditionalNeedsApiClient.createStrengths.mockResolvedValue(null)
 
       // When
       await service.createStrengths(username, unPersistedStrengthDtos)

--- a/server/testsupport/alnScreenerRequestTestDataBuilder.ts
+++ b/server/testsupport/alnScreenerRequestTestDataBuilder.ts
@@ -1,0 +1,24 @@
+import type { AlnChallenge, AlnScreenerRequest, AlnStrength } from 'supportAdditionalNeedsApiClient'
+import { format, startOfToday } from 'date-fns'
+
+const aValidAlnScreenerRequest = (options?: {
+  prisonId?: string
+  screenerDate?: Date
+  challenges?: Array<AlnChallenge>
+  strengths?: Array<AlnStrength>
+}): AlnScreenerRequest => ({
+  prisonId: options?.prisonId || 'BXI',
+  screenerDate: format(options?.screenerDate || startOfToday(), 'yyyy-MM-dd'),
+  challenges: options?.challenges || [aValidAlnChallenge()],
+  strengths: options?.strengths || [aValidAlnStrength()],
+})
+
+const aValidAlnChallenge = (options?: { challengeTypeCode?: string }): AlnChallenge => ({
+  challengeTypeCode: options?.challengeTypeCode || 'WRITING',
+})
+
+const aValidAlnStrength = (options?: { strengthTypeCode?: string }): AlnStrength => ({
+  strengthTypeCode: options?.strengthTypeCode || 'READING',
+})
+
+export { aValidAlnScreenerRequest, aValidAlnChallenge, aValidAlnStrength }


### PR DESCRIPTION
PR to add the client and service methods to be able to call the API to record an ALN Screener
(service not wired into anything yet; that will be in my next PR)