### PR TITLE
POC 1 for looking up prison names

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,6 +5,7 @@ import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import manageUsersApi from './manageUsersApi'
 import supportAdditionalNeedsApi from './supportAdditionalNeedsApi'
+import prisonRegisterApi from './prisonRegisterApi'
 import stubPing from './common'
 
 interface UserToken {
@@ -109,7 +110,7 @@ export default {
   stubAuthPing: stubPing('auth'),
   stubSignIn: (
     userToken: UserToken = {},
-  ): Promise<[Response, Response, Response, Response, Response, Response, Response]> =>
+  ): Promise<[Response, Response, Response, Response, Response, Response, Response, Response]> =>
     Promise.all([
       favicon(),
       redirect(),
@@ -118,5 +119,6 @@ export default {
       tokenVerification.stubVerifyToken(),
       manageUsersApi.stubGetUserCaseloads(),
       supportAdditionalNeedsApi.stubSearchByPrison(),
+      prisonRegisterApi.stubGetAllPrisons(),
     ]),
 }

--- a/server/data/mappers/challengeDtoMapper.test.ts
+++ b/server/data/mappers/challengeDtoMapper.test.ts
@@ -5,6 +5,11 @@ import type { ChallengeResponseDto, ReferenceDataItemDto } from 'dto'
 import toChallengeDto from './challengeDtoMapper'
 
 describe('toChallengeDto', () => {
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
   it('should map a single challenge correctly', () => {
     const prisonNumber = 'A1234BC'
     const testRef = 'abcdef'
@@ -33,7 +38,7 @@ describe('toChallengeDto', () => {
       ],
     }
 
-    const result = toChallengeDto(prisonNumber, apiResponse)
+    const result = toChallengeDto(prisonNumber, apiResponse, prisonNamesById)
 
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual<ChallengeResponseDto>({
@@ -44,7 +49,7 @@ describe('toChallengeDto', () => {
       createdBy: 'user1',
       updatedAt: parseISO('2025-07-26T12:00:00.000Z'),
       updatedBy: 'user2',
-      updatedAtPrison: 'BXI',
+      updatedAtPrison: 'Brixton (HMP)',
       reference: testRef,
       fromALNScreener: false,
       active: true,
@@ -105,7 +110,7 @@ describe('toChallengeDto', () => {
       ],
     }
 
-    const result = toChallengeDto(prisonNumber, apiResponse)
+    const result = toChallengeDto(prisonNumber, apiResponse, prisonNamesById)
 
     expect(result).toHaveLength(2)
     expect(result[0]).toEqual<ChallengeResponseDto>({
@@ -116,7 +121,7 @@ describe('toChallengeDto', () => {
       createdBy: 'user1',
       updatedAt: parseISO('2025-07-26T12:00:00.000Z'),
       updatedBy: 'user2',
-      updatedAtPrison: 'BXI',
+      updatedAtPrison: 'Brixton (HMP)',
       reference: testRef1,
       fromALNScreener: false,
       active: true,
@@ -134,7 +139,7 @@ describe('toChallengeDto', () => {
       createdBy: 'user1',
       updatedAt: parseISO('2025-07-26T12:00:00.000Z'),
       updatedBy: 'user2',
-      updatedAtPrison: 'BXI',
+      updatedAtPrison: 'Brixton (HMP)',
       reference: testRef2,
       fromALNScreener: true,
       active: true,
@@ -149,7 +154,7 @@ describe('toChallengeDto', () => {
   it('should handle empty `challenges` array', () => {
     const prisonNumber = 'C9012EF'
     const apiResponse: ChallengeListResponse = { challenges: [] }
-    const result = toChallengeDto(prisonNumber, apiResponse)
+    const result = toChallengeDto(prisonNumber, apiResponse, prisonNamesById)
 
     expect(result).toHaveLength(0)
   })

--- a/server/data/mappers/challengeDtoMapper.ts
+++ b/server/data/mappers/challengeDtoMapper.ts
@@ -3,11 +3,15 @@ import type { ChallengeResponseDto } from 'dto'
 import { toReferenceDataItem } from './referenceDataListResponseMapper'
 import toReferenceAndAuditable from './referencedAndAuditableMapper'
 
-const toChallengeDto = (prisonNumber: string, apiResponse: ChallengeListResponse): ChallengeResponseDto[] => {
+const toChallengeDto = (
+  prisonNumber: string,
+  apiResponse: ChallengeListResponse,
+  prisonNamesById: Map<string, string>,
+): ChallengeResponseDto[] => {
   return (apiResponse.challenges as Array<ChallengeResponse>).map(
     challenge =>
       ({
-        ...toReferenceAndAuditable(challenge),
+        ...toReferenceAndAuditable(challenge, prisonNamesById),
         prisonNumber,
         fromALNScreener: challenge.fromALNScreener,
         challengeType: toReferenceDataItem(challenge.challengeType),

--- a/server/data/mappers/conditionDtoMapper.test.ts
+++ b/server/data/mappers/conditionDtoMapper.test.ts
@@ -6,6 +6,11 @@ import ConditionType from '../../enums/conditionType'
 import ConditionSource from '../../enums/conditionSource'
 
 describe('conditionDtoMapper', () => {
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
   it('should map ConditionListResponse to a ConditionsList', () => {
     // Given
     const prisonNumber = 'A1234BC'
@@ -39,13 +44,13 @@ describe('conditionDtoMapper', () => {
           conditionName: 'Phonological dyslexia',
           conditionTypeCode: ConditionType.DYSLEXIA,
           createdAt: parseISO('2023-06-19T09:39:44Z'),
-          createdAtPrison: 'MDI',
+          createdAtPrison: 'Moorland (HMP & YOI)',
           createdBy: 'asmith_gen',
           createdByDisplayName: 'Alex Smith',
           reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
           source: ConditionSource.SELF_DECLARED,
           updatedAt: parseISO('2023-06-19T09:39:44Z'),
-          updatedAtPrison: 'MDI',
+          updatedAtPrison: 'Moorland (HMP & YOI)',
           updatedBy: 'asmith_gen',
           updatedByDisplayName: 'Alex Smith',
         },
@@ -53,7 +58,7 @@ describe('conditionDtoMapper', () => {
     })
 
     // When
-    const actual = toConditionsList(apiResponse, prisonNumber)
+    const actual = toConditionsList(apiResponse, prisonNumber, prisonNamesById)
 
     // Then
     expect(actual).toEqual(expected)
@@ -70,7 +75,7 @@ describe('conditionDtoMapper', () => {
     })
 
     // When
-    const actual = toConditionsList(apiResponse, prisonNumber)
+    const actual = toConditionsList(apiResponse, prisonNumber, prisonNamesById)
 
     // Then
     expect(actual).toEqual(expected)

--- a/server/data/mappers/conditionDtoMapper.ts
+++ b/server/data/mappers/conditionDtoMapper.ts
@@ -2,13 +2,21 @@ import type { ConditionDto, ConditionsList } from 'dto'
 import type { ConditionListResponse, ConditionResponse } from 'supportAdditionalNeedsApiClient'
 import toReferenceAndAuditable from './referencedAndAuditableMapper'
 
-const toConditionsList = (conditionListResponse: ConditionListResponse, prisonNumber: string): ConditionsList => ({
+const toConditionsList = (
+  conditionListResponse: ConditionListResponse,
+  prisonNumber: string,
+  prisonNamesById: Map<string, string>,
+): ConditionsList => ({
   prisonNumber,
-  conditions: conditionListResponse?.conditions.map(toConditionDto) || [],
+  conditions: conditionListResponse
+    ? (conditionListResponse?.conditions as Array<ConditionResponse>).map(condition =>
+        toConditionDto(condition, prisonNamesById),
+      )
+    : [],
 })
 
-const toConditionDto = (conditionResponse: ConditionResponse): ConditionDto => ({
-  ...toReferenceAndAuditable(conditionResponse),
+const toConditionDto = (conditionResponse: ConditionResponse, prisonNamesById: Map<string, string>): ConditionDto => ({
+  ...toReferenceAndAuditable(conditionResponse, prisonNamesById),
   conditionTypeCode: conditionResponse.conditionType.code,
   conditionName: conditionResponse.conditionName,
   conditionDetails: conditionResponse.conditionDetails,

--- a/server/data/mappers/referencedAndAuditableMapper.ts
+++ b/server/data/mappers/referencedAndAuditableMapper.ts
@@ -1,26 +1,29 @@
 import { parseISO } from 'date-fns'
 import type { ReferencedAndAuditable } from 'dto'
 
-const toReferenceAndAuditable = (apiResponse: {
-  reference: string
-  createdBy: string
-  createdByDisplayName: string
-  createdAt: string
-  createdAtPrison: string
-  updatedBy: string
-  updatedByDisplayName: string
-  updatedAt: string
-  updatedAtPrison: string
-}): ReferencedAndAuditable => ({
+const toReferenceAndAuditable = (
+  apiResponse: {
+    reference: string
+    createdBy: string
+    createdByDisplayName: string
+    createdAt: string
+    createdAtPrison: string
+    updatedBy: string
+    updatedByDisplayName: string
+    updatedAt: string
+    updatedAtPrison: string
+  },
+  prisonNamesById: Map<string, string>,
+): ReferencedAndAuditable => ({
   reference: apiResponse.reference,
   createdBy: apiResponse.createdBy,
   createdByDisplayName: apiResponse.createdByDisplayName,
   createdAt: apiResponse.createdAt ? parseISO(apiResponse.createdAt) : null,
-  createdAtPrison: apiResponse.createdAtPrison,
+  createdAtPrison: prisonNamesById.get(apiResponse.createdAtPrison) || apiResponse.createdAtPrison,
   updatedBy: apiResponse.updatedBy,
   updatedByDisplayName: apiResponse.updatedByDisplayName,
   updatedAt: apiResponse.updatedAt ? parseISO(apiResponse.updatedAt) : null,
-  updatedAtPrison: apiResponse.updatedAtPrison,
+  updatedAtPrison: prisonNamesById.get(apiResponse.updatedAtPrison) || apiResponse.updatedAtPrison,
 })
 
 export default toReferenceAndAuditable

--- a/server/routes/challenges/create/detail/detailController.test.ts
+++ b/server/routes/challenges/create/detail/detailController.test.ts
@@ -9,7 +9,7 @@ import ChallengeType from '../../../../enums/challengeType'
 jest.mock('../../../../services/challengeService')
 
 describe('detailController', () => {
-  const mockedChallengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
+  const mockedChallengeService = new ChallengeService(null, null) as jest.Mocked<ChallengeService>
   const controller = new DetailController(mockedChallengeService)
 
   const username = 'FRED_123'

--- a/server/routes/conditions/create/details/detailsController.test.ts
+++ b/server/routes/conditions/create/details/detailsController.test.ts
@@ -9,7 +9,7 @@ import ConditionSource from '../../../../enums/conditionSource'
 jest.mock('../../../../services/conditionService')
 
 describe('detailsController', () => {
-  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const conditionService = new ConditionService(null, null) as jest.Mocked<ConditionService>
   const controller = new DetailsController(conditionService)
 
   const username = 'FRED_123'

--- a/server/routes/profile/middleware/retrieveConditions.test.ts
+++ b/server/routes/profile/middleware/retrieveConditions.test.ts
@@ -6,7 +6,7 @@ import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataB
 jest.mock('../../../services/conditionService')
 
 describe('retrieveConditions', () => {
-  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const conditionService = new ConditionService(null, null) as jest.Mocked<ConditionService>
   const requestHandler = retrieveConditions(conditionService)
 
   const prisonNumber = 'A1234BC'

--- a/server/routes/profile/middleware/retrieveCurrentChallenges.test.ts
+++ b/server/routes/profile/middleware/retrieveCurrentChallenges.test.ts
@@ -6,7 +6,7 @@ import { aValidChallengeResponse } from '../../../testsupport/challengeResponseT
 jest.mock('../../../services/challengeService')
 
 describe('retrieveCurrentChallenges', () => {
-  const mockedChallengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
+  const mockedChallengeService = new ChallengeService(null, null) as jest.Mocked<ChallengeService>
 
   const requestHandler = retrieveCurrentChallenges(mockedChallengeService)
   const prisonNumber = 'A1234BC'

--- a/server/services/challengeService.test.ts
+++ b/server/services/challengeService.test.ts
@@ -4,20 +4,29 @@ import aValidChallengeDto from '../testsupport/challengeDtoTestDataBuilder'
 import { aValidCreateChallengesRequest } from '../testsupport/challengeRequestTestDataBuilder'
 import { aValidChallengeListResponse, aValidChallengeResponse } from '../testsupport/challengeResponseTestDataBuilder'
 import toChallengeDto from '../data/mappers/challengeDtoMapper'
+import PrisonService from './prisonService'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
+jest.mock('./prisonService')
 
 describe('challengeService', () => {
   const supportAdditionalNeedsApiClient = new SupportAdditionalNeedsApiClient(
     null,
   ) as jest.Mocked<SupportAdditionalNeedsApiClient>
-  const service = new ChallengeService(supportAdditionalNeedsApiClient)
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
+  const service = new ChallengeService(supportAdditionalNeedsApiClient, prisonService)
 
   const prisonNumber = 'A1234BC'
   const username = 'some-username'
 
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
   beforeEach(() => {
     jest.resetAllMocks()
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
   })
 
   describe('createChallenges', () => {
@@ -75,7 +84,7 @@ describe('challengeService', () => {
       // Then
       expect(supportAdditionalNeedsApiClient.getChallenges).toHaveBeenCalledWith('A1234BC', username)
       expect(result).toHaveLength(1)
-      expect(result).toEqual(toChallengeDto(prisonNumber, expectedChallengeListResponse))
+      expect(result).toEqual(toChallengeDto(prisonNumber, expectedChallengeListResponse, prisonNamesById))
     })
   })
 })

--- a/server/services/challengeService.ts
+++ b/server/services/challengeService.ts
@@ -3,9 +3,13 @@ import { SupportAdditionalNeedsApiClient } from '../data'
 import { toCreateChallengesRequest } from '../data/mappers/createChallengesRequestMapper'
 import logger from '../../logger'
 import toChallengeDto from '../data/mappers/challengeDtoMapper'
+import PrisonService from './prisonService'
 
 export default class ChallengeService {
-  constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
+  constructor(
+    private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient,
+    private readonly prisonService: PrisonService,
+  ) {}
 
   async createChallenges(username: string, challenges: Array<ChallengeDto>): Promise<void> {
     const [firstChallenge] = challenges
@@ -21,8 +25,9 @@ export default class ChallengeService {
 
   async getChallenges(username: string, prisonNumber: string): Promise<Array<ChallengeResponseDto>> {
     try {
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       const challengeListResponse = await this.supportAdditionalNeedsApiClient.getChallenges(prisonNumber, username)
-      return toChallengeDto(prisonNumber, challengeListResponse)
+      return toChallengeDto(prisonNumber, challengeListResponse, prisonNamesById)
     } catch (e) {
       logger.error(`Error getting Challenges for [${prisonNumber}]`, e)
       throw e

--- a/server/services/conditionService.test.ts
+++ b/server/services/conditionService.test.ts
@@ -6,20 +6,29 @@ import { aValidCreateConditionsRequest } from '../testsupport/conditionRequestTe
 import { aValidConditionListResponse } from '../testsupport/conditionResponseTestDataBuilder'
 import ConditionType from '../enums/conditionType'
 import ConditionSource from '../enums/conditionSource'
+import PrisonService from './prisonService'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
+jest.mock('./prisonService')
 
 describe('conditionService', () => {
   const supportAdditionalNeedsApiClient = new SupportAdditionalNeedsApiClient(
     null,
   ) as jest.Mocked<SupportAdditionalNeedsApiClient>
-  const service = new ConditionService(supportAdditionalNeedsApiClient)
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
+  const service = new ConditionService(supportAdditionalNeedsApiClient, prisonService)
+
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
 
   const prisonNumber = 'A1234BC'
   const username = 'some-username'
 
   beforeEach(() => {
     jest.resetAllMocks()
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
   })
 
   describe('createConditions', () => {
@@ -77,13 +86,13 @@ describe('conditionService', () => {
             conditionName: 'Phonological dyslexia',
             conditionTypeCode: ConditionType.DYSLEXIA,
             createdAt: parseISO('2023-06-19T09:39:44Z'),
-            createdAtPrison: 'MDI',
+            createdAtPrison: 'Moorland (HMP & YOI)',
             createdBy: 'asmith_gen',
             createdByDisplayName: 'Alex Smith',
             reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
             source: ConditionSource.SELF_DECLARED,
             updatedAt: parseISO('2023-06-19T09:39:44Z'),
-            updatedAtPrison: 'MDI',
+            updatedAtPrison: 'Moorland (HMP & YOI)',
             updatedBy: 'asmith_gen',
             updatedByDisplayName: 'Alex Smith',
           },

--- a/server/services/conditionService.ts
+++ b/server/services/conditionService.ts
@@ -3,9 +3,13 @@ import { SupportAdditionalNeedsApiClient } from '../data'
 import { toCreateConditionsRequest } from '../data/mappers/createConditionsRequestMapper'
 import logger from '../../logger'
 import { toConditionsList } from '../data/mappers/conditionDtoMapper'
+import PrisonService from './prisonService'
 
 export default class ConditionService {
-  constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
+  constructor(
+    private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient,
+    private readonly prisonService: PrisonService,
+  ) {}
 
   async createConditions(username: string, conditions: ConditionsList): Promise<void> {
     const { prisonNumber } = conditions
@@ -20,8 +24,9 @@ export default class ConditionService {
 
   async getConditions(username: string, prisonNumber: string): Promise<ConditionsList> {
     try {
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       const conditionListResponse = await this.supportAdditionalNeedsApiClient.getConditions(prisonNumber, username)
-      return toConditionsList(conditionListResponse, prisonNumber)
+      return toConditionsList(conditionListResponse, prisonNumber, prisonNamesById)
     } catch (e) {
       logger.error(`Error getting Conditions for [${prisonNumber}]`, e)
       throw e

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -29,19 +29,21 @@ export const services = () => {
     referenceDataStore,
   } = dataAccess()
 
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient)
+
   return {
     applicationInfo,
     auditService: new AuditService(hmppsAuditClient),
     journeyDataService: new JourneyDataService(journeyDataStore),
     prisonerService: new PrisonerService(prisonerSearchStore, prisonerSearchClient),
-    prisonService: new PrisonService(prisonRegisterStore, prisonRegisterClient),
+    prisonService,
     userService: new UserService(managedUsersApiClient),
     searchService: new SearchService(supportAdditionalNeedsApiClient),
     curiousService: new CuriousService(curiousApiClient),
     educationSupportPlanService: new EducationSupportPlanService(supportAdditionalNeedsApiClient),
     educationSupportPlanScheduleService: new EducationSupportPlanScheduleService(supportAdditionalNeedsApiClient),
-    challengeService: new ChallengeService(supportAdditionalNeedsApiClient),
-    conditionService: new ConditionService(supportAdditionalNeedsApiClient),
+    challengeService: new ChallengeService(supportAdditionalNeedsApiClient, prisonService),
+    conditionService: new ConditionService(supportAdditionalNeedsApiClient, prisonService),
     referenceDataService: new ReferenceDataService(referenceDataStore, supportAdditionalNeedsApiClient),
     strengthService: new StrengthService(supportAdditionalNeedsApiClient),
     additionalLearningNeedsService: new AdditionalLearningNeedsScreenerService(supportAdditionalNeedsApiClient),


### PR DESCRIPTION
## POC 1 for looking up prison names

**This PR is for discussion - DO NOT MERGE**

----

This PR implements the prison lookup at the service layer, by wiring the `PrisonService` into other services that return data that should include prison names rather than prison IDs. In our case that is in `ChallengeService`, `ConditionService` etc, and the mappers that they use.

The basic idea is that the `PrisonService` is wired into eg: `ConditionService`. The method in `ConditionService` (eg: `getConditions` calls the API client to get the raw response data from the API, and also calls `PrisonService` to get the prison ID to prison name map (`PrisonService` caches this internally, so no worries about repeated / inefficient calls)
With both the raw response data from the API, and the map of prisons, the service method then calls the mapper to map the results into a DTO.
Therefore the mapper has to change in order to accept and process the prisons data. It is actually the mapper that maps the correct prison name into the resultant DTO, rather than the prison ID from the raw API response.

Pros:
* It works

Cons:
* A bit messy / coupled
* The service methods are now coupled a little tighter to screen designs because they now return DTOs that contain looked up prison names (what if we needed to call the same service method elsewhere, where we wanted the prison ID? / what if the screen designs changed and we no longer need the prison name? etc)
* The service layer has a dependency on the `PrisonService` purely so it can pass the resultant data into the mapper
* Because of the way I've structured the mappers (specifically mapping the prison name in `toReferenceAndAuditable`), it means we need to do all challenges, conditions, strengths etc together