### PR TITLE
RR-1685 - Fixed typo on Strengths detail page

### DIFF
--- a/server/views/pages/strengths/detail/index.njk
+++ b/server/views/pages/strengths/detail/index.njk
@@ -24,7 +24,7 @@
             value: form.description,
             type: "text",
             label: {
-              text: "Description of text",
+              text: "Description of strength",
               classes: "govuk-label--m",
               attributes: { "aria-live": "polite" }
             },


### PR DESCRIPTION
Fixed typo on Strengths detail page

### With typo:
<img width="1240" height="1165" alt="Screenshot 2025-08-18 at 15 26 41" src="https://github.com/user-attachments/assets/ef6086ee-f77f-4dae-b70c-eaeb91ba9ae1" />

### With fix:
<img width="1241" height="1132" alt="Screenshot 2025-08-18 at 15 27 47" src="https://github.com/user-attachments/assets/0937b3c0-1470-4c93-9136-45cefe87bbff" />
