### PR TITLE
RR-1741 - Added prison name to non-ALN strengths

### DIFF
--- a/server/views/pages/profile/strengths/components/strengths-summary-card/strengthsSummaryCard.test.ts
+++ b/server/views/pages/profile/strengths/components/strengths-summary-card/strengthsSummaryCard.test.ts
@@ -112,7 +112,7 @@ describe('Tests for Strengths Summary Card component', () => {
       `I have seen and experienced John's written text before`,
     ) // 'other' text
     expect(firstStrength.find('[data-qa=non-aln-strength-audit]').text().trim()).toEqual(
-      'Added on 10 February 2025 by Person 1',
+      'Added on 10 February 2025 by Person 1, Leeds (HMP)',
     )
 
     const secondStrength = nonAlnStrengths.eq(1)
@@ -122,7 +122,7 @@ describe('Tests for Strengths Summary Card component', () => {
       'Direct observation in education, skills and work',
     ) // EDUCATION_SKILLS_WORK
     expect(secondStrength.find('[data-qa=non-aln-strength-audit]').text().trim()).toEqual(
-      'Added on 10 February 2025 by Person 1',
+      'Added on 10 February 2025 by Person 1, Leeds (HMP)',
     )
 
     // assert ALN strengths
@@ -177,7 +177,7 @@ describe('Tests for Strengths Summary Card component', () => {
       `I have seen and experienced John's written text before`,
     ) // 'other' text
     expect(firstStrength.find('[data-qa=non-aln-strength-audit]').text().trim()).toEqual(
-      'Added on 10 February 2025 by Person 1',
+      'Added on 10 February 2025 by Person 1, Leeds (HMP)',
     )
 
     // assert ALN strengths

--- a/server/views/pages/profile/strengths/components/strengths-summary-card/template.njk
+++ b/server/views/pages/profile/strengths/components/strengths-summary-card/template.njk
@@ -45,7 +45,8 @@
             }) }}
 
             <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="non-aln-strength-audit">
-              Added on {{ strength.updatedAt | formatDate('d MMMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ strength.updatedByDisplayName }}</span>
+              {% set prisonName = params.prisonNamesById[strength.updatedAtPrison] | default(strength.updatedAtPrison) %}
+              Added on {{ strength.updatedAt | formatDate('d MMMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ strength.updatedByDisplayName }}, {{ prisonName }}</span>
             </p>
           </div>
         {% endfor %}


### PR DESCRIPTION
PR to add the prison name to the rendering of non-ALN strengths

<img width="1225" height="1160" alt="Screenshot 2025-08-14 at 13 41 15" src="https://github.com/user-attachments/assets/6dbee328-fe10-4a2c-9b89-c4ac4d640d8f" />
