### PR TITLE
RR-1669 - Fix "add challenges" and "add strengths" form mapping

### DIFF
--- a/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.test.ts
+++ b/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.test.ts
@@ -47,12 +47,29 @@ describe('addChallengesController', () => {
   it('should render view given previously submitted invalid form', async () => {
     // Given
     const invalidForm = {
-      challengeTypeCodes: 'not-a-valid-value',
+      challengeTypeCodes: ['not-a-valid-value'],
     }
     res.locals.invalidForm = invalidForm
 
     const expectedViewTemplate = 'pages/additional-learning-needs-screener/add-challenges/index'
     const expectedViewModel = { form: invalidForm }
+
+    // When
+    await controller.getAddChallengesView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render view given previously submitted invalid form where challengeTypeCodes is not present', async () => {
+    // Given
+    const invalidForm = {
+      challengeTypeCodes: undefined as unknown as string[],
+    }
+    res.locals.invalidForm = invalidForm
+
+    const expectedViewTemplate = 'pages/additional-learning-needs-screener/add-challenges/index'
+    const expectedViewModel = { form: { challengeTypeCodes: [] as string[] } }
 
     // When
     await controller.getAddChallengesView(req, res, next)

--- a/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.ts
+++ b/server/routes/additional-learning-needs-screener/create/add-challenges/addChallengesController.ts
@@ -1,13 +1,19 @@
 import { NextFunction, Request, Response } from 'express'
 import type { AlnScreenerDto } from 'dto'
 import ChallengeType from '../../../../enums/challengeType'
+import { asArray } from '../../../../utils/utils'
 
 export default class AddChallengesController {
   getAddChallengesView = async (req: Request, res: Response, next: NextFunction) => {
     const { invalidForm } = res.locals
     const { alnScreenerDto } = req.journeyData
 
-    const addChallengesForm = invalidForm ?? this.populateFormFromDto(alnScreenerDto)
+    const addChallengesForm = invalidForm
+      ? {
+          ...invalidForm,
+          challengeTypeCodes: asArray(invalidForm.challengeTypeCodes),
+        }
+      : this.populateFormFromDto(alnScreenerDto)
 
     const viewRenderArgs = { form: addChallengesForm }
     return res.render('pages/additional-learning-needs-screener/add-challenges/index', viewRenderArgs)

--- a/server/routes/additional-learning-needs-screener/create/add-strengths/addStrengthsController.test.ts
+++ b/server/routes/additional-learning-needs-screener/create/add-strengths/addStrengthsController.test.ts
@@ -47,12 +47,29 @@ describe('addStrengthsController', () => {
   it('should render view given previously submitted invalid form', async () => {
     // Given
     const invalidForm = {
-      strengthTypeCodes: 'not-a-valid-value',
+      strengthTypeCodes: ['not-a-valid-value'],
     }
     res.locals.invalidForm = invalidForm
 
     const expectedViewTemplate = 'pages/additional-learning-needs-screener/add-strengths/index'
     const expectedViewModel = { form: invalidForm }
+
+    // When
+    await controller.getAddStrengthsView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render view given previously submitted invalid form where strengthTypeCodes is not present', async () => {
+    // Given
+    const invalidForm = {
+      strengthTypeCodes: undefined as unknown as string[],
+    }
+    res.locals.invalidForm = invalidForm
+
+    const expectedViewTemplate = 'pages/additional-learning-needs-screener/add-strengths/index'
+    const expectedViewModel = { form: { strengthTypeCodes: [] as string[] } }
 
     // When
     await controller.getAddStrengthsView(req, res, next)

--- a/server/routes/additional-learning-needs-screener/create/add-strengths/addStrengthsController.ts
+++ b/server/routes/additional-learning-needs-screener/create/add-strengths/addStrengthsController.ts
@@ -1,13 +1,19 @@
 import { NextFunction, Request, Response } from 'express'
 import type { AlnScreenerDto } from 'dto'
 import StrengthType from '../../../../enums/strengthType'
+import { asArray } from '../../../../utils/utils'
 
 export default class AddStrengthsController {
   getAddStrengthsView = async (req: Request, res: Response, next: NextFunction) => {
     const { invalidForm } = res.locals
     const { alnScreenerDto } = req.journeyData
 
-    const addStrengthsForm = invalidForm ?? this.populateFormFromDto(alnScreenerDto)
+    const addStrengthsForm = invalidForm
+      ? {
+          ...invalidForm,
+          strengthTypeCodes: asArray(invalidForm.strengthTypeCodes),
+        }
+      : this.populateFormFromDto(alnScreenerDto)
 
     const viewRenderArgs = { form: addStrengthsForm }
     return res.render('pages/additional-learning-needs-screener/add-strengths/index', viewRenderArgs)


### PR DESCRIPTION
Small PR to fix a small bug on the "add challenges" and "add strengths" form handling.

Both these pages contain a list of checkboxes, where you need to select at least 1. The form submission submits the selected checkboxes as an array, and then the zod validator checks you have selected at least 1 (and that you've not selected one or more of the options AND "None")

Anyway, in the case where you don't select any checkboxes at all and submit the form, the validator correctly fails the validation and redirects you back to the same page. In the GET handler for the page, we populate the form object (that the view uses) with `invalidForm` (populated by the zod validator with the original request body/fields). But in the case of no checkboxes selected, `invalidForm` has a `challengeTypeCodes` (or `strengthTypeCodes`) field 👍 , but it is null/undefined. The nunjucks view has a problem with this 😢 

The fix (which we've done on similar pages in SAN) is to ensure it is an array, even if that is ultimately an array of null.