### PR TITLE
RR-1705 - Logic to display relevant header for self-declared/diagnosed conditions

### DIFF
--- a/integration_tests/e2e/conditions/create/createConditions.cy.ts
+++ b/integration_tests/e2e/conditions/create/createConditions.cy.ts
@@ -9,12 +9,10 @@ import { urlEqualTo } from '../../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../../mockApis/wiremock/matchers/content'
 
 describe('Create Conditions', () => {
-  const prisonNumber = 'A00001A'
+  const prisonNumber = 'A00001A' // This prisoner is Abby Kyriakopoulos
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubCreateConditions', prisonNumber)
@@ -22,6 +20,8 @@ describe('Create Conditions', () => {
 
   it('should be able to navigate directly to the create Conditions page', () => {
     // Given
+    cy.task('stubSignIn')
+    cy.signIn()
 
     // When
     cy.visit(`/conditions/${prisonNumber}/create/select-conditions`)
@@ -30,8 +30,11 @@ describe('Create Conditions', () => {
     Page.verifyOnPage(SelectConditionsPage)
   })
 
-  it('should create a prisoners Conditions, triggering validation on every screen', () => {
+  it('should create a prisoners self-declared Conditions, triggering validation on every screen given user does not have permission to create diagnosed conditions', () => {
     // Given
+    cy.task('stubSignIn', { roles: ['ROLE_SOME_OTHER_ROLE'] }) // user has some DPS roles, but not the specific role that gives them permission to create diagnosed conditions
+    cy.signIn()
+
     cy.visit(`/profile/${prisonNumber}/overview`)
     Page.verifyOnPage(OverviewPage) //
       .selectTab('Conditions', ConditionsPage)
@@ -39,6 +42,83 @@ describe('Create Conditions', () => {
 
     // When
     Page.verifyOnPage(SelectConditionsPage) //
+      .hasPageHeading('What self-declared condition do you want to record for Abby Kyriakopoulos?')
+      // submit the page without answering the question to trigger a validation error
+      .submitPageTo(SelectConditionsPage)
+      .hasErrorCount(1)
+      .hasFieldInError('conditions')
+      // select Conditions but do not complete conditionally displayed fields
+      .selectCondition(ConditionType.ADHD) // does not display a conditional field
+      .selectCondition(ConditionType.VISUAL_IMPAIR) // does display a conditional field
+      .selectCondition(ConditionType.LONG_TERM_OTHER) // does display a conditional field
+      .submitPageTo(SelectConditionsPage)
+      .hasErrorCount(2)
+      .hasFieldInError('VISUAL_IMPAIR_conditionNames')
+      .hasFieldInError('LONG_TERM_OTHER_conditionNames')
+      // specify the conditions in the conditional fields
+      .specifyCondition(ConditionType.VISUAL_IMPAIR, 'Colour blindness')
+      .specifyCondition(ConditionType.LONG_TERM_OTHER, 'Arthritis')
+      .submitPageTo(ConditionsDetailsPage)
+
+    Page.verifyOnPage(ConditionsDetailsPage)
+      // submit the page without answering the questions to trigger a validation error
+      .submitPageTo(ConditionsDetailsPage)
+      .hasErrorCount(3)
+      .hasFieldInError('ADHD_details')
+      .hasFieldInError('VISUAL_IMPAIR_details')
+      .hasFieldInError('LONG_TERM_OTHER_details')
+      // enter the condition details
+      .enterConditionDetails(
+        ConditionType.ADHD,
+        'Has trouble concentrating and sitting still for long periods. Easily distracted.',
+      )
+      .enterConditionDetails(ConditionType.VISUAL_IMPAIR, 'Has red-green colour blindness.')
+      .enterConditionDetails(ConditionType.LONG_TERM_OTHER, 'Acute arthritis in the right arm and hand. Cause unknown.')
+      .submitPageTo(ConditionsPage)
+
+    // Then
+    Page.verifyOnPage(ConditionsPage).hasSuccessMessage('Condition(s) updated')
+
+    cy.wiremockVerify(
+      postRequestedFor(urlEqualTo(`/support-additional-needs-api/profile/${prisonNumber}/conditions`)) //
+        .withRequestBody(
+          matchingJsonPath(
+            '$[?(' +
+              '@.conditions.size() == 3 && ' +
+              "@.conditions[0].prisonId == 'BXI' && " +
+              "@.conditions[0].conditionTypeCode == 'ADHD' && " +
+              "@.conditions[0].source == 'SELF_DECLARED' && " +
+              '!@.conditions[0].conditionName && ' +
+              "@.conditions[0].conditionDetails == 'Has trouble concentrating and sitting still for long periods. Easily distracted.' && " +
+              "@.conditions[1].prisonId == 'BXI' && " +
+              "@.conditions[1].conditionTypeCode == 'VISUAL_IMPAIR' && " +
+              "@.conditions[1].source == 'SELF_DECLARED' && " +
+              "@.conditions[1].conditionName == 'Colour blindness' && " +
+              "@.conditions[1].conditionDetails == 'Has red-green colour blindness.' && " +
+              "@.conditions[2].prisonId == 'BXI' && " +
+              "@.conditions[2].conditionTypeCode == 'LONG_TERM_OTHER' && " +
+              "@.conditions[2].source == 'SELF_DECLARED' && " +
+              "@.conditions[2].conditionName == 'Arthritis' && " +
+              "@.conditions[2].conditionDetails == 'Acute arthritis in the right arm and hand. Cause unknown.' " +
+              ')]',
+          ),
+        ),
+    )
+  })
+
+  it('should create a prisoners Conditions, triggering validation on every screen given user has permission to create diagnosed conditions', () => {
+    // Given
+    cy.task('stubSignIn', { roles: ['ROLE_SAN_MANAGER'] }) // user has the role that gives them permission to create diagnosed conditions
+    cy.signIn()
+
+    cy.visit(`/profile/${prisonNumber}/overview`)
+    Page.verifyOnPage(OverviewPage) //
+      .selectTab('Conditions', ConditionsPage)
+      .clickRecordConditionsButton()
+
+    // When
+    Page.verifyOnPage(SelectConditionsPage) //
+      .hasPageHeading('What self-declared or diagnosed condition do you want to record for Abby Kyriakopoulos?')
       // submit the page without answering the question to trigger a validation error
       .submitPageTo(SelectConditionsPage)
       .hasErrorCount(1)
@@ -104,6 +184,9 @@ describe('Create Conditions', () => {
 
   it('should not create Conditions given API returns an error response', () => {
     // Given
+    cy.task('stubSignIn')
+    cy.signIn()
+
     cy.task('stubCreateConditions500Error', prisonNumber)
 
     cy.visit(`/conditions/${prisonNumber}/create/select-conditions`)

--- a/server/views/components/actions-card/_challengesActions.test.ts
+++ b/server/views/components/actions-card/_challengesActions.test.ts
@@ -19,6 +19,10 @@ const templateParams: ActionsCardParams = {
 }
 
 describe('_challengesActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render the challenges actions section given user has permission to create challenges', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)

--- a/server/views/components/actions-card/_conditionsActions.test.ts
+++ b/server/views/components/actions-card/_conditionsActions.test.ts
@@ -19,6 +19,10 @@ const templateParams: ActionsCardParams = {
 }
 
 describe('_conditionsActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render the conditions actions section given user has permission to create conditions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)

--- a/server/views/components/actions-card/_educationSupportPlanActions.test.ts
+++ b/server/views/components/actions-card/_educationSupportPlanActions.test.ts
@@ -24,6 +24,10 @@ const templateParams: ActionsCardParams = {
 }
 
 describe('_educationSupportPlanActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render support plan actions section given plan creation schedule status is SCHEDULED', () => {
     // Given
     const params = {

--- a/server/views/components/actions-card/_strengthsActions.test.ts
+++ b/server/views/components/actions-card/_strengthsActions.test.ts
@@ -19,6 +19,10 @@ const templateParams: ActionsCardParams = {
 }
 
 describe('_strengthsActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render the strengths actions section given user has permission to create strengths', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)

--- a/server/views/pages/conditions/select-conditions/index.njk
+++ b/server/views/pages/conditions/select-conditions/index.njk
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">What self-declared condition do you want to record for {{ prisonerSummary | formatFirst_name_Last_name }}?</h1>
+      <h1 class="govuk-heading-l">What self-declared{{ ' or diagnosed' if userHasPermissionTo('RECORD_DIAGNOSED_CONDITIONS') }} condition do you want to record for {{ prisonerSummary | formatFirst_name_Last_name }}?</h1>
       {{ govukWarningText({
         text: "You must have " + prisonerSummary | formatFirst_name_Last_name + "'s consent to share this information",
         iconFallbackText: "Warning"

--- a/server/views/pages/conditions/select-conditions/index.test.ts
+++ b/server/views/pages/conditions/select-conditions/index.test.ts
@@ -1,0 +1,62 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
+import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
+import findErrorFilter from '../../../../filters/findErrorFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+njkEnv //
+  .addFilter('assetMap', () => '')
+  .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
+  .addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
+  .addFilter('findError', findErrorFilter)
+
+const userHasPermissionTo = jest.fn()
+const prisonerSummary = aValidPrisonerSummary({ firstName: 'IFEREECA', lastName: 'PEIGH' })
+const templateParams = {
+  prisonerSummary,
+  userHasPermissionTo,
+  form: {
+    conditions: [] as Array<string>,
+  },
+}
+
+describe('Select Conditions', () => {
+  it('should render template given the user does not have permissions to create diagnosed conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = { ...templateParams }
+
+    // When
+    const content = nunjucks.render('index.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('h1').text().trim()).toEqual('What self-declared condition do you want to record for Ifereeca Peigh?')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_DIAGNOSED_CONDITIONS')
+  })
+
+  it('should render template given the user has permissions to create diagnosed conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = { ...templateParams }
+
+    // When
+    const content = nunjucks.render('index.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('h1').text().trim()).toEqual(
+      'What self-declared or diagnosed condition do you want to record for Ifereeca Peigh?',
+    )
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_DIAGNOSED_CONDITIONS')
+  })
+})


### PR DESCRIPTION
This PR introduces the logic to have a slightly different heading on the "Select conditions" screen, based on whether the user has permission to create only self-declared conditions, or self-declared and diagnosed conditions:

* If the user is a “default access” user (and therefore only has permission to record self-declared conditions), the heading is `What self-declared condition do you want to record for <prisoner name>?`
* If the user has permissions to record diagnosed conditions, the heading is `What self-declared or diagnosed condition do you want to record for <prisoner name>?`

Functionally there are no changes to the screen or journey; it is simply some logic re: the heading (the next story RR-1706 will make some functional changes to the Details screen, but this story and PR is just about the heading)

