### PR TITLE
RR-1711 - Lookup prison names on Conditions profile page

### DIFF
--- a/server/routes/profile/conditions/conditionsController.test.ts
+++ b/server/routes/profile/conditions/conditionsController.test.ts
@@ -9,11 +9,12 @@ describe('conditionsController', () => {
 
   const prisonerSummary = aValidPrisonerSummary()
   const conditions = Result.fulfilled(aValidConditionsList())
+  const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
 
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary, conditions },
+    locals: { prisonerSummary, conditions, prisonNamesById },
   } as unknown as Response
   const next = jest.fn()
 
@@ -27,6 +28,7 @@ describe('conditionsController', () => {
     const expectedViewModel = {
       prisonerSummary,
       conditions,
+      prisonNamesById,
       tab: 'conditions',
     }
 

--- a/server/routes/profile/conditions/conditionsController.ts
+++ b/server/routes/profile/conditions/conditionsController.ts
@@ -2,8 +2,8 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default class ConditionsController {
   getConditionsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary, conditions } = res.locals
-    const viewRenderArgs = { prisonerSummary, conditions, tab: 'conditions' }
+    const { prisonerSummary, conditions, prisonNamesById } = res.locals
+    const viewRenderArgs = { prisonerSummary, conditions, prisonNamesById, tab: 'conditions' }
     return res.render('pages/profile/conditions/index', viewRenderArgs)
   }
 }

--- a/server/routes/profile/conditions/index.ts
+++ b/server/routes/profile/conditions/index.ts
@@ -3,13 +3,18 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ConditionsController from './conditionsController'
 import { Services } from '../../../services'
 import retrieveConditions from '../middleware/retrieveConditions'
+import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
 
 const conditionsRoutes = (services: Services): Router => {
-  const { conditionService } = services
+  const { conditionService, prisonService } = services
   const controller = new ConditionsController()
 
   return Router({ mergeParams: true }) //
-    .get('/', [retrieveConditions(conditionService), asyncMiddleware(controller.getConditionsView)])
+    .get('/', [
+      retrievePrisonsLookup(prisonService),
+      retrieveConditions(conditionService),
+      asyncMiddleware(controller.getConditionsView),
+    ])
 }
 
 export default conditionsRoutes

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/conditionsSummaryCard.test.njk
@@ -2,6 +2,7 @@
 
 {{ conditionsSummaryCard({
   conditions: conditions,
+  prisonNamesById: prisonNamesById,
   title: title,
   classes: classes,
   attributes: attributes

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/macro.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/macro.njk
@@ -3,10 +3,11 @@
 Data supplied to this marco:
   params: {
     conditions: Array<ConditionDto> - Pre-filtered array of conditions to render
+    prisonNamesById: Object of key value pairs, where the key is the prison ID, and the value is the prison name
     title: string - Summary Card title
     id: string
     classes: string
-    attributes: Map<string, string>
+    attributes: Object of key value pairs of additonal attributes to add the to the component
   }
 #}
 {% macro conditionsSummaryCard(params) %}

--- a/server/views/pages/profile/conditions/components/conditions-summary-card/template.njk
+++ b/server/views/pages/profile/conditions/components/conditions-summary-card/template.njk
@@ -27,7 +27,8 @@
             <p class="govuk-body app-u-multiline-text govuk-!-margin-bottom-2" data-qa="condition-details">{{ condition.conditionDetails }}</p>
 
             <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="condition-audit">
-              Added on {{ condition.updatedAt | formatDate('d MMMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ condition.updatedByDisplayName }}, {{ condition.updatedAtPrison }}</span>
+              {% set prisonName = params.prisonNamesById[condition.updatedAtPrison] | default(condition.updatedAtPrison) %}
+              Added on {{ condition.updatedAt | formatDate('d MMMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ condition.updatedByDisplayName }}, {{ prisonName }}</span>
             </p>
           </div>
         {% endfor %}

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -12,11 +12,12 @@
 
       {% if conditions.isFulfilled() %}
         {% set activeConditions = conditions.value.conditions | filterArrayOnProperty('active', true) %}
-
+        {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
         {% if activeConditions | length %}
 
           {{ conditionsSummaryCard({
             conditions: activeConditions | filterArrayOnProperty('source', 'CONFIRMED_DIAGNOSIS'),
+            prisonNamesById: prisonNamesById,
             title: 'Confirmed diagnoses',
             attributes: {
               'data-qa': 'diagnosed-conditions-summary-card'
@@ -25,6 +26,7 @@
 
           {{ conditionsSummaryCard({
             conditions: activeConditions | filterArrayOnProperty('source', 'SELF_DECLARED'),
+            prisonNamesById: prisonNamesById,
             title: 'Self-declared conditions',
             attributes: {
               'data-qa': 'self-declared-conditions-summary-card'

--- a/server/views/pages/profile/conditions/index.test.ts
+++ b/server/views/pages/profile/conditions/index.test.ts
@@ -32,6 +32,10 @@ const prisonerSummary = aValidPrisonerSummary({
   firstName: 'IFEREECA',
   lastName: 'PEIGH',
 })
+const prisonNamesById = {
+  BXI: 'Brixton (HMP)',
+  LEI: 'Leeds (HMP)',
+}
 const template = 'index.njk'
 
 const userHasPermissionTo = jest.fn()
@@ -40,6 +44,7 @@ const templateParams = {
   userHasPermissionTo,
   tab: 'conditions',
   conditions: Result.fulfilled(aValidConditionsList()),
+  prisonNamesById: Result.fulfilled(prisonNamesById),
   pageHasApiErrors: false,
 }
 


### PR DESCRIPTION
Calls the new prison lookup middleware in the Conditions route; lookup the prison name as part of rendering the view
(as per POC4 #210 )

<img width="1231" height="993" alt="Screenshot 2025-08-08 at 13 12 54" src="https://github.com/user-attachments/assets/a9286636-e618-4389-b9e2-427b3b5413e0" />
