### PR TITLE
RR-1711 - Client and service methods to get conditions

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -7,6 +7,21 @@ declare module 'dto' {
   import ChallengeType from '../../enums/challengeType'
   import StrengthType from '../../enums/strengthType'
 
+  /**
+   * Interface defining common reference and audit related properties that DTO types can inherit through extension.
+   */
+  interface ReferencedAndAuditable {
+    reference?: string
+    createdBy?: string
+    createdByDisplayName?: string
+    createdAt?: Date
+    createdAtPrison?: string
+    updatedBy?: string
+    updatedByDisplayName?: string
+    updatedAt?: Date
+    updatedAtPrison?: string
+  }
+
   export interface EducationSupportPlanDto {
     prisonNumber: string
     prisonId: string
@@ -54,20 +69,11 @@ declare module 'dto' {
     howIdentifiedOther?: string
   }
 
-  export interface ChallengeResponseDto {
+  export interface ChallengeResponseDto extends ReferencedAndAuditable {
     prisonNumber: string
-    reference: string
     fromALNScreener: boolean
     challengeType: ReferenceDataItemDto
     active: boolean
-    createdBy: string
-    createdByDisplayName: string
-    createdAt: Date
-    createdAtPrison: string
-    updatedBy: string
-    updatedByDisplayName: string
-    updatedAt: Date
-    updatedAtPrison: string
     symptoms?: string
     howIdentified?: (
       | 'EDUCATION_SKILLS_WORK'
@@ -87,12 +93,13 @@ declare module 'dto' {
     conditions: Array<ConditionDto>
   }
 
-  export interface ConditionDto {
-    prisonId: string
+  export interface ConditionDto extends ReferencedAndAuditable {
+    prisonId?: string
     conditionTypeCode: ConditionType
     conditionName?: string
     conditionDetails: string
     source: ConditionSource
+    active?: boolean
   }
 
   export interface StrengthDto {

--- a/server/data/mappers/challengeDtoMapper.ts
+++ b/server/data/mappers/challengeDtoMapper.ts
@@ -1,26 +1,18 @@
-import { parseISO } from 'date-fns'
 import type { ChallengeListResponse, ChallengeResponse } from 'supportAdditionalNeedsApiClient'
 import type { ChallengeResponseDto } from 'dto'
 import { toReferenceDataItem } from './referenceDataListResponseMapper'
+import toReferenceAndAuditable from './referencedAndAuditableMapper'
 
 const toChallengeDto = (prisonNumber: string, apiResponse: ChallengeListResponse): ChallengeResponseDto[] => {
   return (apiResponse.challenges as Array<ChallengeResponse>).map(
     challenge =>
       ({
+        ...toReferenceAndAuditable(challenge),
         prisonNumber,
-        reference: challenge.reference,
         fromALNScreener: challenge.fromALNScreener,
         challengeType: toReferenceDataItem(challenge.challengeType),
         symptoms: challenge.symptoms,
-        createdAt: parseISO(challenge.createdAt),
-        createdBy: challenge.createdBy,
-        updatedAt: challenge.updatedAt ? parseISO(challenge.updatedAt) : null,
-        updatedBy: challenge.updatedBy || null,
         howIdentified: challenge.howIdentified,
-        createdAtPrison: challenge.createdAtPrison,
-        updatedAtPrison: challenge.updatedAtPrison,
-        createdByDisplayName: challenge.createdByDisplayName,
-        updatedByDisplayName: challenge.updatedByDisplayName,
         active: challenge.active,
         howIdentifiedOther: challenge.howIdentifiedOther,
       }) as ChallengeResponseDto,

--- a/server/data/mappers/conditionDtoMapper.test.ts
+++ b/server/data/mappers/conditionDtoMapper.test.ts
@@ -1,0 +1,60 @@
+import { parseISO } from 'date-fns'
+import { toConditionsList } from './conditionDtoMapper'
+import { aValidConditionListResponse } from '../../testsupport/conditionResponseTestDataBuilder'
+import { aValidConditionsList } from '../../testsupport/conditionDtoTestDataBuilder'
+import ConditionType from '../../enums/conditionType'
+import ConditionSource from '../../enums/conditionSource'
+
+describe('conditionDtoMapper', () => {
+  it('should map ConditionListResponse to a ConditionsList', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const apiResponse = aValidConditionListResponse({
+      conditionResponses: [
+        {
+          active: true,
+          source: 'SELF_DECLARED',
+          conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
+          conditionType: { code: 'DYSLEXIA' },
+          conditionName: 'Phonological dyslexia',
+          reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+          createdBy: 'asmith_gen',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-06-19T09:39:44Z',
+          createdAtPrison: 'MDI',
+          updatedBy: 'asmith_gen',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-06-19T09:39:44Z',
+          updatedAtPrison: 'MDI',
+        },
+      ],
+    })
+
+    const expected = aValidConditionsList({
+      conditions: [
+        {
+          active: true,
+          conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
+          conditionName: 'Phonological dyslexia',
+          conditionTypeCode: ConditionType.DYSLEXIA,
+          createdAt: parseISO('2023-06-19T09:39:44Z'),
+          createdAtPrison: 'MDI',
+          createdBy: 'asmith_gen',
+          createdByDisplayName: 'Alex Smith',
+          reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+          source: ConditionSource.SELF_DECLARED,
+          updatedAt: parseISO('2023-06-19T09:39:44Z'),
+          updatedAtPrison: 'MDI',
+          updatedBy: 'asmith_gen',
+          updatedByDisplayName: 'Alex Smith',
+        },
+      ],
+    })
+
+    // When
+    const actual = toConditionsList(apiResponse, prisonNumber)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/conditionDtoMapper.ts
+++ b/server/data/mappers/conditionDtoMapper.ts
@@ -1,0 +1,19 @@
+import type { ConditionDto, ConditionsList } from 'dto'
+import type { ConditionListResponse, ConditionResponse } from 'supportAdditionalNeedsApiClient'
+import toReferenceAndAuditable from './referencedAndAuditableMapper'
+
+const toConditionsList = (conditionListResponse: ConditionListResponse, prisonNumber: string): ConditionsList => ({
+  prisonNumber,
+  conditions: conditionListResponse.conditions.map(toConditionDto),
+})
+
+const toConditionDto = (conditionResponse: ConditionResponse): ConditionDto => ({
+  ...toReferenceAndAuditable(conditionResponse),
+  conditionTypeCode: conditionResponse.conditionType.code,
+  conditionName: conditionResponse.conditionName,
+  conditionDetails: conditionResponse.conditionDetails,
+  source: conditionResponse.source,
+  active: conditionResponse.active,
+})
+
+export { toConditionsList, toConditionDto }

--- a/server/data/mappers/referencedAndAuditableMapper.ts
+++ b/server/data/mappers/referencedAndAuditableMapper.ts
@@ -1,0 +1,26 @@
+import { parseISO } from 'date-fns'
+import type { ReferencedAndAuditable } from 'dto'
+
+const toReferenceAndAuditable = (apiResponse: {
+  reference: string
+  createdBy: string
+  createdByDisplayName: string
+  createdAt: string
+  createdAtPrison: string
+  updatedBy: string
+  updatedByDisplayName: string
+  updatedAt: string
+  updatedAtPrison: string
+}): ReferencedAndAuditable => ({
+  reference: apiResponse.reference,
+  createdBy: apiResponse.createdBy,
+  createdByDisplayName: apiResponse.createdByDisplayName,
+  createdAt: apiResponse.createdAt ? parseISO(apiResponse.createdAt) : null,
+  createdAtPrison: apiResponse.createdAtPrison,
+  updatedBy: apiResponse.updatedBy,
+  updatedByDisplayName: apiResponse.updatedByDisplayName,
+  updatedAt: apiResponse.updatedAt ? parseISO(apiResponse.updatedAt) : null,
+  updatedAtPrison: apiResponse.updatedAtPrison,
+})
+
+export default toReferenceAndAuditable

--- a/server/data/supportAdditionalNeedsApiClient.ts
+++ b/server/data/supportAdditionalNeedsApiClient.ts
@@ -149,6 +149,16 @@ export default class SupportAdditionalNeedsApiClient extends RestClient {
     )
   }
 
+  async getConditions(prisonNumber: string, username: string): Promise<ConditionListResponse> {
+    return this.get<ConditionListResponse>(
+      {
+        path: `/profile/${prisonNumber}/conditions`,
+        errorHandler: restClientErrorHandler({ ignore404: true }),
+      },
+      asSystem(username),
+    )
+  }
+
   async createStrengths(
     prisonNumber: string,
     username: string,

--- a/server/services/conditionService.test.ts
+++ b/server/services/conditionService.test.ts
@@ -1,7 +1,11 @@
+import { parseISO } from 'date-fns'
 import SupportAdditionalNeedsApiClient from '../data/supportAdditionalNeedsApiClient'
 import ConditionService from './conditionService'
 import { aValidConditionsList } from '../testsupport/conditionDtoTestDataBuilder'
 import { aValidCreateConditionsRequest } from '../testsupport/conditionRequestTestDataBuilder'
+import { aValidConditionListResponse } from '../testsupport/conditionResponseTestDataBuilder'
+import ConditionType from '../enums/conditionType'
+import ConditionSource from '../enums/conditionSource'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
 
@@ -56,5 +60,67 @@ describe('conditionService', () => {
         expectedCreateConditionsRequest,
       )
     })
+  })
+
+  describe('getConditions', () => {
+    it('should get conditions', async () => {
+      // Given
+      const conditionListResponse = aValidConditionListResponse()
+      supportAdditionalNeedsApiClient.getConditions.mockResolvedValue(conditionListResponse)
+
+      const expectedConditionsList = aValidConditionsList({
+        conditions: [
+          {
+            active: true,
+            conditionDetails:
+              'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
+            conditionName: 'Phonological dyslexia',
+            conditionTypeCode: ConditionType.DYSLEXIA,
+            createdAt: parseISO('2023-06-19T09:39:44Z'),
+            createdAtPrison: 'MDI',
+            createdBy: 'asmith_gen',
+            createdByDisplayName: 'Alex Smith',
+            reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+            source: ConditionSource.SELF_DECLARED,
+            updatedAt: parseISO('2023-06-19T09:39:44Z'),
+            updatedAtPrison: 'MDI',
+            updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
+          },
+        ],
+      })
+
+      // When
+      const actual = await service.getConditions(username, prisonNumber)
+
+      // Then
+      expect(actual).toEqual(expectedConditionsList)
+      expect(supportAdditionalNeedsApiClient.getConditions).toHaveBeenCalledWith(prisonNumber, username)
+    })
+  })
+
+  it('should return null given API returns null', async () => {
+    // Given
+    supportAdditionalNeedsApiClient.getConditions.mockResolvedValue(null)
+
+    // When
+    const actual = await service.getConditions(username, prisonNumber)
+
+    // Then
+    expect(actual).toBeNull()
+    expect(supportAdditionalNeedsApiClient.getConditions).toHaveBeenCalledWith(prisonNumber, username)
+  })
+
+  it('should rethrow error given API client throws error', async () => {
+    // Given
+    const expectedError = new Error('Internal Server Error')
+    supportAdditionalNeedsApiClient.getConditions.mockRejectedValue(expectedError)
+
+    // When
+    const actual = await service.getConditions(username, prisonNumber).catch(e => e)
+
+    // Then
+    expect(actual).toEqual(expectedError)
+    expect(supportAdditionalNeedsApiClient.getConditions).toHaveBeenCalledWith(prisonNumber, username)
   })
 })

--- a/server/services/conditionService.ts
+++ b/server/services/conditionService.ts
@@ -2,6 +2,7 @@ import type { ConditionsList } from 'dto'
 import { SupportAdditionalNeedsApiClient } from '../data'
 import { toCreateConditionsRequest } from '../data/mappers/createConditionsRequestMapper'
 import logger from '../../logger'
+import { toConditionsList } from '../data/mappers/conditionDtoMapper'
 
 export default class ConditionService {
   constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
@@ -13,6 +14,16 @@ export default class ConditionService {
       await this.supportAdditionalNeedsApiClient.createConditions(prisonNumber, username, createConditionsRequest)
     } catch (e) {
       logger.error(`Error creating Conditions for [${prisonNumber}]`, e)
+      throw e
+    }
+  }
+
+  async getConditions(username: string, prisonNumber: string): Promise<ConditionsList> {
+    try {
+      const conditionListResponse = await this.supportAdditionalNeedsApiClient.getConditions(prisonNumber, username)
+      return conditionListResponse ? toConditionsList(conditionListResponse, prisonNumber) : null
+    } catch (e) {
+      logger.error(`Error getting Conditions for [${prisonNumber}]`, e)
       throw e
     }
   }

--- a/server/testsupport/auditFieldsTestDataBuilder.ts
+++ b/server/testsupport/auditFieldsTestDataBuilder.ts
@@ -1,15 +1,5 @@
 export type AuditFields = {
-  createdBy: string
-  createdByDisplayName: string
-  createdAt: string
-  createdAtPrison: string
-  updatedBy: string
-  updatedByDisplayName: string
-  updatedAt: string
-  updatedAtPrison: string
-}
-
-const validAuditFields = (options?: {
+  reference?: string
   createdBy?: string
   createdByDisplayName?: string
   createdAt?: string
@@ -18,7 +8,22 @@ const validAuditFields = (options?: {
   updatedByDisplayName?: string
   updatedAt?: string
   updatedAtPrison?: string
-}): AuditFields => ({
+}
+
+const validAuditFields = (
+  options?: AuditFields,
+): {
+  reference: string
+  createdBy: string
+  createdByDisplayName: string
+  createdAt: string
+  createdAtPrison: string
+  updatedBy: string
+  updatedByDisplayName: string
+  updatedAt: string
+  updatedAtPrison: string
+} => ({
+  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
   createdBy: options?.createdBy || 'asmith_gen',
   createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
   createdAt: options?.createdAt || '2023-06-19T09:39:44Z',

--- a/server/testsupport/challengeResponseTestDataBuilder.ts
+++ b/server/testsupport/challengeResponseTestDataBuilder.ts
@@ -1,6 +1,6 @@
 import { format, startOfToday, subMonths } from 'date-fns'
 import type { ChallengeListResponse, ChallengeResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields from './auditFieldsTestDataBuilder'
+import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
 
 const aValidChallengeListResponse = (options?: {
   challengeResponses?: Array<ChallengeResponse>
@@ -8,24 +8,16 @@ const aValidChallengeListResponse = (options?: {
   challenges: options?.challengeResponses || [aValidChallengeResponse()],
 })
 
-const aValidChallengeResponse = (options?: {
-  reference?: string
-  active?: boolean
-  fromALNScreener?: boolean
-  screeningDate?: Date
-  challengeTypeCode?: string
-  symptoms?: string
-  howIdentified?: string
-  createdBy?: string
-  createdByDisplayName?: string
-  createdAt?: string
-  createdAtPrison?: string
-  updatedBy?: string
-  updatedByDisplayName?: string
-  updatedAt?: string
-  updatedAtPrison?: string
-}): ChallengeResponse => ({
-  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+const aValidChallengeResponse = (
+  options?: AuditFields & {
+    active?: boolean
+    fromALNScreener?: boolean
+    screeningDate?: Date
+    challengeTypeCode?: string
+    symptoms?: string
+    howIdentified?: string
+  },
+): ChallengeResponse => ({
   active: options?.active == null ? true : options?.active,
   fromALNScreener: options?.fromALNScreener == null ? true : options?.fromALNScreener,
   screeningDate:

--- a/server/testsupport/conditionResponseTestDataBuilder.ts
+++ b/server/testsupport/conditionResponseTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { ConditionListResponse, ConditionResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields from './auditFieldsTestDataBuilder'
+import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
 import ConditionSource from '../enums/conditionSource'
 
 const aValidConditionListResponse = (options?: {
@@ -8,23 +8,15 @@ const aValidConditionListResponse = (options?: {
   conditions: options?.conditionResponses || [aValidConditionResponse()],
 })
 
-const aValidConditionResponse = (options?: {
-  reference?: string
-  active?: boolean
-  conditionTypeCode?: string
-  source?: ConditionSource
-  conditionDetails?: string
-  conditionName?: string
-  createdBy?: string
-  createdByDisplayName?: string
-  createdAt?: string
-  createdAtPrison?: string
-  updatedBy?: string
-  updatedByDisplayName?: string
-  updatedAt?: string
-  updatedAtPrison?: string
-}): ConditionResponse => ({
-  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+const aValidConditionResponse = (
+  options?: AuditFields & {
+    active?: boolean
+    conditionTypeCode?: string
+    source?: ConditionSource
+    conditionDetails?: string
+    conditionName?: string
+  },
+): ConditionResponse => ({
   active: options?.active == null ? true : options?.active,
   source: options?.source || ConditionSource.SELF_DECLARED,
   conditionDetails:

--- a/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
@@ -1,27 +1,21 @@
 import type { EducationSupportPlanResponse, PlanContributor } from 'supportAdditionalNeedsApiClient'
-import validAuditFields from './auditFieldsTestDataBuilder'
+import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
 import aValidPlanContributor from './planContributorTestDataBuilder'
 
-const aValidEducationSupportPlanResponse = (options?: {
-  hasCurrentEhcp?: boolean
-  createdBy?: string
-  createdByDisplayName?: string
-  createdAt?: string
-  createdAtPrison?: string
-  updatedBy?: string
-  updatedByDisplayName?: string
-  updatedAt?: string
-  updatedAtPrison?: string
-  planCreatedBy?: PlanContributor
-  otherContributors?: Array<PlanContributor>
-  learningEnvironmentAdjustments?: string
-  teachingAdjustments?: string
-  specificTeachingSkills?: string
-  examAccessArrangements?: string
-  lnspSupport?: string
-  individualSupport?: string
-  detail?: string
-}): EducationSupportPlanResponse => ({
+const aValidEducationSupportPlanResponse = (
+  options?: AuditFields & {
+    hasCurrentEhcp?: boolean
+    planCreatedBy?: PlanContributor
+    otherContributors?: Array<PlanContributor>
+    learningEnvironmentAdjustments?: string
+    teachingAdjustments?: string
+    specificTeachingSkills?: string
+    examAccessArrangements?: string
+    lnspSupport?: string
+    individualSupport?: string
+    detail?: string
+  },
+): EducationSupportPlanResponse => ({
   hasCurrentEhcp: options?.hasCurrentEhcp ?? false,
   planCreatedBy: options?.planCreatedBy === null ? null : options?.planCreatedBy || aValidPlanContributor(),
   otherContributors:

--- a/server/testsupport/planCreationScheduleResponseTestDataBuilder.ts
+++ b/server/testsupport/planCreationScheduleResponseTestDataBuilder.ts
@@ -1,7 +1,7 @@
 import { addMonths, format, startOfToday } from 'date-fns'
 import type { PlanCreationScheduleResponse, PlanCreationSchedulesResponse } from 'supportAdditionalNeedsApiClient'
 import PlanCreationScheduleStatus from '../enums/planCreationScheduleStatus'
-import validAuditFields from './auditFieldsTestDataBuilder'
+import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
 
 const aValidPlanCreationSchedulesResponse = (options?: {
   planCreationSchedules?: Array<PlanCreationScheduleResponse>
@@ -9,23 +9,15 @@ const aValidPlanCreationSchedulesResponse = (options?: {
   planCreationSchedules: options?.planCreationSchedules || [aValidPlanCreationScheduleResponse()],
 })
 
-const aValidPlanCreationScheduleResponse = (options?: {
-  reference?: string
-  deadlineDate?: Date
-  status?: PlanCreationScheduleStatus
-  exemptionReason?: string
-  exemptionDetail?: string
-  version?: number
-  createdBy?: string
-  createdByDisplayName?: string
-  createdAt?: string
-  createdAtPrison?: string
-  updatedBy?: string
-  updatedByDisplayName?: string
-  updatedAt?: string
-  updatedAtPrison?: string
-}): PlanCreationScheduleResponse => ({
-  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+const aValidPlanCreationScheduleResponse = (
+  options?: AuditFields & {
+    deadlineDate?: Date
+    status?: PlanCreationScheduleStatus
+    exemptionReason?: string
+    exemptionDetail?: string
+    version?: number
+  },
+): PlanCreationScheduleResponse => ({
   deadlineDate:
     options?.deadlineDate === null ? null : format(options?.deadlineDate || addMonths(startOfToday(), 2), 'yyyy-MM-dd'),
   status: options?.status || PlanCreationScheduleStatus.SCHEDULED,

--- a/server/testsupport/strengthResponseTestDataBuilder.ts
+++ b/server/testsupport/strengthResponseTestDataBuilder.ts
@@ -1,29 +1,21 @@
 import type { StrengthListResponse, StrengthResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields from './auditFieldsTestDataBuilder'
+import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
 import StrengthIdentificationSource from '../enums/strengthIdentificationSource'
 
 const aValidStrengthListResponse = (options?: { strengths?: Array<StrengthResponse> }): StrengthListResponse => ({
   strengths: options?.strengths || [aValidStrengthResponse()],
 })
 
-const aValidStrengthResponse = (options?: {
-  reference?: string
-  active?: boolean
-  fromALNScreener?: boolean
-  strengthTypeCode?: string
-  symptoms?: string
-  howIdentified?: Array<StrengthIdentificationSource>
-  howIdentifiedOther?: string
-  createdBy?: string
-  createdByDisplayName?: string
-  createdAt?: string
-  createdAtPrison?: string
-  updatedBy?: string
-  updatedByDisplayName?: string
-  updatedAt?: string
-  updatedAtPrison?: string
-}): StrengthResponse => ({
-  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+const aValidStrengthResponse = (
+  options?: AuditFields & {
+    active?: boolean
+    fromALNScreener?: boolean
+    strengthTypeCode?: string
+    symptoms?: string
+    howIdentified?: Array<StrengthIdentificationSource>
+    howIdentifiedOther?: string
+  },
+): StrengthResponse => ({
   active: options?.active == null ? true : options?.active,
   fromALNScreener: options?.fromALNScreener == null ? true : options?.fromALNScreener,
   symptoms:


### PR DESCRIPTION
PR to add the API client and service methods to be able to retrieve a prisoners conditions from the API

Also includes some refactoring of the challenge mapper, and some test data builders, to reduce duplication re: common audit & reference number fields