### PR TITLE
RR-1751-list-empty-tweak

### DIFF
--- a/server/views/pages/profile/challenges/_challenges.njk
+++ b/server/views/pages/profile/challenges/_challenges.njk
@@ -2,27 +2,22 @@
 {% from "./components/challenges-summary-card/macro.njk" import challengesSummaryCard %}
 {% from "./components/challenges-summary-card/macro.njk" import alnChallengesSummaryCard %}
 
-{% if groupedChallenges %}
   {% for groupName, challengesData in groupedChallenges %}
-
-    <div class="govuk-summary-card" data-qa="challenges-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">{{ groupName | formatChallengeCategoryScreenValue }}</h2>
-      </div>
-
-      <div class="govuk-summary-card__content govuk-!-padding-top-0">
-        <div class="govuk-summary-list">
-          {% for challenge in challengesData.nonAlnChallenges %}
-                {{  challengesSummaryCard(challenge) }}
-          {% endfor %}
-          {% if challengesData.alnChallenges | length %}
-            {{  alnChallengesSummaryCard(challengesData.alnChallenges) }}
-          {% endif %}
-
+      <div class="govuk-summary-card" data-qa="challenges-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">{{ groupName | formatChallengeCategoryScreenValue }}</h2>
+        </div>
+        <div class="govuk-summary-card__content govuk-!-padding-top-0">
+          <div class="govuk-summary-list">
+            {% for challenge in challengesData.nonAlnChallenges %}
+                  {{  challengesSummaryCard(challenge) }}
+            {% endfor %}
+            {% if challengesData.alnChallenges | length %}
+              {{  alnChallengesSummaryCard(challengesData.alnChallenges) }}
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
   {% endfor %}
-{% endif %}
 
 

--- a/server/views/pages/profile/challenges/components/_noChallengesSummaryCard.njk
+++ b/server/views/pages/profile/challenges/components/_noChallengesSummaryCard.njk
@@ -1,0 +1,10 @@
+<div class="govuk-summary-card" data-qa="no-challenges-summary-card">
+  <div class="govuk-summary-card__content">
+    <p class="govuk-body">
+      No challenges recorded
+    </p>
+    {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+      <a class="govuk-link govuk-body" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category">Add challenge</a>
+    {% endif %}
+  </div>
+</div>

--- a/server/views/pages/profile/challenges/index.njk
+++ b/server/views/pages/profile/challenges/index.njk
@@ -8,9 +8,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       <h2 class="govuk-heading-m">Challenges</h2>
-        {% if groupedChallenges.isFulfilled() %}
-          {% set groupedChallenges = groupedChallenges.value %}
-          {% include "./_challenges.njk" %}
+      {% if groupedChallenges.isFulfilled() %}
+        {% set groupedChallenges = groupedChallenges.value %}
+          {% if groupedChallenges | length == 0 %}
+            {% include "./components/_noChallengesSummaryCard.njk" %}
+          {% else %}
+            {% include "./_challenges.njk" %}
+          {% endif %}
+      {% else %}
+            <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
+            <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
       {% endif %}
     </div>
 


### PR DESCRIPTION
Small change to show the 'add challenge' card when there are no recorded challenges. 
And to also display some error text in the event that either the screener or challenges calls to the API have failed.

* Cypress tests to cover this to be added in a later PR.