### PR TITLE
RR-1757 - Get and sort strength categories

### DIFF
--- a/server/routes/profile/overview/index.ts
+++ b/server/routes/profile/overview/index.ts
@@ -4,15 +4,20 @@ import OverviewController from './overviewController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import retrieveCurrentEducationSupportPlanCreationSchedule from '../middleware/retrieveCurrentEducationSupportPlanCreationSchedule'
 import retrieveConditions from '../middleware/retrieveConditions'
+import retrieveStrengths from '../middleware/retrieveStrengths'
+import retrieveAlnScreeners from '../middleware/retrieveAlnScreeners'
 
 const overviewRoutes = (services: Services): Router => {
-  const { conditionService, educationSupportPlanScheduleService } = services
+  const { additionalLearningNeedsService, conditionService, educationSupportPlanScheduleService, strengthService } =
+    services
   const controller = new OverviewController()
 
   return Router({ mergeParams: true }) //
     .get('/', [
       retrieveCurrentEducationSupportPlanCreationSchedule(educationSupportPlanScheduleService),
+      retrieveAlnScreeners(additionalLearningNeedsService),
       retrieveConditions(conditionService),
+      retrieveStrengths(strengthService),
       asyncMiddleware(controller.getOverviewView),
     ])
 }

--- a/server/routes/profile/overview/overviewController.test.ts
+++ b/server/routes/profile/overview/overviewController.test.ts
@@ -4,6 +4,14 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
 import { Result } from '../../../utils/result/result'
 import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataBuilder'
+import {
+  setupAlnScreenersPromise,
+  setupAlnStrengths,
+  setupNonAlnStrengths,
+  setupNonAlnStrengthsPromise,
+} from '../profileTestSupportFunctions'
+import { aValidAlnScreenerResponseDto } from '../../../testsupport/alnScreenerDtoTestDataBuilder'
+import StrengthCategory from '../../../enums/strengthCategory'
 
 describe('overviewController', () => {
   const controller = new OverviewController()
@@ -12,26 +20,128 @@ describe('overviewController', () => {
   const educationSupportPlanCreationSchedule = Result.fulfilled(aValidPlanCreationScheduleDto())
   const conditions = Result.fulfilled(aValidConditionsList())
 
+  // Non-ALN strengths
+  const { numeracy, numeracy2, literacy, emotionsNonActive, attention, speaking } = setupNonAlnStrengths()
+  const strengths = setupNonAlnStrengthsPromise({
+    strengths: [numeracy, numeracy2, literacy, emotionsNonActive, attention, speaking],
+  })
+
+  // Latest ALN strengths
+  const { reading, writing, alphabetOrdering, wordFindingNonActive, arithmetic, focussing, tidiness } =
+    setupAlnStrengths()
+  const latestScreener = aValidAlnScreenerResponseDto({
+    strengths: [reading, writing, wordFindingNonActive, arithmetic, focussing, tidiness, alphabetOrdering],
+  })
+  const alnScreeners = setupAlnScreenersPromise({ latestScreener })
+
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary, educationSupportPlanCreationSchedule, conditions },
+    locals: { prisonerSummary, educationSupportPlanCreationSchedule, conditions, strengths, alnScreeners },
   } as unknown as Response
   const next = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
+    res.locals.strengths = strengths
+    res.locals.alnScreeners = alnScreeners
   })
 
   it('should render the view', async () => {
     // Given
     const expectedViewTemplate = 'pages/profile/overview/index'
-    const expectedViewModel = {
+    const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       educationSupportPlanCreationSchedule,
       conditions,
       tab: 'overview',
-    }
+      strengthCategories: expect.objectContaining({
+        status: 'fulfilled',
+        value: [
+          StrengthCategory.ATTENTION_ORGANISING_TIME,
+          StrengthCategory.LANGUAGE_COMM_SKILLS,
+          StrengthCategory.LITERACY_SKILLS,
+          StrengthCategory.NUMERACY_SKILLS,
+        ],
+      }),
+    })
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render the view given the strengths promise is not resolved', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+
+    const expectedError = new Error('Some error retrieving strengths')
+    res.locals.strengths = Result.rejected(expectedError)
+
+    const expectedViewModel = expect.objectContaining({
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      conditions,
+      tab: 'overview',
+      strengthCategories: expect.objectContaining({
+        status: 'rejected',
+        reason: expectedError,
+      }),
+    })
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render the view given the ALN Screeners promise is not resolved', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+
+    const expectedError = new Error('Some error retrieving ALN Screeners')
+    res.locals.alnScreeners = Result.rejected(expectedError)
+
+    const expectedViewModel = expect.objectContaining({
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      conditions,
+      tab: 'overview',
+      strengthCategories: expect.objectContaining({
+        status: 'rejected',
+        reason: expectedError,
+      }),
+    })
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render the view given both the Strengths and ALN Screeners promises are not resolved', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+
+    res.locals.strengths = Result.rejected(new Error('Some error retrieving strengths'))
+    res.locals.alnScreeners = Result.rejected(new Error('Some error retrieving ALN Screeners'))
+
+    const expectedError = new Error('Some error retrieving ALN Screeners, Some error retrieving strengths')
+
+    const expectedViewModel = expect.objectContaining({
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      conditions,
+      tab: 'overview',
+      strengthCategories: expect.objectContaining({
+        status: 'rejected',
+        reason: expectedError,
+      }),
+    })
 
     // When
     await controller.getOverviewView(req, res, next)

--- a/server/routes/profile/overview/overviewController.ts
+++ b/server/routes/profile/overview/overviewController.ts
@@ -1,9 +1,41 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { Result } from '../../../utils/result/result'
+import StrengthCategory from '../../../enums/strengthCategory'
+import {
+  getActiveStrengthsFromAlnScreener,
+  getLatestAlnScreener,
+  getNonAlnActiveStrengths,
+  reWrapRejectedPromises,
+} from '../profileStrengthsFunctions'
+import enumComparator from '../../enumComparator'
 
 export default class OverviewController {
   getOverviewView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary, conditions, educationSupportPlanCreationSchedule } = res.locals
-    const viewRenderArgs = { prisonerSummary, conditions, educationSupportPlanCreationSchedule, tab: 'overview' }
+    const { prisonerSummary, alnScreeners, conditions, educationSupportPlanCreationSchedule, strengths } = res.locals
+
+    let strengthCategoriesPromise: Result<Array<StrengthCategory>, Error>
+    if (alnScreeners.isFulfilled() && strengths.isFulfilled()) {
+      const nonAlnStrengths = getNonAlnActiveStrengths(strengths)
+      const latestAlnScreener = getLatestAlnScreener(alnScreeners)
+      const strengthsFromLatestAlnScreener = getActiveStrengthsFromAlnScreener(latestAlnScreener)
+
+      const strengthCategories = Array.from(
+        new Set(nonAlnStrengths.concat(strengthsFromLatestAlnScreener).map(strength => strength.strengthCategory)),
+      ).sort(enumComparator)
+      strengthCategoriesPromise = Result.fulfilled(strengthCategories)
+    } else {
+      // At least one of the API calls has failed; we need data from both APIs in order to properly render the Strengths page
+      // Set the groupedStrengths to be a rejected Result containing the error message(s) from the original rejected promise(s)
+      strengthCategoriesPromise = reWrapRejectedPromises(alnScreeners, strengths)
+    }
+
+    const viewRenderArgs = {
+      prisonerSummary,
+      conditions,
+      educationSupportPlanCreationSchedule,
+      strengthCategories: strengthCategoriesPromise,
+      tab: 'overview',
+    }
     return res.render('pages/profile/overview/index', viewRenderArgs)
   }
 }

--- a/server/routes/profile/profileStrengthsFunctions.ts
+++ b/server/routes/profile/profileStrengthsFunctions.ts
@@ -1,0 +1,30 @@
+import type { AlnScreenerList, AlnScreenerResponseDto, StrengthResponseDto, StrengthsList } from 'dto'
+import { Result } from '../../utils/result/result'
+import dateComparator from '../dateComparator'
+
+const getNonAlnActiveStrengths = (strengths: Result<StrengthsList>): Array<StrengthResponseDto> =>
+  strengths.getOrNull()?.strengths.filter(strength => strength.active && !strength.fromALNScreener) ?? []
+
+const getLatestAlnScreener = (screeners: Result<AlnScreenerList>): AlnScreenerResponseDto =>
+  screeners
+    .getOrNull()
+    .screeners.sort((left: AlnScreenerResponseDto, right: AlnScreenerResponseDto) =>
+      dateComparator(left.screenerDate, right.screenerDate, 'DESC'),
+    )[0]
+
+const getActiveStrengthsFromAlnScreener = (alnScreener: AlnScreenerResponseDto): Array<StrengthResponseDto> =>
+  alnScreener?.strengths.filter(strength => strength.active && strength.fromALNScreener) ?? []
+
+const reWrapRejectedPromises = <T>(
+  alnScreeners: Result<AlnScreenerList>,
+  strengths: Result<StrengthsList>,
+): Result<T> => {
+  const apiErrorMessages = [alnScreeners, strengths]
+    .map(result => (!result.isFulfilled() ? result : null))
+    .filter(result => result != null)
+    .map(result => result.getOrHandle(error => error.message))
+    .join(', ')
+  return Result.rejected(new Error(apiErrorMessages))
+}
+
+export { getNonAlnActiveStrengths, getLatestAlnScreener, getActiveStrengthsFromAlnScreener, reWrapRejectedPromises }

--- a/server/routes/profile/profileTestSupportFunctions.ts
+++ b/server/routes/profile/profileTestSupportFunctions.ts
@@ -1,0 +1,139 @@
+import { startOfToday, subDays } from 'date-fns'
+import type { AlnScreenerResponseDto, StrengthResponseDto } from 'dto'
+import { aValidStrengthResponseDto, aValidStrengthsList } from '../../testsupport/strengthResponseDtoTestDataBuilder'
+import StrengthType from '../../enums/strengthType'
+import StrengthCategory from '../../enums/strengthCategory'
+import { Result } from '../../utils/result/result'
+import { aValidAlnScreenerList, aValidAlnScreenerResponseDto } from '../../testsupport/alnScreenerDtoTestDataBuilder'
+
+const today = startOfToday()
+
+export function setupNonAlnStrengths() {
+  const numeracy = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.NUMERACY_SKILLS_DEFAULT,
+    strengthCategory: StrengthCategory.NUMERACY_SKILLS,
+    symptoms: 'Can add up really well',
+    fromALNScreener: false,
+    active: true,
+    updatedAt: subDays(today, 5),
+  })
+  const numeracy2 = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.NUMERACY_SKILLS_DEFAULT,
+    strengthCategory: StrengthCategory.NUMERACY_SKILLS,
+    symptoms: 'Can subtract really well',
+    fromALNScreener: false,
+    active: true,
+    updatedAt: subDays(today, 3),
+  })
+  const literacy = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.LITERACY_SKILLS_DEFAULT,
+    strengthCategory: StrengthCategory.LITERACY_SKILLS,
+    fromALNScreener: false,
+    active: true,
+    updatedAt: subDays(today, 1),
+  })
+  const emotionsNonActive = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.EMOTIONS_FEELINGS_DEFAULT,
+    strengthCategory: StrengthCategory.EMOTIONS_FEELINGS,
+    fromALNScreener: false,
+    active: false,
+    updatedAt: subDays(today, 1),
+  })
+  const attention = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.ATTENTION_ORGANISING_TIME_DEFAULT,
+    strengthCategory: StrengthCategory.ATTENTION_ORGANISING_TIME,
+    fromALNScreener: false,
+    active: true,
+    updatedAt: subDays(today, 10),
+  })
+  const speaking = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.SPEAKING,
+    strengthCategory: StrengthCategory.LANGUAGE_COMM_SKILLS,
+    fromALNScreener: false,
+    active: true,
+    updatedAt: subDays(today, 2),
+  })
+
+  return { numeracy, numeracy2, literacy, emotionsNonActive, attention, speaking }
+}
+
+export function setupAlnStrengths() {
+  const reading = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.READING,
+    strengthCategory: StrengthCategory.LITERACY_SKILLS,
+    fromALNScreener: true,
+    active: true,
+  })
+  const writing = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.WRITING,
+    strengthCategory: StrengthCategory.LITERACY_SKILLS,
+    fromALNScreener: true,
+    active: true,
+  })
+  const alphabetOrdering = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.ALPHABET_ORDERING,
+    strengthCategory: StrengthCategory.LITERACY_SKILLS,
+    fromALNScreener: true,
+    active: true,
+  })
+  const wordFindingNonActive = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.WORD_FINDING,
+    strengthCategory: StrengthCategory.LITERACY_SKILLS,
+    fromALNScreener: true,
+    active: false,
+  })
+  const arithmetic = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.ARITHMETIC,
+    strengthCategory: StrengthCategory.NUMERACY_SKILLS,
+    fromALNScreener: true,
+    active: true,
+  })
+  const focussing = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.FOCUSING,
+    strengthCategory: StrengthCategory.ATTENTION_ORGANISING_TIME,
+    fromALNScreener: true,
+    active: true,
+  })
+  const tidiness = aValidStrengthResponseDto({
+    strengthTypeCode: StrengthType.TIDINESS,
+    strengthCategory: StrengthCategory.ATTENTION_ORGANISING_TIME,
+    fromALNScreener: true,
+    active: true,
+  })
+
+  return { reading, writing, alphabetOrdering, wordFindingNonActive, arithmetic, focussing, tidiness }
+}
+
+export function setupNonAlnStrengthsPromise(
+  options: {
+    strengths?: Array<StrengthResponseDto>
+  } = { strengths: Object.values(setupNonAlnStrengths()) },
+) {
+  return Result.fulfilled(aValidStrengthsList({ strengths: options.strengths }))
+}
+
+export function setupAlnScreenersPromise(
+  options: {
+    latestScreener?: AlnScreenerResponseDto
+  } = {
+    latestScreener: aValidAlnScreenerResponseDto({
+      screenerDate: startOfToday(),
+      createdAtPrison: 'BXI',
+      strengths: Object.values(setupAlnStrengths()),
+    }),
+  },
+) {
+  const latestScreenerDate = options.latestScreener.screenerDate
+  return Result.fulfilled(
+    aValidAlnScreenerList({
+      screeners: [
+        // Latest screener
+        options.latestScreener,
+        // Screener from yesterday
+        aValidAlnScreenerResponseDto({ screenerDate: subDays(latestScreenerDate, 1) }),
+        // Screener from the day before yesterday
+        aValidAlnScreenerResponseDto({ screenerDate: subDays(latestScreenerDate, 2) }),
+      ],
+    }),
+  )
+}


### PR DESCRIPTION
PR to get and sort the strength categories to be able to render them on the Overview page
(This PR does not do the actual rendering on the page yet, that will be in the next PR)

The requirements for displaying Strengths on the Overview page are:
* Get the non-ALN screener strengths
* Get the strengths from the latest ALN screener
* Combine the 2 lists of strengths, flatten the list to just the list of strength categories, remove any duplicates, and sort alphabetically

This is very similar to what we already do on the Strengths page in respect of getting the non ALN strengths and the strengths from the latest ALN screener

So this PR does some refactoring of the StrengthsController and it's test to move the common stuff (common between Strengths and Overview) into some common files