### PR TITLE
RR-1741 - Render conditions in view - empty state and error state

### DIFF
--- a/integration_tests/e2e/profile/conditions.cy.ts
+++ b/integration_tests/e2e/profile/conditions.cy.ts
@@ -1,5 +1,5 @@
 /**
- * Cypress scenarios for the Profile Overview page.
+ * Cypress scenarios for the Profile Conditions page.
  */
 
 import Page from '../../pages/page'

--- a/integration_tests/e2e/profile/strengths.cy.ts
+++ b/integration_tests/e2e/profile/strengths.cy.ts
@@ -1,0 +1,42 @@
+/**
+ * Cypress scenarios for the Profile Strengths page.
+ */
+
+import Page from '../../pages/page'
+import StrengthsPage from '../../pages/profile/strengthsPage'
+
+context('Profile Strengths Page', () => {
+  const prisonNumber = 'A00001A'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+  })
+
+  it('should render the strengths page given the prisoner has no Strengths', () => {
+    // Given
+    cy.task('stubGetStrengths', { prisonNumber, strengths: [] })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/strengths`)
+
+    // Then
+    Page.verifyOnPage(StrengthsPage) //
+      .hasNoActiveStrengths()
+      .apiErrorBannerIsNotDisplayed()
+  })
+
+  it('should render the strengths page given the API to get Strengths returns an error', () => {
+    // Given
+    cy.task('stubGetStrengths500Error', prisonNumber)
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/strengths`)
+
+    // Then
+    Page.verifyOnPage(StrengthsPage) //
+      .apiErrorBannerIsDisplayed()
+  })
+})

--- a/integration_tests/pages/profile/strengthsPage.ts
+++ b/integration_tests/pages/profile/strengthsPage.ts
@@ -8,6 +8,11 @@ export default class StrengthsPage extends ProfilePage {
     this.activeTabIs('Strengths')
   }
 
+  hasNoActiveStrengths(): StrengthsPage {
+    this.noStrengthsSummaryCard().should('be.visible')
+    return this
+  }
+
   clickAddStrengthButton(): SelectStrengthCategoryPage {
     this.addStrengthButton().click()
     return Page.verifyOnPage(SelectStrengthCategoryPage)
@@ -16,4 +21,6 @@ export default class StrengthsPage extends ProfilePage {
   private strengthsActionItems = (): PageElement => cy.get('[data-qa=strengths-action-items] li')
 
   private addStrengthButton = (): PageElement => this.strengthsActionItems().find('[data-qa=add-strength-button]')
+
+  private noStrengthsSummaryCard = (): PageElement => cy.get('[data-qa=no-strengths-summary-card]')
 }

--- a/server/views/pages/profile/strengths/_noStrengthsSummaryCard.njk
+++ b/server/views/pages/profile/strengths/_noStrengthsSummaryCard.njk
@@ -1,0 +1,10 @@
+<div class="govuk-summary-card" data-qa="no-strengths-summary-card">
+  <div class="govuk-summary-card__content">
+    <p class="govuk-body">
+      No strengths recorded
+    </p>
+    {% if userHasPermissionTo('RECORD_STRENGTHS') %}
+      <a class="govuk-link govuk-body" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">Add strength</a>
+    {% endif %}
+  </div>
+</div>

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -16,11 +16,11 @@
           {# TODO - loop through activeStrengths rendering each one #}
 
         {% else %}
-          {# TODO - 'empty state', where the person has no Strengths recorded #}
+          {% include './_noStrengthsSummaryCard.njk' %}
         {% endif %}
 
       {% else %}
-        <h2 class="govuk-heading-m" data-qa="strengths-unavailable-message">We cannot show these details right now</h2>
+        <h3 class="govuk-heading-s" data-qa="strengths-unavailable-message">We cannot show these details right now</h3>
         <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
       {% endif %}
     </div>

--- a/server/views/pages/profile/strengths/index.test.ts
+++ b/server/views/pages/profile/strengths/index.test.ts
@@ -1,0 +1,129 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import formatDate from '../../../../filters/formatDateFilter'
+import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../../utils/result/result'
+import { aValidStrengthDto, aValidStrengthsList } from '../../../../testsupport/strengthDtoTestDataBuilder'
+import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnPropertyFilter'
+import StrengthType from '../../../../enums/strengthType'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('assetMap', () => '')
+  .addFilter('formatDate', formatDate)
+  .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
+  .addFilter('formatLast_name_comma_First_name', formatPrisonerNameFilter(NameFormat.Last_name_comma_First_name))
+  .addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
+
+const prisonerSummary = aValidPrisonerSummary({
+  firstName: 'IFEREECA',
+  lastName: 'PEIGH',
+})
+const template = 'index.njk'
+
+const userHasPermissionTo = jest.fn()
+const templateParams = {
+  prisonerSummary,
+  userHasPermissionTo,
+  tab: 'strengths',
+  strengths: Result.fulfilled(aValidStrengthsList()),
+  pageHasApiErrors: false,
+}
+
+describe('Profile strengths page', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the profile strengths page given prisoner has no active Strengths', () => {
+    // Given
+    const strengthList = aValidStrengthsList({
+      strengths: [
+        aValidStrengthDto({ strengthTypeCode: StrengthType.ARITHMETIC, active: false }),
+        aValidStrengthDto({ strengthTypeCode: StrengthType.WRITING, active: false }),
+        aValidStrengthDto({ strengthTypeCode: StrengthType.READING, active: false }),
+      ],
+    })
+    const params = {
+      ...templateParams,
+      strengths: Result.fulfilled(strengthList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-strengths-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-strengths-summary-card] a').length).toEqual(1)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+  })
+
+  it('should render the profile strengths page given prisoner has no Strengths at all', () => {
+    // Given
+    const strengthList = aValidStrengthsList({ strengths: [] })
+    const params = {
+      ...templateParams,
+      strengths: Result.fulfilled(strengthList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-strengths-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-strengths-summary-card] a').length).toEqual(1)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+  })
+
+  it('should render the profile strengths page given prisoner has no Strengths and the user does not have permission to create Strengths', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+    const strengthList = aValidStrengthsList({ strengths: [] })
+    const params = {
+      ...templateParams,
+      strengths: Result.fulfilled(strengthList),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-strengths-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-strengths-summary-card] a').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+  })
+
+  it('should render the profile strengths page given the Strengths service API promise is not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      strengths: Result.rejected(new Error('Failed to get strengths')),
+      pageHasApiErrors: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-strengths-summary-card]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(1)
+  })
+})


### PR DESCRIPTION
PR for the rendering of Strengths - empty state (ie. prisoner has no active Strengths) and error state (ie. the API returned an error whilst retrieving the Strengths)

<img width="999" height="718" alt="Screenshot 2025-08-05 at 14 14 24" src="https://github.com/user-attachments/assets/034c3cd1-38de-49b6-b6f8-c5aa61876a98" />

<img width="999" height="833" alt="Screenshot 2025-08-05 at 14 14 06" src="https://github.com/user-attachments/assets/846a5539-da0b-49e6-95c7-5510b5dd0ed1" />

