### PR TITLE
RR-1802 - Middleware function to allow retrieval of prison name lookup data

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,6 +5,7 @@ import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import manageUsersApi from './manageUsersApi'
 import supportAdditionalNeedsApi from './supportAdditionalNeedsApi'
+import prisonRegisterApi from './prisonRegisterApi'
 import stubPing from './common'
 
 interface UserToken {
@@ -109,7 +110,7 @@ export default {
   stubAuthPing: stubPing('auth'),
   stubSignIn: (
     userToken: UserToken = {},
-  ): Promise<[Response, Response, Response, Response, Response, Response, Response]> =>
+  ): Promise<[Response, Response, Response, Response, Response, Response, Response, Response]> =>
     Promise.all([
       favicon(),
       redirect(),
@@ -118,5 +119,6 @@ export default {
       tokenVerification.stubVerifyToken(),
       manageUsersApi.stubGetUserCaseloads(),
       supportAdditionalNeedsApi.stubSearchByPrison(),
+      prisonRegisterApi.stubGetAllPrisons(),
     ]),
 }

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 
   jest.resetAllMocks()
 
-  prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([['BXI', 'Brixton (HMP)']]))
+  prisonService.getAllPrisonNamesById.mockResolvedValue({ BXI: 'Brixton (HMP)' })
 })
 
 describe('auditMiddleware', () => {

--- a/server/routes/middleware/retrievePrisonsLookup.test.ts
+++ b/server/routes/middleware/retrievePrisonsLookup.test.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express'
+import PrisonService from '../../services/prisonService'
+import retrievePrisonsLookup from './retrievePrisonsLookup'
+
+jest.mock('../../services/prisonService')
+
+describe('retrievePrisonsLookup', () => {
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
+  const requestHandler = retrievePrisonsLookup(prisonService)
+
+  const username = 'a-dps-user'
+
+  const apiErrorCallback = jest.fn()
+  const req = {
+    user: { username },
+  } as unknown as Request
+  const res = {
+    render: jest.fn(),
+    locals: {},
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    res.locals = { user: undefined, apiErrorCallback }
+  })
+
+  it('should retrieve Conditions and store on res.locals', async () => {
+    // Given
+    const prisonNamesById = {
+      BXI: 'Brixton (HMP)',
+      MDI: 'Moorland (HMP & YOI)',
+    }
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.prisonNamesById.isFulfilled()).toEqual(true)
+    expect(res.locals.prisonNamesById.value).toEqual(prisonNamesById)
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
+    expect(next).toHaveBeenCalled()
+    expect(apiErrorCallback).not.toHaveBeenCalled()
+  })
+
+  it('should store un-fulfilled promise on res.locals given service returns an error', async () => {
+    // Given
+    const error = new Error('An error occurred')
+    prisonService.getAllPrisonNamesById.mockRejectedValue(error)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.prisonNamesById.isFulfilled()).toEqual(false)
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
+    expect(next).toHaveBeenCalled()
+    expect(apiErrorCallback).toHaveBeenCalledWith(error)
+  })
+})

--- a/server/routes/middleware/retrievePrisonsLookup.ts
+++ b/server/routes/middleware/retrievePrisonsLookup.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { PrisonService } from '../../services'
+import { Result } from '../../utils/result/result'
+
+/**
+ *  Function that returns a middleware function to retrieve all prison names by ID
+ */
+const retrievePrisonsLookup = (prisonService: PrisonService): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const { username } = req.user
+
+    // Lookup the prison names by ID and store in res.locals
+    const { apiErrorCallback } = res.locals
+    res.locals.prisonNamesById = await Result.wrap(prisonService.getAllPrisonNamesById(username), apiErrorCallback)
+
+    return next()
+  }
+}
+
+export default retrievePrisonsLookup

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -58,12 +58,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -78,12 +73,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -98,12 +88,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -118,7 +103,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(new Map())
+      expect(actual).toEqual({})
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -134,12 +119,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -15,15 +15,18 @@ export default class PrisonService {
   ) {}
 
   /**
-   * Returns a Map of prison id to prison name
+   * Returns a simple object of prison id to prison name
    */
-  async getAllPrisonNamesById(username: string): Promise<Map<string, string>> {
+  async getAllPrisonNamesById(username: string): Promise<Record<string, string>> {
     try {
       const prisons = (await this.getCachedPrisons()) || (await this.retrieveAndCacheActivePrisons(username))
-      return new Map(prisons.map(obj => [obj.prisonId, obj.prisonName]))
+      return prisons.reduce((acc, prison) => {
+        acc[prison.prisonId] = prison.prisonName
+        return acc
+      }, {})
     } catch (e) {
       logger.error(`Error looking up prisons`, e)
-      return new Map<string, string>()
+      return {}
     }
   }
 


### PR DESCRIPTION
PR based on POC [PR#210](https://github.com/ministryofjustice/hmpps-support-additional-needs-ui/pull/210) that introduces the middleware function and associated refactoring to allow routes to get prison data to pass into the view, therefore allowing the UI to perform prison name lookups