### PR TITLE
RR-1809 - Add "plan created by" fields to the ELSP page

### DIFF
--- a/assets/scss/components/_profile-education-support-plan.scss
+++ b/assets/scss/components/_profile-education-support-plan.scss
@@ -1,6 +1,6 @@
 .profile-education-support-plan {
 
-  [data-qa="education-support-plan-summary-card"] {
+  [data-qa="education-support-plan-summary-card"], [data-qa="education-support-plan-persons-view-summary-card"] {
     dt, dd {
       display: block;
       width: auto;

--- a/server/views/pages/profile/education-support-plan/index.njk
+++ b/server/views/pages/profile/education-support-plan/index.njk
@@ -82,7 +82,7 @@
             </div>
           </div>
 
-          <div class="govuk-summary-card" data-qa="education-support-plan-summary-card">
+          <div class="govuk-summary-card" data-qa="education-support-plan-persons-view-summary-card">
             <div class="govuk-summary-card__content">
               <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
@@ -91,6 +91,56 @@
                   </dt>
                   <dd class="govuk-summary-list__value" data-qa="individual-support-requirements">
                     <span class="app-u-multiline-text">{{ educationSupportPlan.individualSupport | default('None', true) }}</span>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <div class="govuk-summary-card" data-qa="education-support-plan-created-audit-fields-summary-card">
+            <div class="govuk-summary-card__content">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Created by
+                  </dt>
+                  <dd class="govuk-summary-list__value" data-qa="plan-created-by">
+                    {{ educationSupportPlan.createdByDisplayName if educationSupportPlan.planCreatedByLoggedInUser else educationSupportPlan.planCreatedByOtherFullName + ' (' + educationSupportPlan.planCreatedByOtherJobRole + ')' }}
+                  </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Created on
+                  </dt>
+                  <dd class="govuk-summary-list__value" data-qa="plan-created-on">
+                    {{ educationSupportPlan.createdAt | formatDate('d MMM yyyy') }}
+                  </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Plan recorded by
+                  </dt>
+                  <dd class="govuk-summary-list__value" data-qa="plan-recorded-by">
+                    {{ educationSupportPlan.createdByDisplayName }}
+                  </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Other people consulted or involved
+                  </dt>
+                  <dd class="govuk-summary-list__value" data-qa="plan-people-consulted">
+                    {% if educationSupportPlan.wereOtherPeopleConsulted %}
+                      <ul class="govuk-list">
+                        {% for person in educationSupportPlan.otherPeopleConsulted %}
+                          <li>{{ person.name }} {{ '(' + person.jobRole + ')' if person.jobRole != 'N/A' }}</li>
+                        {% endfor %}
+                      </ul>
+                    {% else %}
+                      No
+                    {% endif %}
                   </dd>
                 </div>
               </dl>

--- a/server/views/pages/profile/education-support-plan/index.test.ts
+++ b/server/views/pages/profile/education-support-plan/index.test.ts
@@ -70,6 +70,8 @@ describe('Profile education support plan page', () => {
           additionalInformation: null,
           hasCurrentEhcp: false,
           individualSupport: 'Ifereeca has asked that he is not sat with disruptive people as he is keen to learn', // this is the only mandatory text field in the Create ELSP journey
+          createdByDisplayName: 'Mr Plan CreatedBy',
+          createdAt: startOfDay('2025-11-03'),
         }),
       ),
     }
@@ -91,6 +93,10 @@ describe('Profile education support plan page', () => {
     expect($('[data-qa=individual-support-requirements]').text().trim()).toEqual(
       'Ifereeca has asked that he is not sat with disruptive people as he is keen to learn',
     )
+    expect($('[data-qa=plan-recorded-by]').text().trim()).toEqual('Mr Plan CreatedBy')
+    expect($('[data-qa=plan-created-by]').text().trim()).toEqual('Mr Plan CreatedBy')
+    expect($('[data-qa=plan-created-on]').text().trim()).toEqual('3 Nov 2025')
+    expect($('[data-qa=plan-people-consulted]').text().trim()).toEqual('No')
 
     expect($('[data-qa=elsp-unavailable-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
@@ -102,7 +108,7 @@ describe('Profile education support plan page', () => {
       ...templateParams,
       educationSupportPlan: Result.fulfilled(
         aValidEducationSupportPlanDto({
-          planCreatedByOther: { name: 'Mr Plan CreatedBy', jobRole: 'Education Instructor' },
+          planCreatedByOther: { name: 'Mr Plan CreatedByOther', jobRole: 'Education Instructor' },
           otherPeopleConsulted: [
             { name: 'Person 1', jobRole: 'Teacher' },
             { name: 'Person 2', jobRole: 'Peer Mentor' },
@@ -115,6 +121,8 @@ describe('Profile education support plan page', () => {
           additionalInformation: 'Ifereeca is very open about his issues and is a pleasure to talk to.',
           hasCurrentEhcp: true,
           individualSupport: 'Ifereeca has asked that he is not sat with disruptive people as he is keen to learn', // this is the only mandatory text field in the Create ELSP journey
+          createdByDisplayName: 'Mr Plan CreatedBy',
+          createdAt: startOfDay('2025-11-03'),
         }),
       ),
     }
@@ -145,6 +153,11 @@ describe('Profile education support plan page', () => {
     expect($('[data-qa=individual-support-requirements]').text().trim()).toEqual(
       'Ifereeca has asked that he is not sat with disruptive people as he is keen to learn',
     )
+    expect($('[data-qa=plan-recorded-by]').text().trim()).toEqual('Mr Plan CreatedBy')
+    expect($('[data-qa=plan-created-by]').text().trim()).toEqual('Mr Plan CreatedByOther (Education Instructor)')
+    expect($('[data-qa=plan-created-on]').text().trim()).toEqual('3 Nov 2025')
+    expect($('[data-qa=plan-people-consulted] li').eq(0).text().trim()).toEqual('Person 1 (Teacher)')
+    expect($('[data-qa=plan-people-consulted] li').eq(1).text().trim()).toEqual('Person 2 (Peer Mentor)')
 
     expect($('[data-qa=elsp-unavailable-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)


### PR DESCRIPTION
PR to add the "plan created by" fields to the Education Support Plan page:

<img width="921" height="1007" alt="Screenshot 2025-09-01 at 14 34 49" src="https://github.com/user-attachments/assets/8f757091-1ca4-441d-9451-7e60b0111472" />
