### PR TITLE
RR-1711 - Render conditions in view - empty state and error state

### DIFF
--- a/integration_tests/e2e/profile/conditions.cy.ts
+++ b/integration_tests/e2e/profile/conditions.cy.ts
@@ -1,0 +1,42 @@
+/**
+ * Cypress scenarios for the Profile Overview page.
+ */
+
+import Page from '../../pages/page'
+import ConditionsPage from '../../pages/profile/conditionsPage'
+
+context('Profile Conditions Page', () => {
+  const prisonNumber = 'A00001A'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+  })
+
+  it('should render the conditions page given the prisoner has no Conditions', () => {
+    // Given
+    cy.task('stubGetConditions', { prisonNumber, conditions: [] })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/conditions`)
+
+    // Then
+    Page.verifyOnPage(ConditionsPage) //
+      .hasNoActiveConditions()
+      .apiErrorBannerIsNotDisplayed()
+  })
+
+  it('should render the conditions page given the API to get Conditions returns an error', () => {
+    // Given
+    cy.task('stubGetConditions500Error', prisonNumber)
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/conditions`)
+
+    // Then
+    Page.verifyOnPage(ConditionsPage) //
+      .apiErrorBannerIsDisplayed()
+  })
+})

--- a/integration_tests/pages/profile/conditionsPage.ts
+++ b/integration_tests/pages/profile/conditionsPage.ts
@@ -8,6 +8,11 @@ export default class ConditionsPage extends ProfilePage {
     this.activeTabIs('Conditions')
   }
 
+  hasNoActiveConditions(): ConditionsPage {
+    this.noConditionsSummaryCard().should('be.visible')
+    return this
+  }
+
   clickRecordConditionsButton(): SelectConditionsPage {
     this.recordConditionsButton().click()
     return Page.verifyOnPage(SelectConditionsPage)
@@ -17,4 +22,6 @@ export default class ConditionsPage extends ProfilePage {
 
   private recordConditionsButton = (): PageElement =>
     this.conditionsActionItems().find('[data-qa=record-conditions-button]')
+
+  private noConditionsSummaryCard = (): PageElement => cy.get('[data-qa=no-conditions-summary-card]')
 }

--- a/server/testsupport/conditionDtoTestDataBuilder.ts
+++ b/server/testsupport/conditionDtoTestDataBuilder.ts
@@ -16,6 +16,7 @@ const aValidConditionDto = (options?: {
   conditionName?: string
   conditionDetails?: string
   source?: ConditionSource
+  active?: boolean
 }): ConditionDto => ({
   prisonId: options?.prisonId || 'BXI',
   conditionTypeCode: options?.conditionTypeCode || ConditionType.DYSLEXIA,
@@ -26,6 +27,7 @@ const aValidConditionDto = (options?: {
       : options?.conditionDetails ||
         'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
   conditionName: options?.conditionName === null ? null : options?.conditionName || 'Phonological dyslexia',
+  active: options?.active == null ? true : options?.active,
 })
 
 export { aValidConditionDto, aValidConditionsList }

--- a/server/views/pages/profile/conditions/_noConditionsSummaryCard.njk
+++ b/server/views/pages/profile/conditions/_noConditionsSummaryCard.njk
@@ -1,0 +1,10 @@
+<div class="govuk-summary-card" data-qa="no-conditions-summary-card">
+  <div class="govuk-summary-card__content">
+    <p class="govuk-body">
+      No conditions recorded
+    </p>
+    {% if userHasPermissionTo('RECORD_SELF_DECLARED_CONDITIONS') %}
+      <a class="govuk-link govuk-body" href="/conditions/{{ prisonerSummary.prisonNumber }}/create/select-conditions">Record condition</a>
+    {% endif %}
+  </div>
+</div>

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -17,11 +17,11 @@
           {# TODO - loop through activeConditions rendering each one #}
 
         {% else %}
-          {# TODO - 'empty state', where the person has no Conditions recorded #}
+          {% include './_noConditionsSummaryCard.njk' %}
         {% endif %}
 
       {% else %}
-        <h2 class="govuk-heading-m" data-qa="conditions-unavailable-message">We cannot show these details right now</h2>
+        <h3 class="govuk-heading-s" data-qa="conditions-unavailable-message">We cannot show these details right now</h3>
         <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
       {% endif %}
     </div>

--- a/server/views/pages/profile/conditions/index.test.ts
+++ b/server/views/pages/profile/conditions/index.test.ts
@@ -1,0 +1,128 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import formatDate from '../../../../filters/formatDateFilter'
+import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../../utils/result/result'
+import { aValidConditionDto, aValidConditionsList } from '../../../../testsupport/conditionDtoTestDataBuilder'
+import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnPropertyFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('assetMap', () => '')
+  .addFilter('formatDate', formatDate)
+  .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
+  .addFilter('formatLast_name_comma_First_name', formatPrisonerNameFilter(NameFormat.Last_name_comma_First_name))
+  .addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
+
+const prisonerSummary = aValidPrisonerSummary({
+  firstName: 'IFEREECA',
+  lastName: 'PEIGH',
+})
+const template = 'index.njk'
+
+const userHasPermissionTo = jest.fn()
+const templateParams = {
+  prisonerSummary,
+  userHasPermissionTo,
+  tab: 'conditions',
+  conditions: Result.fulfilled(aValidConditionsList()),
+  pageHasApiErrors: false,
+}
+
+describe('Profile conditions page', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the profile conditions page given prisoner has no active Conditions', () => {
+    // Given
+    const conditionList = aValidConditionsList({
+      conditions: [
+        aValidConditionDto({ conditionName: 'Condition 1', active: false }),
+        aValidConditionDto({ conditionName: 'Condition 2', active: false }),
+        aValidConditionDto({ conditionName: 'Condition 3', active: false }),
+      ],
+    })
+    const params = {
+      ...templateParams,
+      conditions: Result.fulfilled(conditionList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-conditions-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-conditions-summary-card] a').length).toEqual(1)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the profile conditions page given prisoner has no Conditions at all', () => {
+    // Given
+    const conditionList = aValidConditionsList({ conditions: [] })
+    const params = {
+      ...templateParams,
+      conditions: Result.fulfilled(conditionList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-conditions-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-conditions-summary-card] a').length).toEqual(1)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the profile conditions page given prisoner has no Conditions and the user does not have permission to create Conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+    const conditionList = aValidConditionsList({ conditions: [] })
+    const params = {
+      ...templateParams,
+      conditions: Result.fulfilled(conditionList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-conditions-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-conditions-summary-card] a').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the profile conditions page given the Conditions service API promise is not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      conditions: Result.rejected(new Error('Failed to get conditions')),
+      pageHasApiErrors: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-conditions-summary-card]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(1)
+  })
+})


### PR DESCRIPTION
PR for the rendering of Conditions - empty state (ie. prisoner has no active Conditions) and error state (ie. the API returned an error whilst retrieving the Conditions)

<img width="997" height="799" alt="Screenshot 2025-08-04 at 11 59 19" src="https://github.com/user-attachments/assets/61441117-3ce4-4d4a-adbf-4c16905a9d62" />

<img width="1002" height="805" alt="Screenshot 2025-08-04 at 11 57 57" src="https://github.com/user-attachments/assets/9e6d670c-494c-43e4-ba2b-b3c071bdcbd4" />

