### PR TITLE
RR-1811 - Re-import swagger spec & update DTO and mapper

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -230,10 +230,12 @@ declare module 'dto' {
     planCreationDeadlineDate?: Date
     // Review Dateline Date - only set if the ELSP has been created and therefore is in the Review cycle
     reviewDeadlineDate?: Date
-    // If the creation of the ELSP was declibed by the prisoner, this object describes the reason. Only set if the status property is PLAN_DECLINED
+    // If the creation of the ELSP was declined by the prisoner, this object describes the reason. Only set if the status property is PLAN_DECLINED
     planDeclined?: {
       reason: PlanCreationScheduleExemptionReason
       details: string
+      recordedBy: string
+      recordedAt: Date
     }
   }
 }

--- a/server/@types/supportAdditionalNeedsApi/index.d.ts
+++ b/server/@types/supportAdditionalNeedsApi/index.d.ts
@@ -1766,10 +1766,21 @@ export interface components {
        */
       exemptionReason?: 'EXEMPT_REFUSED_TO_ENGAGE' | 'EXEMPT_NOT_REQUIRED' | 'EXEMPT_INACCURATE_IDENTIFICATION'
       /**
-       * @description More detail about the reason for this exemption. This is mainly used for EXEMPT_PRISONER_NOT_COMPLY.
+       * @description More detail about the reason the plan was declined. This is mainly used for EXEMPT_PRISONER_NOT_COMPLY.
        * @example null
        */
       exemptionDetail?: string
+      /**
+       * @description If the plan was declined by the prisoner, the display name of the person who recorded the plan exemption.
+       * @example Alex Smith
+       */
+      exemptionRecordedBy?: string
+      /**
+       * Format: date-time
+       * @description If the plan was declined by the prisoner, the timestamp that the plan was exempted.
+       * @example 2025-10-04
+       */
+      exemptionRecordedAt?: string
     }
     ALNScreenerResponse: {
       /**

--- a/server/data/mappers/planLifecycleStatusDtoMapper.test.ts
+++ b/server/data/mappers/planLifecycleStatusDtoMapper.test.ts
@@ -1,4 +1,4 @@
-import { startOfDay } from 'date-fns'
+import { parseISO, startOfDay } from 'date-fns'
 import type { PlanActionStatus } from 'supportAdditionalNeedsApiClient'
 import toPlanLifecycleStatusDto from './planLifecycleStatusDtoMapper'
 import aPlanActionStatus from '../../testsupport/planActionStatusTestDataBuilder'
@@ -16,6 +16,8 @@ describe('planLifecycleStatusDtoMapper', () => {
         reviewDeadlineDate: null,
         exemptionReason: null,
         exemptionDetail: null,
+        exemptionRecordedBy: null,
+        exemptionRecordedAt: null,
       })
 
       const expected = aPlanLifecycleStatusDto({
@@ -40,6 +42,8 @@ describe('planLifecycleStatusDtoMapper', () => {
         reviewDeadlineDate: null,
         exemptionReason: 'EXEMPT_NOT_REQUIRED',
         exemptionDetail: 'Chris does not want a plan',
+        exemptionRecordedBy: 'Alex Smith',
+        exemptionRecordedAt: '2021-01-02T14:32:16.126Z',
       })
 
       const expected = aPlanLifecycleStatusDto({
@@ -49,6 +53,8 @@ describe('planLifecycleStatusDtoMapper', () => {
         planDeclined: {
           reason: PlanCreationScheduleExemptionReason.EXEMPT_NOT_REQUIRED,
           details: 'Chris does not want a plan',
+          recordedBy: 'Alex Smith',
+          recordedAt: parseISO('2021-01-02T14:32:16.126Z'),
         },
       })
 
@@ -67,6 +73,8 @@ describe('planLifecycleStatusDtoMapper', () => {
         reviewDeadlineDate: '2021-03-01',
         exemptionReason: null,
         exemptionDetail: null,
+        exemptionRecordedBy: null,
+        exemptionRecordedAt: null,
       })
 
       const expected = aPlanLifecycleStatusDto({

--- a/server/data/mappers/planLifecycleStatusDtoMapper.ts
+++ b/server/data/mappers/planLifecycleStatusDtoMapper.ts
@@ -13,6 +13,8 @@ const toPlanLifecycleStatusDto = (planActionStatus: PlanActionStatus): PlanLifec
     ? {
         reason: planActionStatus.exemptionReason,
         details: planActionStatus.exemptionDetail,
+        recordedBy: planActionStatus.exemptionRecordedBy,
+        recordedAt: parseISO(planActionStatus.exemptionRecordedAt),
       }
     : null,
 })

--- a/server/testsupport/planActionStatusTestDataBuilder.ts
+++ b/server/testsupport/planActionStatusTestDataBuilder.ts
@@ -15,6 +15,8 @@ const aPlanActionStatus = (options?: {
   reviewDeadlineDate?: string
   exemptionReason?: 'EXEMPT_REFUSED_TO_ENGAGE' | 'EXEMPT_NOT_REQUIRED' | 'EXEMPT_INACCURATE_IDENTIFICATION'
   exemptionDetail?: string
+  exemptionRecordedBy?: string
+  exemptionRecordedAt?: string
 }): PlanActionStatus => ({
   status: options?.status || 'PLAN_DECLINED',
   planCreationDeadlineDate:
@@ -25,6 +27,9 @@ const aPlanActionStatus = (options?: {
     options?.exemptionDetail === null
       ? null
       : options?.exemptionDetail || 'Chris feels he does not need a support plan',
+  exemptionRecordedBy: options?.exemptionRecordedBy === null ? null : options?.exemptionRecordedBy || 'Alex Smith',
+  exemptionRecordedAt:
+    options?.exemptionRecordedAt === null ? null : options?.exemptionRecordedAt || '2021-01-03T10:32:17.491Z',
 })
 
 export default aPlanActionStatus

--- a/server/testsupport/planLifecycleStatusDtoTestDataBuilder.ts
+++ b/server/testsupport/planLifecycleStatusDtoTestDataBuilder.ts
@@ -1,4 +1,4 @@
-import { startOfDay } from 'date-fns'
+import { parseISO, startOfDay } from 'date-fns'
 import type { PlanLifecycleStatusDto } from 'dto'
 import PlanActionStatus from '../enums/planActionStatus'
 import PlanCreationScheduleExemptionReason from '../enums/planCreationScheduleExemptionReason'
@@ -10,6 +10,8 @@ const aPlanLifecycleStatusDto = (options?: {
   planDeclined?: {
     reason: PlanCreationScheduleExemptionReason
     details: string
+    recordedBy: string
+    recordedAt: Date
   }
 }): PlanLifecycleStatusDto => ({
   status: options?.status || PlanActionStatus.PLAN_DECLINED,
@@ -23,6 +25,8 @@ const aPlanLifecycleStatusDto = (options?: {
       : {
           reason: options?.planDeclined?.reason || PlanCreationScheduleExemptionReason.EXEMPT_REFUSED_TO_ENGAGE,
           details: options?.planDeclined?.details || 'Chris feels he does not need a support plan',
+          recordedBy: options?.planDeclined?.recordedBy || 'Alex Smith',
+          recordedAt: options?.planDeclined?.recordedAt || parseISO('2021-01-03T10:32:17.491Z'),
         },
 })
 


### PR DESCRIPTION
Re-import swagger spec & update DTO and mapper to bring in the new "exemption recorded by/at" fields from the `/plan-action-status` API endpoint