### PR TITLE
RR-1756 Fix logic for handling errors 

### DIFF
--- a/server/routes/profile/overview/overviewController.test.ts
+++ b/server/routes/profile/overview/overviewController.test.ts
@@ -241,4 +241,78 @@ describe('overviewController', () => {
     // Then
     expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
   })
+
+  it('should render the view with challenges, when an error occurs with strengths', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+
+    // Strengths has failed
+    res.locals.strengths = Result.rejected(new Error('Some error retrieving strengths'))
+
+    const expectedError = new Error('Some error retrieving strengths')
+
+    const expectedViewModel = expect.objectContaining({
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      conditions,
+      curiousAlnAndLddAssessments,
+      tab: 'overview',
+      strengthCategories: expect.objectContaining({
+        status: 'rejected',
+        reason: expectedError,
+      }),
+      challengeCategories: expect.objectContaining({
+        status: 'fulfilled',
+        value: [
+          ChallengeCategory.ATTENTION_ORGANISING_TIME,
+          ChallengeCategory.LANGUAGE_COMM_SKILLS,
+          ChallengeCategory.LITERACY_SKILLS,
+          ChallengeCategory.NUMERACY_SKILLS,
+        ],
+      }),
+    })
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+
+  it('should render the view with strengths, when an error occurs with challenges', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/overview/index'
+
+    // Challenges has failed
+    res.locals.challenges = Result.rejected(new Error('Some error retrieving challenges'))
+
+    const expectedError = new Error('Some error retrieving challenges')
+
+    const expectedViewModel = expect.objectContaining({
+      prisonerSummary,
+      educationSupportPlanCreationSchedule,
+      conditions,
+      curiousAlnAndLddAssessments,
+      tab: 'overview',
+      challengeCategories: expect.objectContaining({
+        status: 'rejected',
+        reason: expectedError,
+      }),
+      strengthCategories: expect.objectContaining({
+        status: 'fulfilled',
+        value: [
+          ChallengeCategory.ATTENTION_ORGANISING_TIME,
+          ChallengeCategory.LANGUAGE_COMM_SKILLS,
+          ChallengeCategory.LITERACY_SKILLS,
+          ChallengeCategory.NUMERACY_SKILLS,
+        ],
+      }),
+    })
+
+    // When
+    await controller.getOverviewView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
 })


### PR DESCRIPTION
* Apply logic fix for when data retrieval fails for strengths/challenges/alnScreeners
* Challenge categories should still display when challenges and screener results are fulfilled (irrespective of strengths)
* Strengths categories should still display when strengths and screener results are fulfilled (irrespective of challenges)