### PR TITLE
RR-1706 - Add conditional radio buttons, asking if the condition is self-declared or diagnosed

### DIFF
--- a/server/routes/conditions/create/details/detailsController.ts
+++ b/server/routes/conditions/create/details/detailsController.ts
@@ -50,14 +50,19 @@ export default class DetailsController {
     }
   }
 
-  private updateDtoFromForm = (req: Request, form: { conditionDetails: Record<ConditionType, string> }) => {
+  private updateDtoFromForm = (
+    req: Request,
+    form: { conditionDetails: Record<ConditionType, string>; conditionDiagnosis?: Record<ConditionType, string> },
+  ) => {
     const { conditionsList } = req.journeyData
     Object.entries(form.conditionDetails)
       .filter(([_conditionType, conditionDetail]) => conditionDetail != null)
-      .forEach(([conditionType, details]) => {
-        ;(conditionsList.conditions as Array<ConditionDto>).find(
-          condition => condition.conditionTypeCode === conditionType,
-        ).conditionDetails = details
+      .forEach(([conditionType, details]: [ConditionType, string]) => {
+        const conditionDto = (conditionsList.conditions as Array<ConditionDto>).find(
+          it => it.conditionTypeCode === conditionType,
+        )
+        conditionDto.conditionDetails = details
+        conditionDto.source = form.conditionDiagnosis?.[conditionType] ?? 'SELF_DECLARED'
       })
     req.journeyData.conditionsList = conditionsList
   }

--- a/server/views/pages/conditions/details/index.njk
+++ b/server/views/pages/conditions/details/index.njk
@@ -8,8 +8,11 @@
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-l">
-        {# TODO - heading text is dependent on user's role - this heading is correct for default access; RR-1706 will add logic to render a different heading based on role #}
-        Provide details for {{ prisonerSummary | formatFirst_name_Last_name }}'s self-declared conditions
+        {% if userHasPermissionTo('RECORD_DIAGNOSED_CONDITIONS') %}
+          Select if the condition is self-declared by {{ prisonerSummary | formatFirst_name_Last_name }} or a confirmed diagnosis
+        {% else %}
+          Provide details for {{ prisonerSummary | formatFirst_name_Last_name }}'s self-declared conditions
+        {% endif %}
       </h1>
 
       <form class="form" method="post" novalidate="">
@@ -21,6 +24,25 @@
               <h2 class="govuk-heading-m govuk-!-margin-bottom-2">{{ condition.conditionTypeCode | formatConditionTypeScreenValue | default(condition.conditionTypeCode, true) }}</h2>
               {% if condition.conditionName %}
                 <p class="govuk-body govuk-!-margin-bottom-2">{{ condition.conditionName }}</p>
+              {% endif %}
+
+              {% if userHasPermissionTo('RECORD_DIAGNOSED_CONDITIONS') %}
+                {{ govukRadios({
+                  name: "conditionDiagnosis[" + condition.conditionTypeCode + "]",
+                  items: [
+                    {
+                      value: "SELF_DECLARED",
+                      text: "Self-declared",
+                      checked: form.conditionDiagnosis[condition.conditionTypeCode] === "SELF_DECLARED"
+                    },
+                    {
+                      value: "CONFIRMED_DIAGNOSIS",
+                      text: "Confirmed diagnosis",
+                      checked: form.conditionDiagnosis[condition.conditionTypeCode] === "CONFIRMED_DIAGNOSIS"
+                    }
+                  ],
+                  errorMessage: errors | findError("conditionDiagnosis[" + condition.conditionTypeCode + "]")
+                }) }}
               {% endif %}
 
               {{ govukTextarea({

--- a/server/views/pages/conditions/details/index.test.ts
+++ b/server/views/pages/conditions/details/index.test.ts
@@ -1,0 +1,72 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
+import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
+import findErrorFilter from '../../../../filters/findErrorFilter'
+import { aValidConditionDto, aValidConditionsList } from '../../../../testsupport/conditionDtoTestDataBuilder'
+import ConditionType from '../../../../enums/conditionType'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+njkEnv //
+  .addFilter('assetMap', () => '')
+  .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
+  .addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
+  .addFilter('findError', findErrorFilter)
+
+const userHasPermissionTo = jest.fn()
+const prisonerSummary = aValidPrisonerSummary({ firstName: 'IFEREECA', lastName: 'PEIGH' })
+const templateParams = {
+  prisonerSummary,
+  userHasPermissionTo,
+  form: {
+    conditionDetails: {},
+  },
+  dto: aValidConditionsList({
+    conditions: [
+      aValidConditionDto({ conditionTypeCode: ConditionType.ADHD }),
+      aValidConditionDto({ conditionTypeCode: ConditionType.DYSLEXIA }),
+    ],
+  }),
+}
+
+describe('Add Conditions - Details page', () => {
+  it('should render template given the user does not have permissions to create diagnosed conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = { ...templateParams }
+
+    // When
+    const content = nunjucks.render('index.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('h1').text().trim()).toEqual(`Provide details for Ifereeca Peigh's self-declared conditions`)
+    expect($('input[type=radio]').length).toEqual(0) // expect no radio buttons as the user does not have permission to create diagnosed conditions, so is not asked about them
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_DIAGNOSED_CONDITIONS')
+  })
+
+  it('should render template given the user has permissions to create diagnosed conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = { ...templateParams }
+
+    // When
+    const content = nunjucks.render('index.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('h1').text().trim()).toEqual(
+      'Select if the condition is self-declared by Ifereeca Peigh or a confirmed diagnosis',
+    )
+    expect($('input[type=radio]').length).toEqual(4) // expect 4 radio buttons as the user has permission to create diagnosed conditions, so is asked about them (the DTO has 2 conditions; 2 radios for each condition)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_DIAGNOSED_CONDITIONS')
+  })
+})


### PR DESCRIPTION
### Background
RR-1706 is to add the additional radio button fields to the Conditions Details form to collect whether the Condition is self-declared or diagnosed:

<img width="728" height="737" alt="image" src="https://github.com/user-attachments/assets/d6750bc8-073c-4342-a2f6-914781fc791c" />

These radio button fields are only to be asked if the user has the permission to record Diagnosed Conditions; but its all part of the same "Add Conditions" journey.

What this essentially means is that:
* The radio buttons are conditionally displayed
* In respect of the form submission, the form fields for the radio buttons may or may not be there
* In respect of form validation, the form fields may or may not be there, but if they are there then then are mandatory for the set of ConditionTypes already collected
* The mapping of the form data -> DTO -> API request object will need to cater for these conditional questions
* The cypress tests will need to provide data for the conditional questions in the scenarios that are for users with the permission to record Diagnosed Conditions

Whilst the cumulative set of changes might not touch _that_ many files, I've opted to break this down into some quite granular and focussed PRs.

### This PR
This PR adds the radio buttons asking whether the Condition is self-declared or diagnosed to the nunjucks form, conditional on whether the user has permission to create Diagnosed conditions or not.
It also updates the controller so that the answer for each is mapped into the DTO (defaulting to self-declared if not present on the form)

The cypress test for a user with the create Diagnosed condition is still disabled; I'll get that working in my next PR 👍 