### PR TITLE
RR-1711 - Render conditions in view - diagnosed + self declared conditions

### DIFF
--- a/integration_tests/e2e/profile/conditions.cy.ts
+++ b/integration_tests/e2e/profile/conditions.cy.ts
@@ -4,6 +4,9 @@
 
 import Page from '../../pages/page'
 import ConditionsPage from '../../pages/profile/conditionsPage'
+import ConditionType from '../../../server/enums/conditionType'
+import ConditionSource from '../../../server/enums/conditionSource'
+import { aValidConditionResponse } from '../../../server/testsupport/conditionResponseTestDataBuilder'
 
 context('Profile Conditions Page', () => {
   const prisonNumber = 'A00001A'
@@ -13,6 +16,42 @@ context('Profile Conditions Page', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
+  })
+
+  it('should render the conditions page given the prisoner has Conditions', () => {
+    // Given
+    cy.task('stubGetConditions', {
+      prisonNumber,
+      conditions: [
+        aValidConditionResponse({
+          conditionTypeCode: ConditionType.ADHD,
+          conditionName: null,
+          conditionDetails: 'ADHD diagnosed at childhood',
+          source: ConditionSource.CONFIRMED_DIAGNOSIS,
+        }),
+        aValidConditionResponse({
+          conditionTypeCode: ConditionType.DYSLEXIA,
+          conditionName: null,
+          conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
+          source: ConditionSource.SELF_DECLARED,
+        }),
+        aValidConditionResponse({
+          conditionTypeCode: ConditionType.VISUAL_IMPAIR,
+          conditionName: 'Colour blindness',
+          conditionDetails: 'Red-green colour blindness. Formally diagnosed by an optometrist.',
+          source: ConditionSource.CONFIRMED_DIAGNOSIS,
+        }),
+      ],
+    })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/conditions`)
+
+    // Then
+    Page.verifyOnPage(ConditionsPage) //
+      .hasDiagnosedConditions(ConditionType.ADHD, ConditionType.VISUAL_IMPAIR)
+      .hasSelfDeclaredConditions(ConditionType.DYSLEXIA)
+      .apiErrorBannerIsNotDisplayed()
   })
 
   it('should render the conditions page given the prisoner has no Conditions', () => {

--- a/integration_tests/pages/profile/conditionsPage.ts
+++ b/integration_tests/pages/profile/conditionsPage.ts
@@ -1,6 +1,7 @@
 import ProfilePage from './profilePage'
 import Page, { PageElement } from '../page'
 import SelectConditionsPage from '../conditions/selectConditionsPage'
+import ConditionType from '../../../server/enums/conditionType'
 
 export default class ConditionsPage extends ProfilePage {
   constructor() {
@@ -8,8 +9,32 @@ export default class ConditionsPage extends ProfilePage {
     this.activeTabIs('Conditions')
   }
 
+  hasDiagnosedConditions(...conditions: Array<ConditionType>): ConditionsPage {
+    this.diagnosedConditionsSummaryCard().should('be.visible')
+    this.diagnosedConditionsSummaryCard().find('.govuk-summary-list__row').should('have.length', conditions.length)
+    conditions.forEach(condition => {
+      this.diagnosedConditionsSummaryCard().find(`.govuk-summary-list__row[data-qa=${condition}]`).should('be.visible')
+    })
+    this.noConditionsSummaryCard().should('not.exist')
+    return this
+  }
+
+  hasSelfDeclaredConditions(...conditions: Array<ConditionType>): ConditionsPage {
+    this.selfDeclaredConditionsSummaryCard().should('be.visible')
+    this.selfDeclaredConditionsSummaryCard().find('.govuk-summary-list__row').should('have.length', conditions.length)
+    conditions.forEach(condition => {
+      this.selfDeclaredConditionsSummaryCard()
+        .find(`.govuk-summary-list__row[data-qa=${condition}]`)
+        .should('be.visible')
+    })
+    this.noConditionsSummaryCard().should('not.exist')
+    return this
+  }
+
   hasNoActiveConditions(): ConditionsPage {
     this.noConditionsSummaryCard().should('be.visible')
+    this.selfDeclaredConditionsSummaryCard().should('not.exist')
+    this.diagnosedConditionsSummaryCard().should('not.exist')
     return this
   }
 
@@ -22,6 +47,11 @@ export default class ConditionsPage extends ProfilePage {
 
   private recordConditionsButton = (): PageElement =>
     this.conditionsActionItems().find('[data-qa=record-conditions-button]')
+
+  private diagnosedConditionsSummaryCard = (): PageElement => cy.get('[data-qa=diagnosed-conditions-summary-card]')
+
+  private selfDeclaredConditionsSummaryCard = (): PageElement =>
+    cy.get('[data-qa=self-declared-conditions-summary-card]')
 
   private noConditionsSummaryCard = (): PageElement => cy.get('[data-qa=no-conditions-summary-card]')
 }

--- a/server/testsupport/auditFieldsTestDataBuilder.ts
+++ b/server/testsupport/auditFieldsTestDataBuilder.ts
@@ -1,3 +1,5 @@
+import { parseISO } from 'date-fns'
+
 export type AuditFields = {
   reference?: string
   createdBy?: string
@@ -34,4 +36,40 @@ const validAuditFields = (
   updatedAtPrison: options?.updatedAtPrison || 'MDI',
 })
 
-export default validAuditFields
+export type DtoAuditFields = {
+  reference?: string
+  createdBy?: string
+  createdByDisplayName?: string
+  createdAt?: Date
+  createdAtPrison?: string
+  updatedBy?: string
+  updatedByDisplayName?: string
+  updatedAt?: Date
+  updatedAtPrison?: string
+}
+
+const validDtoAuditFields = (
+  options?: DtoAuditFields,
+): {
+  reference: string
+  createdBy: string
+  createdByDisplayName: string
+  createdAt: Date
+  createdAtPrison: string
+  updatedBy: string
+  updatedByDisplayName: string
+  updatedAt: Date
+  updatedAtPrison: string
+} => ({
+  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+  createdBy: options?.createdBy || 'asmith_gen',
+  createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+  createdAt: options?.createdAt || parseISO('2023-06-19T09:39:44Z'),
+  createdAtPrison: options?.createdAtPrison || 'MDI',
+  updatedBy: options?.updatedBy || 'asmith_gen',
+  updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
+  updatedAt: options?.updatedAt || parseISO('2023-06-19T09:39:44Z'),
+  updatedAtPrison: options?.updatedAtPrison || 'MDI',
+})
+
+export { validAuditFields, validDtoAuditFields }

--- a/server/testsupport/challengeResponseTestDataBuilder.ts
+++ b/server/testsupport/challengeResponseTestDataBuilder.ts
@@ -1,6 +1,6 @@
 import { format, startOfToday, subMonths } from 'date-fns'
 import type { ChallengeListResponse, ChallengeResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
+import { validAuditFields, AuditFields } from './auditFieldsTestDataBuilder'
 
 const aValidChallengeListResponse = (options?: {
   challengeResponses?: Array<ChallengeResponse>

--- a/server/testsupport/conditionDtoTestDataBuilder.ts
+++ b/server/testsupport/conditionDtoTestDataBuilder.ts
@@ -1,6 +1,7 @@
 import type { ConditionDto, ConditionsList } from 'dto'
 import ConditionSource from '../enums/conditionSource'
 import ConditionType from '../enums/conditionType'
+import { DtoAuditFields, validDtoAuditFields } from './auditFieldsTestDataBuilder'
 
 const aValidConditionsList = (options?: {
   prisonNumber?: string
@@ -10,14 +11,16 @@ const aValidConditionsList = (options?: {
   conditions: options?.conditions || [aValidConditionDto()],
 })
 
-const aValidConditionDto = (options?: {
-  prisonId?: string
-  conditionTypeCode?: ConditionType
-  conditionName?: string
-  conditionDetails?: string
-  source?: ConditionSource
-  active?: boolean
-}): ConditionDto => ({
+const aValidConditionDto = (
+  options?: DtoAuditFields & {
+    prisonId?: string
+    conditionTypeCode?: ConditionType
+    conditionName?: string
+    conditionDetails?: string
+    source?: ConditionSource
+    active?: boolean
+  },
+): ConditionDto => ({
   prisonId: options?.prisonId || 'BXI',
   conditionTypeCode: options?.conditionTypeCode || ConditionType.DYSLEXIA,
   source: options?.source || ConditionSource.SELF_DECLARED,
@@ -28,6 +31,7 @@ const aValidConditionDto = (options?: {
         'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
   conditionName: options?.conditionName === null ? null : options?.conditionName || 'Phonological dyslexia',
   active: options?.active == null ? true : options?.active,
+  ...validDtoAuditFields(options),
 })
 
 export { aValidConditionDto, aValidConditionsList }

--- a/server/testsupport/conditionResponseTestDataBuilder.ts
+++ b/server/testsupport/conditionResponseTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { ConditionListResponse, ConditionResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
+import { validAuditFields, AuditFields } from './auditFieldsTestDataBuilder'
 import ConditionSource from '../enums/conditionSource'
 
 const aValidConditionListResponse = (options?: {

--- a/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanResponseTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { EducationSupportPlanResponse, PlanContributor } from 'supportAdditionalNeedsApiClient'
-import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
+import { validAuditFields, AuditFields } from './auditFieldsTestDataBuilder'
 import aValidPlanContributor from './planContributorTestDataBuilder'
 
 const aValidEducationSupportPlanResponse = (

--- a/server/testsupport/planCreationScheduleResponseTestDataBuilder.ts
+++ b/server/testsupport/planCreationScheduleResponseTestDataBuilder.ts
@@ -1,7 +1,7 @@
 import { addMonths, format, startOfToday } from 'date-fns'
 import type { PlanCreationScheduleResponse, PlanCreationSchedulesResponse } from 'supportAdditionalNeedsApiClient'
 import PlanCreationScheduleStatus from '../enums/planCreationScheduleStatus'
-import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
+import { validAuditFields, AuditFields } from './auditFieldsTestDataBuilder'
 
 const aValidPlanCreationSchedulesResponse = (options?: {
   planCreationSchedules?: Array<PlanCreationScheduleResponse>

--- a/server/testsupport/strengthResponseTestDataBuilder.ts
+++ b/server/testsupport/strengthResponseTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { StrengthListResponse, StrengthResponse } from 'supportAdditionalNeedsApiClient'
-import validAuditFields, { AuditFields } from './auditFieldsTestDataBuilder'
+import { validAuditFields, AuditFields } from './auditFieldsTestDataBuilder'
 import StrengthIdentificationSource from '../enums/strengthIdentificationSource'
 
 const aValidStrengthListResponse = (options?: { strengths?: Array<StrengthResponse> }): StrengthListResponse => ({

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.njk
@@ -1,0 +1,8 @@
+{% from "./macro.njk" import conditionsSummaryCard %}
+
+{{ conditionsSummaryCard({
+  conditions: conditions,
+  title: title,
+  classes: classes,
+  attributes: attributes
+}) }}

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.ts
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.ts
@@ -1,0 +1,89 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { parseISO } from 'date-fns'
+import type { ConditionDto } from 'dto'
+import { aValidConditionDto } from '../../../../../../testsupport/conditionDtoTestDataBuilder'
+import formatDateFilter from '../../../../../../filters/formatDateFilter'
+import formatConditionTypeScreenValueFilter from '../../../../../../filters/formatConditionTypeFilter'
+import ConditionType from '../../../../../../enums/conditionType'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('formatDate', formatDateFilter)
+  .addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
+
+const templateParams = {
+  title: 'Conditions',
+  id: 'conditions',
+  conditions: [aValidConditionDto()],
+}
+
+const template = 'conditionsSummaryCard.test.njk'
+
+describe('Tests for Conditions Summary Card component', () => {
+  it('should render the component', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      conditions: [
+        aValidConditionDto({
+          conditionTypeCode: ConditionType.ADHD,
+          conditionName: null,
+          conditionDetails: 'ADHD details',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'Leeds (HMP)',
+          updatedAt: parseISO('2025-02-10'),
+        }),
+        aValidConditionDto({
+          conditionTypeCode: ConditionType.DYSLEXIA,
+          conditionName: 'Phonological dyslexia',
+          conditionDetails: 'Dyslexia details',
+          updatedByDisplayName: 'Person 2',
+          updatedAtPrison: 'Brixton (HMP)',
+          updatedAt: parseISO('2025-06-03'),
+        }),
+      ],
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Conditions')
+    expect($('.govuk-summary-list__row').length).toEqual(2)
+
+    const firstCondition = $('.govuk-summary-list__row:nth-of-type(1)')
+    expect(firstCondition.find('h3').text().trim()).toEqual('Attention deficit hyperactivity disorder (ADHD or ADD)')
+    expect(firstCondition.find('[data-qa=condition-name]').length).toEqual(0)
+    expect(firstCondition.find('[data-qa=condition-details]').text().trim()).toEqual('ADHD details')
+    expect(firstCondition.find('[data-qa=condition-audit]').text().trim()).toEqual(
+      'Added on 10 February 2025 by Person 1, Leeds (HMP)',
+    )
+
+    const secondCondition = $('.govuk-summary-list__row:nth-of-type(2)')
+    expect(secondCondition.find('h3').text().trim()).toEqual('Dyslexia')
+    expect(secondCondition.find('[data-qa=condition-name]').text().trim()).toEqual('Phonological dyslexia')
+    expect(secondCondition.find('[data-qa=condition-details]').text().trim()).toEqual('Dyslexia details')
+    expect(secondCondition.find('[data-qa=condition-audit]').text().trim()).toEqual(
+      'Added on 3 June 2025 by Person 2, Brixton (HMP)',
+    )
+  })
+
+  it('should not render the component given no conditions', () => {
+    // Given
+    const params = { ...templateParams, conditions: [] as Array<ConditionDto> }
+
+    // When
+    const content = njkEnv.render(template, params)
+
+    // Then
+    expect(content.trim()).toEqual('')
+  })
+})

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/macro.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/macro.njk
@@ -1,0 +1,14 @@
+{# Conditions Summary Card macro
+
+Data supplied to this marco:
+  params: {
+    conditions: Array<ConditionDto> - Pre-filtered array of conditions to render
+    title: string - Summary Card title
+    id: string
+    classes: string
+    attributes: Map<string, string>
+  }
+#}
+{% macro conditionsSummaryCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/template.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/template.njk
@@ -1,0 +1,38 @@
+{% from "govuk/macros/attributes.njk" import govukAttributes %}
+
+{#- Set classes for this component #}
+{%- set classNames = "govuk-summary-card" -%}
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{#- Define component attributes #}
+{%- set componentAttributes %} class="{{ classNames }}" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
+
+{% if params.conditions | length %}
+  <div {{ componentAttributes | safe }}>
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">{{ params.title }}</h2>
+    </div>
+
+    <div class="govuk-summary-card__content govuk-!-padding-top-0">
+      <div class="govuk-summary-list">
+
+        {% for condition in params.conditions %}
+          <div class="govuk-summary-list__row" data-qa="{{ condition.conditionTypeCode }}">
+            <h3 class="govuk-heading-s govuk-!-margin-top-3 govuk-!-margin-bottom-2">{{ condition.conditionTypeCode | formatConditionTypeScreenValue | default(condition.conditionTypeCode, true) }}</h3>
+            {% if condition.conditionName %}
+              <p class="govuk-body govuk-!-margin-bottom-2" data-qa="condition-name">{{ condition.conditionName }}</p>
+            {% endif %}
+            <p class="govuk-body app-u-multiline-text govuk-!-margin-bottom-2" data-qa="condition-details">{{ condition.conditionDetails }}</p>
+
+            <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="condition-audit">
+              Added on {{ condition.updatedAt | formatDate('d MMMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ condition.updatedByDisplayName }}, {{ condition.updatedAtPrison }}</span>
+            </p>
+          </div>
+        {% endfor %}
+
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "./components/conditions-summary-card/macro.njk" import conditionsSummaryCard %}
 {% from "../../../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-conditions' %}
@@ -9,12 +10,26 @@
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       <h2 class="govuk-heading-m">Conditions</h2>
 
-
       {% if conditions.isFulfilled() %}
         {% set activeConditions = conditions.value.conditions | filterArrayOnProperty('active', true) %}
 
         {% if activeConditions | length %}
-          {# TODO - loop through activeConditions rendering each one #}
+
+          {{ conditionsSummaryCard({
+            conditions: activeConditions | filterArrayOnProperty('source', 'CONFIRMED_DIAGNOSIS'),
+            title: 'Confirmed diagnoses',
+            attributes: {
+              'data-qa': 'diagnosed-conditions-summary-card'
+            }
+          }) }}
+
+          {{ conditionsSummaryCard({
+            conditions: activeConditions | filterArrayOnProperty('source', 'SELF_DECLARED'),
+            title: 'Self-declared conditions',
+            attributes: {
+              'data-qa': 'self-declared-conditions-summary-card'
+            }
+          }) }}
 
         {% else %}
           {% include './_noConditionsSummaryCard.njk' %}

--- a/server/views/pages/profile/conditions/index.test.ts
+++ b/server/views/pages/profile/conditions/index.test.ts
@@ -6,6 +6,9 @@ import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDa
 import { Result } from '../../../../utils/result/result'
 import { aValidConditionDto, aValidConditionsList } from '../../../../testsupport/conditionDtoTestDataBuilder'
 import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnPropertyFilter'
+import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
+import ConditionType from '../../../../enums/conditionType'
+import ConditionSource from '../../../../enums/conditionSource'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -23,6 +26,7 @@ njkEnv //
   .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
   .addFilter('formatLast_name_comma_First_name', formatPrisonerNameFilter(NameFormat.Last_name_comma_First_name))
   .addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
+  .addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
 
 const prisonerSummary = aValidPrisonerSummary({
   firstName: 'IFEREECA',
@@ -43,6 +47,46 @@ describe('Profile conditions page', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the profile conditions page given prisoner has both diagnosed and self-declared conditions', () => {
+    // Given
+    const conditionList = aValidConditionsList({
+      conditions: [
+        aValidConditionDto({ conditionTypeCode: ConditionType.ADHD, source: ConditionSource.CONFIRMED_DIAGNOSIS }),
+        aValidConditionDto({ conditionTypeCode: ConditionType.DYSLEXIA, source: ConditionSource.SELF_DECLARED }),
+        aValidConditionDto({
+          conditionTypeCode: ConditionType.VISUAL_IMPAIR,
+          source: ConditionSource.CONFIRMED_DIAGNOSIS,
+        }),
+      ],
+    })
+    const params = {
+      ...templateParams,
+      conditions: Result.fulfilled(conditionList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=diagnosed-conditions-summary-card]').length).toEqual(1)
+    expect($('[data-qa=diagnosed-conditions-summary-card] .govuk-summary-list__row').length).toEqual(2) // Prisoner has 2 diagnosed conditions
+    expect($('[data-qa=diagnosed-conditions-summary-card] .govuk-summary-list__row').text()).toContain(
+      'Attention deficit hyperactivity disorder (ADHD or ADD)',
+    )
+    expect($('[data-qa=diagnosed-conditions-summary-card] .govuk-summary-list__row').text()).toContain(
+      'Visual impairment',
+    )
+
+    expect($('[data-qa=self-declared-conditions-summary-card]').length).toEqual(1)
+    expect($('[data-qa=self-declared-conditions-summary-card] .govuk-summary-list__row').length).toEqual(1) // Prisoner has 1 self-declared condition
+    expect($('[data-qa=self-declared-conditions-summary-card] .govuk-summary-list__row').text()).toContain('Dyslexia')
+
+    expect($('[data-qa=no-conditions-summary-card]').length).toEqual(0)
+    expect($('[data-qa=no-conditions-summary-card] a').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
   it('should render the profile conditions page given prisoner has no active Conditions', () => {


### PR DESCRIPTION
PR to render both Diagnosed and Self-declared conditions on the Conditions profile page.
(The only bit that is missing is the lookup from prison ID to prison name - that will come next)

<img width="701" height="838" alt="Screenshot 2025-08-04 at 15 24 47" src="https://github.com/user-attachments/assets/c37c8e96-2b59-40c8-b1c1-cc3b27b08ba3" />
