### PR TITLE
POC 3 for looking up prison names

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,6 +5,7 @@ import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import manageUsersApi from './manageUsersApi'
 import supportAdditionalNeedsApi from './supportAdditionalNeedsApi'
+import prisonRegisterApi from './prisonRegisterApi'
 import stubPing from './common'
 
 interface UserToken {
@@ -109,7 +110,7 @@ export default {
   stubAuthPing: stubPing('auth'),
   stubSignIn: (
     userToken: UserToken = {},
-  ): Promise<[Response, Response, Response, Response, Response, Response, Response]> =>
+  ): Promise<[Response, Response, Response, Response, Response, Response, Response, Response]> =>
     Promise.all([
       favicon(),
       redirect(),
@@ -118,5 +119,6 @@ export default {
       tokenVerification.stubVerifyToken(),
       manageUsersApi.stubGetUserCaseloads(),
       supportAdditionalNeedsApi.stubSearchByPrison(),
+      prisonRegisterApi.stubGetAllPrisons(),
     ]),
 }

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -10,7 +10,7 @@ declare module 'dto' {
   /**
    * Interface defining common reference and audit related properties that DTO types can inherit through extension.
    */
-  interface ReferencedAndAuditable {
+  export interface ReferencedAndAuditable {
     reference?: string
     createdBy?: string
     createdByDisplayName?: string

--- a/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.test.ts
+++ b/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.test.ts
@@ -1,0 +1,35 @@
+import { aValidConditionDto } from '../../testsupport/conditionDtoTestDataBuilder'
+import mapPrisonNamesToReferencedAndAuditable from './mapPrisonNamesToReferencedAndAuditable'
+
+describe('mapPrisonNamesToReferencedAndAuditable', () => {
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
+  it('should map prison names to a ReferencedAndAuditable instance given prison IDs are found in the lookup', () => {
+    // Given
+    const conditionDto = aValidConditionDto({ createdAtPrison: 'BXI', updatedAtPrison: 'MDI' })
+
+    const expected = aValidConditionDto({ createdAtPrison: 'Brixton (HMP)', updatedAtPrison: 'Moorland (HMP & YOI)' })
+
+    // When
+    const actual = mapPrisonNamesToReferencedAndAuditable(conditionDto, prisonNamesById)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should not map prison names to a ReferencedAndAuditable instance given prison IDs are not found in the lookup', () => {
+    // Given
+    const conditionDto = aValidConditionDto({ createdAtPrison: 'LEI', updatedAtPrison: 'LEI' })
+
+    const expected = aValidConditionDto({ createdAtPrison: 'LEI', updatedAtPrison: 'LEI' })
+
+    // When
+    const actual = mapPrisonNamesToReferencedAndAuditable(conditionDto, prisonNamesById)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.ts
+++ b/server/data/mappers/mapPrisonNamesToReferencedAndAuditable.ts
@@ -1,0 +1,16 @@
+import type { ReferencedAndAuditable } from 'dto'
+
+/**
+ * Mapper that takes any DTO that extends ReferencedAndAuditable, and a map of prison IDs to prison names; and maps the
+ * prison name into the createdAtPrison and updatedAtPrison properties.
+ */
+const mapPrisonNamesToReferencedAndAuditable = <T extends ReferencedAndAuditable>(
+  dto: T,
+  prisonNamesById: Map<string, string>,
+): T => ({
+  ...dto,
+  createdAtPrison: prisonNamesById.get(dto.createdAtPrison) || dto.createdAtPrison,
+  updatedAtPrison: prisonNamesById.get(dto.updatedAtPrison) || dto.updatedAtPrison,
+})
+
+export default mapPrisonNamesToReferencedAndAuditable

--- a/server/routes/profile/conditions/index.ts
+++ b/server/routes/profile/conditions/index.ts
@@ -5,11 +5,11 @@ import { Services } from '../../../services'
 import retrieveConditions from '../middleware/retrieveConditions'
 
 const conditionsRoutes = (services: Services): Router => {
-  const { conditionService } = services
+  const { conditionService, prisonService } = services
   const controller = new ConditionsController()
 
   return Router({ mergeParams: true }) //
-    .get('/', [retrieveConditions(conditionService), asyncMiddleware(controller.getConditionsView)])
+    .get('/', [retrieveConditions(conditionService, prisonService), asyncMiddleware(controller.getConditionsView)])
 }
 
 export default conditionsRoutes

--- a/server/routes/profile/middleware/retrieveConditions.ts
+++ b/server/routes/profile/middleware/retrieveConditions.ts
@@ -1,18 +1,36 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import { ConditionService } from '../../../services'
+import { ConditionService, PrisonService } from '../../../services'
 import { Result } from '../../../utils/result/result'
+import mapPrisonNamesToReferencedAndAuditable from '../../../data/mappers/mapPrisonNamesToReferencedAndAuditable'
 
 /**
  *  Function that returns a middleware function to retrieve the prisoner's Conditions
  */
-const retrieveConditions = (conditionService: ConditionService): RequestHandler => {
+const retrieveConditions = (conditionService: ConditionService, prisonService: PrisonService): RequestHandler => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
     const { username } = req.user
 
     // Lookup the prisoner's Conditions and store in res.locals
     const { apiErrorCallback } = res.locals
-    res.locals.conditions = await Result.wrap(conditionService.getConditions(username, prisonNumber), apiErrorCallback)
+
+    const retrieveConditionsPromise = new Promise((resolve, reject) => {
+      conditionService
+        .getConditions(username, prisonNumber)
+        .then(conditionsList => {
+          prisonService.getAllPrisonNamesById(username).then(prisonNamesById =>
+            resolve({
+              ...conditionsList,
+              conditions: conditionsList.conditions.map(condition =>
+                mapPrisonNamesToReferencedAndAuditable(condition, prisonNamesById),
+              ),
+            }),
+          )
+        })
+        .catch(err => reject(err))
+    })
+
+    res.locals.conditions = await Result.wrap(retrieveConditionsPromise, apiErrorCallback)
 
     return next()
   }


### PR DESCRIPTION
## POC 3 for looking up prison names

**This PR is for discussion - DO NOT MERGE**

----

This PR implements the prison lookup within the middleware by using a second mapper to re-map the data returned from the service layer.

The basic idea is that the `PrisonService` is wired into the middleware function eg: `retrieveConditions`. The middleware function calls the existing service method eg: `getConditions` which returns DTOs where the `createdAtPrison` and `updatedAtPrison` properties are prison IDs.  It then calls the `PrisonService` to get the prison ID to prison name map (`PrisonService` caches this internally, so no worries about repeated / inefficient calls), and then re-maps the DTOs via the new mapper `mapPrisonNamesToReferencedAndAuditable` which changes the 2 properties to the looked up prison names.

Pros:
* It works
* Conceptually simple (though the actual impl in the middleware is complex - see cons)
* Does not involve any changes to the service layer; UI concerns not coupled into the service layer
* Feels like a better separation of concerns?
* We don't have to make this change to all of Challenges, Strengths and Conditions in one change (as we would have to with POC 1)

Cons:
* Complex and messy promise handling in the middleware function (ie. nested callback hell!), though we might be able to improve this?