### PR TITLE
RR-1751 Update to use screenerdate as opposed to createdAt date

### DIFF
--- a/server/views/pages/profile/challenges/components/challenges-summary-card/aln_template.njk
+++ b/server/views/pages/profile/challenges/components/challenges-summary-card/aln_template.njk
@@ -21,7 +21,7 @@
         </ul>
         {% set prisonName = prisonNamesById[alnChallenges[0].updatedAtPrison] | default(alnChallenges[0].updatedAtPrison) %}
         <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="aln-challenge-audit">
-          From Additional Learning Needs Screener completed on {{ alnChallenges[0].updatedAt | formatDate('d MMMM yyyy') }}, {{ prisonName }}
+          From Additional Learning Needs Screener completed on {{ alnChallenges[0].alnScreenerDate | formatDate('d MMMM yyyy') }}, {{ prisonName }}
         </p>
     </div>
 {% endif %}

--- a/server/views/pages/profile/challenges/components/challenges-summary-card/challengesSummaryCard.test.ts
+++ b/server/views/pages/profile/challenges/components/challenges-summary-card/challengesSummaryCard.test.ts
@@ -106,6 +106,7 @@ describe('Tests for Challenges Summary Card component', () => {
         updatedAt: parseISO('2025-02-15'),
         updatedByDisplayName: 'Person 3',
         updatedAtPrison: 'BXI',
+        alnScreenerDate: parseISO('2025-02-12'),
       }),
     ]
 
@@ -127,7 +128,7 @@ describe('Tests for Challenges Summary Card component', () => {
       challengeStaffSupportTextLookupFilter(ChallengeType.COMMUNICATION),
     )
     expect(challengeRowElement.find('[data-qa=aln-challenge-audit]').text().trim()).toEqual(
-      'From Additional Learning Needs Screener completed on 15 February 2025, Brixton (HMP)',
+      'From Additional Learning Needs Screener completed on 12 February 2025, Brixton (HMP)',
     )
   })
 


### PR DESCRIPTION
* Display the ALN Screener Date as opposed to the creation date for ALN Screener created challenges 