### PR TITLE
RR-1808 - Wire in middleware; add link to create plan when plan is due or overdue

### DIFF
--- a/integration_tests/e2e/profile/overview.cy.ts
+++ b/integration_tests/e2e/profile/overview.cy.ts
@@ -26,6 +26,7 @@ context('Profile Overview Page', () => {
     cy.task('stubGetStrengths', { prisonNumber })
     cy.task('stubGetCuriousV2Assessments', { prisonNumber })
     cy.task('stubGetEducationSupportPlan', prisonNumber)
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
 
   it('should be able to navigate directly to the profile overview page', () => {

--- a/integration_tests/mockApis/supportAdditionalNeedsApi/index.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi/index.ts
@@ -8,6 +8,7 @@ import supportStrategiesEndpoints from './supportStrategiesEndpoints'
 import educationSupportPlanEndpoints from './educationSupportPlanEndpoints'
 import educationSupportPlanCreationScheduleEndpoints from './educationSupportPlanCreationScheduleEndpoints'
 import additionalLearningNeedsScreenerEndpoints from './additionalLearningNeedsScreenerEndpoints'
+import planActionStatusEndpoints from './planActionStatusEndpoints'
 
 export default {
   stubSupportAdditionalNeedsApiPing: stubPing('support-additional-needs-api'),
@@ -20,4 +21,5 @@ export default {
   ...educationSupportPlanEndpoints,
   ...educationSupportPlanCreationScheduleEndpoints,
   ...additionalLearningNeedsScreenerEndpoints,
+  ...planActionStatusEndpoints,
 }

--- a/integration_tests/mockApis/supportAdditionalNeedsApi/planActionStatusEndpoints.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi/planActionStatusEndpoints.ts
@@ -1,0 +1,45 @@
+import { SuperAgentRequest } from 'superagent'
+import type { PlanActionStatus } from 'supportAdditionalNeedsApiClient'
+import { stubFor } from '../wiremock'
+
+const stubGetPlanActionStatus = (
+  options: { prisonNumber?: string; planActionStatus?: PlanActionStatus } = { prisonNumber: 'G6115VJ' },
+): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/support-additional-needs-api/profile/${options.prisonNumber}/plan-action-status`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: options.planActionStatus ?? {
+        status: 'PLAN_DECLINED',
+        planCreationDeadlineDate: '2025-10-01',
+        reviewDeadlineDate: null,
+        exemptionReason: 'EXEMPT_REFUSED_TO_ENGAGE',
+        exemptionDetail: 'Chris feels he does not need a support plan',
+      },
+    },
+  })
+
+const stubGetPlanActionStatus500Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/support-additional-needs-api/profile/${prisonNumber}/plan-action-status`,
+    },
+    response: {
+      status: 500,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 500,
+        errorCode: null,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+        moreInfo: null,
+      },
+    },
+  })
+
+export default { stubGetPlanActionStatus, stubGetPlanActionStatus500Error }

--- a/server/routes/profile/education-support-plan/educationSupportPlanController.test.ts
+++ b/server/routes/profile/education-support-plan/educationSupportPlanController.test.ts
@@ -2,17 +2,20 @@ import { Request, Response } from 'express'
 import EducationSupportPlanController from './educationSupportPlanController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidEducationSupportPlanDto from '../../../testsupport/educationSupportPlanDtoTestDataBuilder'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
+import { Result } from '../../../utils/result/result'
 
 describe('educationSupportPlanController', () => {
   const controller = new EducationSupportPlanController()
 
   const prisonerSummary = aValidPrisonerSummary()
-  const educationSupportPlan = aValidEducationSupportPlanDto()
+  const educationSupportPlan = Result.fulfilled(aValidEducationSupportPlanDto())
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
 
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary, educationSupportPlan },
+    locals: { prisonerSummary, educationSupportPlan, educationSupportPlanLifecycleStatus },
   } as unknown as Response
   const next = jest.fn()
 
@@ -26,6 +29,7 @@ describe('educationSupportPlanController', () => {
     const expectedViewModel = {
       prisonerSummary,
       educationSupportPlan,
+      educationSupportPlanLifecycleStatus,
       tab: 'education-support-plan',
     }
 

--- a/server/routes/profile/education-support-plan/educationSupportPlanController.ts
+++ b/server/routes/profile/education-support-plan/educationSupportPlanController.ts
@@ -2,8 +2,13 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default class EducationSupportPlanController {
   getEducationSupportPlanView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary, educationSupportPlan } = res.locals
-    const viewRenderArgs = { prisonerSummary, educationSupportPlan, tab: 'education-support-plan' }
+    const { prisonerSummary, educationSupportPlan, educationSupportPlanLifecycleStatus } = res.locals
+    const viewRenderArgs = {
+      prisonerSummary,
+      educationSupportPlan,
+      educationSupportPlanLifecycleStatus,
+      tab: 'education-support-plan',
+    }
     return res.render('pages/profile/education-support-plan/index', viewRenderArgs)
   }
 }

--- a/server/routes/profile/education-support-plan/index.ts
+++ b/server/routes/profile/education-support-plan/index.ts
@@ -3,6 +3,7 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import EducationSupportPlanController from './educationSupportPlanController'
 import retrieveEducationSupportPlan from '../middleware/retrieveEducationSupportPlan'
 import { Services } from '../../../services'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
 
 const educationSupportPlanRoutes = (services: Services): Router => {
   const { educationSupportPlanService } = services
@@ -10,6 +11,7 @@ const educationSupportPlanRoutes = (services: Services): Router => {
 
   return Router({ mergeParams: true }) //
     .get('/', [
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
       retrieveEducationSupportPlan(educationSupportPlanService),
       asyncMiddleware(controller.getEducationSupportPlanView),
     ])

--- a/server/routes/profile/middleware/retrieveEducationSupportPlanLifecycleStatus.test.ts
+++ b/server/routes/profile/middleware/retrieveEducationSupportPlanLifecycleStatus.test.ts
@@ -37,8 +37,8 @@ describe('retrieveEducationSupportPlanLifecycleStatus', () => {
     await requestHandler(req, res, next)
 
     // Then
-    expect(res.locals.educationSupportPlanlifecycleStatus.isFulfilled()).toEqual(true)
-    expect(res.locals.educationSupportPlanlifecycleStatus.value).toEqual(expectedPlanCreationSchedule)
+    expect(res.locals.educationSupportPlanLifecycleStatus.isFulfilled()).toEqual(true)
+    expect(res.locals.educationSupportPlanLifecycleStatus.value).toEqual(expectedPlanCreationSchedule)
     expect(educationSupportPlanService.getEducationSupportPlanLifecycleStatus).toHaveBeenCalledWith(
       username,
       prisonNumber,
@@ -56,7 +56,7 @@ describe('retrieveEducationSupportPlanLifecycleStatus', () => {
     await requestHandler(req, res, next)
 
     // Then
-    expect(res.locals.educationSupportPlanlifecycleStatus.isFulfilled()).toEqual(false)
+    expect(res.locals.educationSupportPlanLifecycleStatus.isFulfilled()).toEqual(false)
     expect(educationSupportPlanService.getEducationSupportPlanLifecycleStatus).toHaveBeenCalledWith(
       username,
       prisonNumber,

--- a/server/routes/profile/middleware/retrieveEducationSupportPlanLifecycleStatus.ts
+++ b/server/routes/profile/middleware/retrieveEducationSupportPlanLifecycleStatus.ts
@@ -14,7 +14,7 @@ const retrieveEducationSupportPlanLifecycleStatus = (
 
     // Lookup the prisoner's ELSP Lifecycle Status and store in res.locals
     const { apiErrorCallback } = res.locals
-    res.locals.educationSupportPlanlifecycleStatus = await Result.wrap(
+    res.locals.educationSupportPlanLifecycleStatus = await Result.wrap(
       educationSupportPlanService.getEducationSupportPlanLifecycleStatus(username, prisonNumber),
       apiErrorCallback,
     )

--- a/server/views/pages/profile/education-support-plan/index.njk
+++ b/server/views/pages/profile/education-support-plan/index.njk
@@ -5,9 +5,12 @@
 
 {% block content %}
   <div class="govuk-grid-row profile-education-support-plan">
-    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
-      {% if educationSupportPlan.isFulfilled() %}
-        {% set educationSupportPlan = educationSupportPlan.value %}
+
+    {% if educationSupportPlan.isFulfilled() and educationSupportPlanLifecycleStatus.isFulfilled() %}
+      {% set educationSupportPlan = educationSupportPlan.value %}
+      {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value %}
+
+      <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
         {% if educationSupportPlan %}
 
@@ -104,29 +107,34 @@
               <p class="govuk-body">
                 No education support plan recorded
               </p>
+              {% if educationSupportPlanLifecycleStatus.status === 'PLAN_DUE' or educationSupportPlanLifecycleStatus.status === 'PLAN_OVERDUE' %}
+                <p class="govuk-body">
+                  <a class="govuk-link" href="/education-support-plan/{{ prisonerSummary.prisonNumber }}/create/who-created-the-plan">Create an education support plan</a> by {{ educationSupportPlanLifecycleStatus.planCreationDeadlineDate | formatDate('d MMM yyyy') }}
+                </p>
+              {% endif %}
             </div>
           </div>
 
         {% endif %}
 
+        <div class="govuk-grid-column-one-third app-u-print-full-width">
+          {# column for the actions menu #}
+        </div>
+      </div>
 
     {% else %}
-      <div class="govuk-summary-card" data-qa="education-support-plan-summary-card">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-summary-card__title">Education support plan</h2>
-        </div>
-        <div class="govuk-summary-card__content">
-          <h3 class="govuk-heading-s" data-qa="elsp-unavailable-message">We cannot show these details right now</h3>
-          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+      <div class="govuk-grid-column-two-thirds app-u-print-full-width">
+        <div class="govuk-summary-card" data-qa="education-support-plan-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">Education support plan</h2>
+          </div>
+          <div class="govuk-summary-card__content">
+            <h3 class="govuk-heading-s" data-qa="elsp-unavailable-message">We cannot show these details right now</h3>
+            <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+          </div>
         </div>
       </div>
     {% endif %}
 
-    </div>
-
-    {# TODO, we will need to make the actions menu conditional based on whether we successfully retrieved the Plan Statues, and possibly the ELSP itself #}
-    <div class="govuk-grid-column-one-third app-u-print-full-width">
-      {# column for the actions menu #}
-    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR wires in the middleware for retrieving the Plan Lifecycle Status into the Education Support Plan route; and uses it for rendering the Education Support Plan page, specifically the "empty state" journey.

The ticket for the empty state journey (RR-1808) says that if there is no ELSP then it should render "No education support plan recorded" (was already done), but if the status is PLAN_DUE or PLAN_OVERDUE then it should also render a link to create the plan along with the deadline date:

<img width="1221" height="782" alt="Screenshot 2025-09-01 at 12 46 56" src="https://github.com/user-attachments/assets/fab39ec4-0619-48b3-acc7-3222e9d92c79" />
