### PR TITLE
RR-1741 - Add strength category to StrengthDto

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -6,6 +6,7 @@ declare module 'dto' {
   import StrengthIdentificationSource from '../../enums/strengthIdentificationSource'
   import ChallengeType from '../../enums/challengeType'
   import StrengthType from '../../enums/strengthType'
+  import StrengthCategory from '../../enums/strengthCategory'
 
   /**
    * Interface defining common reference and audit related properties that DTO types can inherit through extension.
@@ -111,6 +112,7 @@ declare module 'dto' {
     prisonId?: string
     prisonNumber?: string
     strengthTypeCode: StrengthType
+    strengthCategory: StrengthCategory
     symptoms?: string
     howIdentified?: Array<StrengthIdentificationSource>
     howIdentifiedOther?: string

--- a/server/data/mappers/strengthDtoMapper.test.ts
+++ b/server/data/mappers/strengthDtoMapper.test.ts
@@ -4,6 +4,7 @@ import { aValidStrengthListResponse } from '../../testsupport/strengthResponseTe
 import { aValidStrengthsList } from '../../testsupport/strengthDtoTestDataBuilder'
 import StrengthType from '../../enums/strengthType'
 import StrengthIdentificationSource from '../../enums/strengthIdentificationSource'
+import StrengthCategory from '../../enums/strengthCategory'
 
 describe('strengthDtoMapper', () => {
   it('should map StrengthListResponse to a StrengthsList', () => {
@@ -15,7 +16,7 @@ describe('strengthDtoMapper', () => {
           active: true,
           fromALNScreener: true,
           symptoms: 'John can read and understand very well.',
-          strengthType: { code: 'READING_COMPREHENSION' },
+          strengthType: { code: 'READING_COMPREHENSION', categoryCode: 'LITERACY_SKILLS' },
           howIdentified: ['CONVERSATIONS'],
           howIdentifiedOther: 'I have spoken to the person',
           reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
@@ -39,6 +40,7 @@ describe('strengthDtoMapper', () => {
           fromALNScreener: true,
           symptoms: 'John can read and understand very well.',
           strengthTypeCode: StrengthType.READING_COMPREHENSION,
+          strengthCategory: StrengthCategory.LITERACY_SKILLS,
           howIdentified: [StrengthIdentificationSource.CONVERSATIONS],
           howIdentifiedOther: 'I have spoken to the person',
           createdAt: parseISO('2023-06-19T09:39:44Z'),

--- a/server/data/mappers/strengthDtoMapper.ts
+++ b/server/data/mappers/strengthDtoMapper.ts
@@ -10,6 +10,7 @@ const toStrengthsList = (strengthListResponse: StrengthListResponse, prisonNumbe
 const toStrengthDto = (strengthResponse: StrengthResponse): StrengthDto => ({
   ...toReferenceAndAuditable(strengthResponse),
   strengthTypeCode: strengthResponse.strengthType.code,
+  strengthCategory: strengthResponse.strengthType.categoryCode,
   symptoms: strengthResponse.symptoms,
   howIdentified: strengthResponse.howIdentified,
   howIdentifiedOther: strengthResponse.howIdentifiedOther,

--- a/server/services/strengthService.test.ts
+++ b/server/services/strengthService.test.ts
@@ -6,6 +6,7 @@ import { aValidCreateStrengthsRequest } from '../testsupport/strengthRequestTest
 import { aValidStrengthListResponse } from '../testsupport/strengthResponseTestDataBuilder'
 import StrengthType from '../enums/strengthType'
 import StrengthIdentificationSource from '../enums/strengthIdentificationSource'
+import StrengthCategory from '../enums/strengthCategory'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
 
@@ -75,6 +76,7 @@ describe('strengthService', () => {
             fromALNScreener: true,
             symptoms: 'John can read and understand written language very well',
             strengthTypeCode: StrengthType.READING_COMPREHENSION,
+            strengthCategory: StrengthCategory.LITERACY_SKILLS,
             howIdentified: [StrengthIdentificationSource.CONVERSATIONS],
             howIdentifiedOther: `John's reading strength was discovered during a poetry recital evening`,
             createdAt: parseISO('2023-06-19T09:39:44Z'),

--- a/server/testsupport/strengthDtoTestDataBuilder.ts
+++ b/server/testsupport/strengthDtoTestDataBuilder.ts
@@ -2,6 +2,7 @@ import type { StrengthDto, StrengthsList } from 'dto'
 import StrengthIdentificationSource from '../enums/strengthIdentificationSource'
 import StrengthType from '../enums/strengthType'
 import { DtoAuditFields, validDtoAuditFields } from './auditFieldsTestDataBuilder'
+import StrengthCategory from '../enums/strengthCategory'
 
 const aValidStrengthsList = (options?: { prisonNumber?: string; strengths?: Array<StrengthDto> }): StrengthsList => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
@@ -13,6 +14,7 @@ const aValidStrengthDto = (
     prisonNumber?: string
     prisonId?: string
     strengthTypeCode?: StrengthType
+    strengthCategory?: StrengthCategory
     symptoms?: string
     howIdentified?: Array<StrengthIdentificationSource>
     howIdentifiedOther?: string
@@ -23,6 +25,7 @@ const aValidStrengthDto = (
   prisonNumber: options?.prisonNumber === null ? null : options?.prisonNumber || 'A1234BC',
   prisonId: options?.prisonId || 'BXI',
   strengthTypeCode: options?.strengthTypeCode || StrengthType.READING_COMPREHENSION,
+  strengthCategory: options?.strengthCategory || StrengthCategory.LITERACY_SKILLS,
   symptoms:
     options?.symptoms === null ? null : options?.symptoms || 'John can read and understand written language very well',
   howIdentified: options?.howIdentified || [StrengthIdentificationSource.CONVERSATIONS],

--- a/server/testsupport/strengthResponseTestDataBuilder.ts
+++ b/server/testsupport/strengthResponseTestDataBuilder.ts
@@ -11,6 +11,7 @@ const aValidStrengthResponse = (
     active?: boolean
     fromALNScreener?: boolean
     strengthTypeCode?: string
+    strengthCategory?: string
     symptoms?: string
     howIdentified?: Array<StrengthIdentificationSource>
     howIdentifiedOther?: string
@@ -27,6 +28,7 @@ const aValidStrengthResponse = (
       : options?.howIdentifiedOther || `John's reading strength was discovered during a poetry recital evening`,
   strengthType: {
     code: options?.strengthTypeCode || 'READING_COMPREHENSION',
+    categoryCode: options?.strengthCategory || 'LITERACY_SKILLS',
   },
   ...validAuditFields(options),
 })


### PR DESCRIPTION
PR to add the strength category to `StrengthDto` and map it from the Strengths API response type
We need the category code in order to group them in the UI