### PR TITLE
RR-1711 - Call middleware to retrieve prisoner conditions; initial skeleton view

### DIFF
--- a/integration_tests/e2e/conditions/create/createConditions.cy.ts
+++ b/integration_tests/e2e/conditions/create/createConditions.cy.ts
@@ -17,6 +17,7 @@ describe('Create Conditions', () => {
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubCreateConditions', prisonNumber)
+    cy.task('stubGetConditions', { prisonNumber })
   })
 
   it('should be able to navigate directly to the create Conditions page', () => {

--- a/integration_tests/e2e/profile/overview.cy.ts
+++ b/integration_tests/e2e/profile/overview.cy.ts
@@ -100,6 +100,7 @@ context('Profile Overview Page', () => {
     const prisonNumber = 'H4115SD'
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetConditions', { prisonNumber })
 
     cy.visit(`/profile/${prisonNumber}/overview`)
 

--- a/integration_tests/mockApis/supportAdditionalNeedsApi/conditionsEndpoints.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi/conditionsEndpoints.ts
@@ -1,4 +1,5 @@
 import { SuperAgentRequest } from 'superagent'
+import type { ConditionResponse } from 'supportAdditionalNeedsApiClient'
 import { stubFor } from '../wiremock'
 
 const stubCreateConditions = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
@@ -61,4 +62,66 @@ const stubCreateConditions500Error = (prisonNumber = 'G6115VJ'): SuperAgentReque
     },
   })
 
-export default { stubCreateConditions, stubCreateConditions500Error }
+const stubGetConditions = (
+  options: { prisonNumber: string; conditions?: Array<ConditionResponse> } = { prisonNumber: 'G6115VJ' },
+): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/support-additional-needs-api/profile/${options.prisonNumber}/conditions`,
+    },
+    response: {
+      status: 201,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        conditions: options.conditions ?? [
+          {
+            createdBy: 'asmith_gen',
+            createdByDisplayName: 'Alex Smith',
+            createdAt: '2023-06-19T09:39:44Z',
+            createdAtPrison: 'BXI',
+            updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
+            updatedAt: '2023-06-19T09:39:44Z',
+            updatedAtPrison: 'BXI',
+            reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+            source: 'SELF_DECLARED',
+            conditionType: {
+              code: 'string',
+              description: 'string',
+              categoryCode: 'string',
+              categoryDescription: 'string',
+              areaCode: 'string',
+              areaDescription: 'string',
+              listSequence: 3,
+              active: true,
+            },
+            conditionName: '(for Mental Health) Social Anxiety',
+            conditionDetails: 'string',
+            active: true,
+          },
+        ],
+      },
+    },
+  })
+
+const stubGetConditions500Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/support-additional-needs-api/profile/${prisonNumber}/conditions`,
+    },
+    response: {
+      status: 500,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 500,
+        errorCode: null,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+        moreInfo: null,
+      },
+    },
+  })
+
+export default { stubCreateConditions, stubCreateConditions500Error, stubGetConditions, stubGetConditions500Error }

--- a/server/filters/filterArrayOnPropertyFilter.test.ts
+++ b/server/filters/filterArrayOnPropertyFilter.test.ts
@@ -1,0 +1,23 @@
+import filterArrayOnPropertyFilter from './filterArrayOnPropertyFilter'
+
+describe('filterArrayOnPropertyFilter', () => {
+  it('should filter an array on a specified property and value', () => {
+    // Given
+    const arrayOfThings = [
+      { name: 'thing1', value: 'value1', active: true },
+      { name: 'thing2', value: 'value2', active: false },
+      { name: 'thing3', value: 'value3', active: true },
+    ]
+
+    const expected = [
+      { name: 'thing1', value: 'value1', active: true },
+      { name: 'thing3', value: 'value3', active: true },
+    ]
+
+    // When
+    const actual = filterArrayOnPropertyFilter(arrayOfThings, 'active', true)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/filters/filterArrayOnPropertyFilter.ts
+++ b/server/filters/filterArrayOnPropertyFilter.ts
@@ -1,0 +1,6 @@
+/**
+ * Simple nunjucks filter to filter an array on the specified property and value
+ */
+export default function filterArrayOnPropertyFilter(array: unknown[], property: string, value: unknown) {
+  return (array as never[]).filter(item => item[property] === value)
+}

--- a/server/routes/profile/conditions/conditionsController.test.ts
+++ b/server/routes/profile/conditions/conditionsController.test.ts
@@ -1,16 +1,19 @@
 import { Request, Response } from 'express'
 import ConditionsController from './conditionsController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataBuilder'
+import { Result } from '../../../utils/result/result'
 
 describe('conditionsController', () => {
   const controller = new ConditionsController()
 
   const prisonerSummary = aValidPrisonerSummary()
+  const conditions = Result.fulfilled(aValidConditionsList())
 
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary },
+    locals: { prisonerSummary, conditions },
   } as unknown as Response
   const next = jest.fn()
 
@@ -23,6 +26,7 @@ describe('conditionsController', () => {
     const expectedViewTemplate = 'pages/profile/conditions/index'
     const expectedViewModel = {
       prisonerSummary,
+      conditions,
       tab: 'conditions',
     }
 

--- a/server/routes/profile/conditions/conditionsController.ts
+++ b/server/routes/profile/conditions/conditionsController.ts
@@ -2,8 +2,8 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default class ConditionsController {
   getConditionsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary } = res.locals
-    const viewRenderArgs = { prisonerSummary, tab: 'conditions' }
+    const { prisonerSummary, conditions } = res.locals
+    const viewRenderArgs = { prisonerSummary, conditions, tab: 'conditions' }
     return res.render('pages/profile/conditions/index', viewRenderArgs)
   }
 }

--- a/server/routes/profile/conditions/index.ts
+++ b/server/routes/profile/conditions/index.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ConditionsController from './conditionsController'
+import { Services } from '../../../services'
+import retrieveConditions from '../middleware/retrieveConditions'
 
-const conditionsRoutes = (): Router => {
+const conditionsRoutes = (services: Services): Router => {
+  const { conditionService } = services
   const controller = new ConditionsController()
 
   return Router({ mergeParams: true }) //
-    .get('/', [asyncMiddleware(controller.getConditionsView)])
+    .get('/', [retrieveConditions(conditionService), asyncMiddleware(controller.getConditionsView)])
 }
 
 export default conditionsRoutes

--- a/server/routes/profile/index.ts
+++ b/server/routes/profile/index.ts
@@ -13,7 +13,7 @@ const profileRoutes = (services: Services): Router => {
     .use('/support-strategies', supportStrategiesRoutes())
     .use('/challenges', challengesRoutes(services))
     .use('/strengths', strengthsRoutes())
-    .use('/conditions', conditionsRoutes())
+    .use('/conditions', conditionsRoutes(services))
     .use('/education-support-plan', educationSupportPlanRoutes())
 }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -24,6 +24,7 @@ import {
   formatStrengthTypeHintTextFilter,
 } from '../filters/formatStrengthTypeFilter'
 import formatConditionTypeScreenValueFilter from '../filters/formatConditionTypeFilter'
+import filterArrayOnPropertyFilter from '../filters/filterArrayOnPropertyFilter'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -72,6 +73,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('formatChallengeTypeScreenValue', formatChallengeTypeScreenValueFilter)
   njkEnv.addFilter('formatChallengeTypeHintText', formatChallengeTypeHintTextFilter)
   njkEnv.addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
+  njkEnv.addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
 
   // Name format filters
   njkEnv.addFilter('formatFIRST_NAME_ONLY', formatPrisonerNameFilter(NameFormat.FIRST_NAME_ONLY))

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -8,6 +8,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       <h2 class="govuk-heading-m">Conditions</h2>
+
+
+      {% if conditions.isFulfilled() %}
+        {% set activeConditions = conditions.value.conditions | filterArrayOnProperty('active', true) %}
+
+        {% if activeConditions | length %}
+          {# TODO - loop through activeConditions rendering each one #}
+
+        {% else %}
+          {# TODO - 'empty state', where the person has no Conditions recorded #}
+        {% endif %}
+
+      {% else %}
+        <h2 class="govuk-heading-m" data-qa="conditions-unavailable-message">We cannot show these details right now</h2>
+        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+      {% endif %}
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">


### PR DESCRIPTION
PR that:

* Wires the middleware to retrieve Conditions into the GET Conditions route & controller
* Adds wiremock stubs to the cypress tests (so that the existing cypress tests that use the Conditions page dont fail)
* Adds a nunjucks filter to be able to filter arrays within the template (our UI calls for only showing active Conditions)
* Adds the basic skeleton to the Conditions nunjucks template