### PR TITLE
POC 2 for looking up prison names

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,6 +5,7 @@ import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import manageUsersApi from './manageUsersApi'
 import supportAdditionalNeedsApi from './supportAdditionalNeedsApi'
+import prisonRegisterApi from './prisonRegisterApi'
 import stubPing from './common'
 
 interface UserToken {
@@ -109,7 +110,7 @@ export default {
   stubAuthPing: stubPing('auth'),
   stubSignIn: (
     userToken: UserToken = {},
-  ): Promise<[Response, Response, Response, Response, Response, Response, Response]> =>
+  ): Promise<[Response, Response, Response, Response, Response, Response, Response, Response]> =>
     Promise.all([
       favicon(),
       redirect(),
@@ -118,5 +119,6 @@ export default {
       tokenVerification.stubVerifyToken(),
       manageUsersApi.stubGetUserCaseloads(),
       supportAdditionalNeedsApi.stubSearchByPrison(),
+      prisonRegisterApi.stubGetAllPrisons(),
     ]),
 }

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -10,7 +10,7 @@ declare module 'dto' {
   /**
    * Interface defining common reference and audit related properties that DTO types can inherit through extension.
    */
-  interface ReferencedAndAuditable {
+  export interface ReferencedAndAuditable {
     reference?: string
     createdBy?: string
     createdByDisplayName?: string

--- a/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.test.ts
+++ b/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.test.ts
@@ -1,0 +1,35 @@
+import { aValidConditionDto } from '../../testsupport/conditionDtoTestDataBuilder'
+import mapPrisonNamesToReferencedAndAuditable from './mapPrisonNamesToReferencedAndAuditable'
+
+describe('mapPrisonNamesToReferencedAndAuditable', () => {
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
+  it('should map prison names to a ReferencedAndAuditable instance given prison IDs are found in the lookup', () => {
+    // Given
+    const conditionDto = aValidConditionDto({ createdAtPrison: 'BXI', updatedAtPrison: 'MDI' })
+
+    const expected = aValidConditionDto({ createdAtPrison: 'Brixton (HMP)', updatedAtPrison: 'Moorland (HMP & YOI)' })
+
+    // When
+    const actual = mapPrisonNamesToReferencedAndAuditable(conditionDto, prisonNamesById)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should not map prison names to a ReferencedAndAuditable instance given prison IDs are not found in the lookup', () => {
+    // Given
+    const conditionDto = aValidConditionDto({ createdAtPrison: 'LEI', updatedAtPrison: 'LEI' })
+
+    const expected = aValidConditionDto({ createdAtPrison: 'LEI', updatedAtPrison: 'LEI' })
+
+    // When
+    const actual = mapPrisonNamesToReferencedAndAuditable(conditionDto, prisonNamesById)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.ts
+++ b/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.ts
@@ -1,0 +1,16 @@
+import type { ReferencedAndAuditable } from 'dto'
+
+/**
+ * Mapper that takes any DTO that extends ReferencedAndAuditable, and a map of prison IDs to prison names; and maps the
+ * prison name into the createdAtPrison and updatedAtPrison properties.
+ */
+const mapPrisonNamesToReferencedAndAuditable = <T extends ReferencedAndAuditable>(
+  dto: T,
+  prisonNamesById: Map<string, string>,
+): T => ({
+  ...dto,
+  createdAtPrison: prisonNamesById.get(dto.createdAtPrison) || dto.createdAtPrison,
+  updatedAtPrison: prisonNamesById.get(dto.updatedAtPrison) || dto.updatedAtPrison,
+})
+
+export default mapPrisonNamesToReferencedAndAuditable

--- a/server/routes/conditions/create/details/detailsController.test.ts
+++ b/server/routes/conditions/create/details/detailsController.test.ts
@@ -9,7 +9,7 @@ import ConditionSource from '../../../../enums/conditionSource'
 jest.mock('../../../../services/conditionService')
 
 describe('detailsController', () => {
-  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const conditionService = new ConditionService(null, null) as jest.Mocked<ConditionService>
   const controller = new DetailsController(conditionService)
 
   const username = 'FRED_123'

--- a/server/routes/profile/middleware/retrieveConditions.test.ts
+++ b/server/routes/profile/middleware/retrieveConditions.test.ts
@@ -6,7 +6,7 @@ import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataB
 jest.mock('../../../services/conditionService')
 
 describe('retrieveConditions', () => {
-  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const conditionService = new ConditionService(null, null) as jest.Mocked<ConditionService>
   const requestHandler = retrieveConditions(conditionService)
 
   const prisonNumber = 'A1234BC'

--- a/server/services/conditionService.test.ts
+++ b/server/services/conditionService.test.ts
@@ -6,20 +6,29 @@ import { aValidCreateConditionsRequest } from '../testsupport/conditionRequestTe
 import { aValidConditionListResponse } from '../testsupport/conditionResponseTestDataBuilder'
 import ConditionType from '../enums/conditionType'
 import ConditionSource from '../enums/conditionSource'
+import PrisonService from './prisonService'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
+jest.mock('./prisonService')
 
 describe('conditionService', () => {
   const supportAdditionalNeedsApiClient = new SupportAdditionalNeedsApiClient(
     null,
   ) as jest.Mocked<SupportAdditionalNeedsApiClient>
-  const service = new ConditionService(supportAdditionalNeedsApiClient)
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
+  const service = new ConditionService(supportAdditionalNeedsApiClient, prisonService)
+
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
 
   const prisonNumber = 'A1234BC'
   const username = 'some-username'
 
   beforeEach(() => {
     jest.resetAllMocks()
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
   })
 
   describe('createConditions', () => {
@@ -77,13 +86,13 @@ describe('conditionService', () => {
             conditionName: 'Phonological dyslexia',
             conditionTypeCode: ConditionType.DYSLEXIA,
             createdAt: parseISO('2023-06-19T09:39:44Z'),
-            createdAtPrison: 'MDI',
+            createdAtPrison: 'Moorland (HMP & YOI)',
             createdBy: 'asmith_gen',
             createdByDisplayName: 'Alex Smith',
             reference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
             source: ConditionSource.SELF_DECLARED,
             updatedAt: parseISO('2023-06-19T09:39:44Z'),
-            updatedAtPrison: 'MDI',
+            updatedAtPrison: 'Moorland (HMP & YOI)',
             updatedBy: 'asmith_gen',
             updatedByDisplayName: 'Alex Smith',
           },

--- a/server/services/conditionService.ts
+++ b/server/services/conditionService.ts
@@ -3,9 +3,14 @@ import { SupportAdditionalNeedsApiClient } from '../data'
 import { toCreateConditionsRequest } from '../data/mappers/createConditionsRequestMapper'
 import logger from '../../logger'
 import { toConditionsList } from '../data/mappers/conditionDtoMapper'
+import PrisonService from './prisonService'
+import mapPrisonNamesToReferencedAndAuditable from '../data/mappers/mapPrisonNamesToReferencedAndAuditable'
 
 export default class ConditionService {
-  constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
+  constructor(
+    private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient,
+    private readonly prisonService: PrisonService,
+  ) {}
 
   async createConditions(username: string, conditions: ConditionsList): Promise<void> {
     const { prisonNumber } = conditions
@@ -20,8 +25,15 @@ export default class ConditionService {
 
   async getConditions(username: string, prisonNumber: string): Promise<ConditionsList> {
     try {
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       const conditionListResponse = await this.supportAdditionalNeedsApiClient.getConditions(prisonNumber, username)
-      return toConditionsList(conditionListResponse, prisonNumber)
+      const conditionsList = toConditionsList(conditionListResponse, prisonNumber)
+      return {
+        ...conditionsList,
+        conditions: conditionsList.conditions.map(condition =>
+          mapPrisonNamesToReferencedAndAuditable(condition, prisonNamesById),
+        ),
+      }
     } catch (e) {
       logger.error(`Error getting Conditions for [${prisonNumber}]`, e)
       throw e

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -29,19 +29,21 @@ export const services = () => {
     referenceDataStore,
   } = dataAccess()
 
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient)
+
   return {
     applicationInfo,
     auditService: new AuditService(hmppsAuditClient),
     journeyDataService: new JourneyDataService(journeyDataStore),
     prisonerService: new PrisonerService(prisonerSearchStore, prisonerSearchClient),
-    prisonService: new PrisonService(prisonRegisterStore, prisonRegisterClient),
+    prisonService,
     userService: new UserService(managedUsersApiClient),
     searchService: new SearchService(supportAdditionalNeedsApiClient),
     curiousService: new CuriousService(curiousApiClient),
     educationSupportPlanService: new EducationSupportPlanService(supportAdditionalNeedsApiClient),
     educationSupportPlanScheduleService: new EducationSupportPlanScheduleService(supportAdditionalNeedsApiClient),
     challengeService: new ChallengeService(supportAdditionalNeedsApiClient),
-    conditionService: new ConditionService(supportAdditionalNeedsApiClient),
+    conditionService: new ConditionService(supportAdditionalNeedsApiClient, prisonService),
     referenceDataService: new ReferenceDataService(referenceDataStore, supportAdditionalNeedsApiClient),
     strengthService: new StrengthService(supportAdditionalNeedsApiClient),
     additionalLearningNeedsService: new AdditionalLearningNeedsScreenerService(supportAdditionalNeedsApiClient),


### PR DESCRIPTION
## POC 2 for looking up prison names

**This PR is for discussion - DO NOT MERGE**

----

This PR implements the prison lookup at the service layer, by using a second mapper within the service layer.

The basic idea is that the `PrisonService` is wired into eg: `ConditionService`. The method in `ConditionService` (eg: `getConditions` calls the API client to get the raw response data from the API, and also calls `PrisonService` to get the prison ID to prison name map (`PrisonService` caches this internally, so no worries about repeated / inefficient calls)
The service method then calls the same mapper that it did previously (`toConditionsList`) and then re-maps the conditions array using the new mapper `mapPrisonNamesToReferencedAndAuditable`
IE. in the first mapping (`toConditionsList`), the DTOs still have the prison IDs in the `createdAtPrison` and `updatedAtPrison` properties. The second mapper `mapPrisonNamesToReferencedAndAuditable` then changes these 2 properties to the looked up prison names.

Pros:
* It works
* Simpler and smaller change set than POC 1
* We don't to make this change to all of Challenges, Strengths and Conditions in one change (as we would have to with POC 1)

Cons:
* The service methods are now coupled a little tighter to screen designs because they now return DTOs that contain looked up prison names (what if we needed to call the same service method elsewhere, where we wanted the prison ID? / what if the screen designs changed and we no longer need the prison name? etc)
* The service layer has a dependency on the `PrisonService` purely so it can pass the resultant data into the mapper
