### PR TITLE
RR-1843 - Action Bar component with initial "default access" actions

### DIFF
--- a/assets/scss/components/_actions-card.scss
+++ b/assets/scss/components/_actions-card.scss
@@ -1,6 +1,5 @@
 .actions-card {
   display: none; // Hide the entire action card by default
-  position: relative;
 
   .govuk-summary-card__content {
     display: none; // Hide the action card content section by default
@@ -13,21 +12,27 @@
   .govuk-summary-card__title-wrapper {
     background: none;
     border-bottom: 2px solid $govuk-border-colour;
-  }
-  li {
-    border-bottom: 1px solid $govuk-border-colour;
-  }
-  li:last-of-type {
-    border: none;
+
+    .govuk-summary-card__title {
+      @extend .govuk-heading-m;
+      @extend .govuk-\!-margin-bottom-1;
+    }
   }
 
   ul {
-    border-bottom: 3px solid $govuk-border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
+    margin: 0;
+    padding: 0;
+    @extend .govuk-\!-padding-bottom-4;
   }
   :last-of-type ul {
-      border: none;
+    border: none;
   }
 
+  li {
+    @extend .govuk-\!-padding-top-1;
+    @extend .govuk-\!-padding-bottom-1;
+  }
   .govuk-tag {
     max-width: fit-content;
   }
@@ -45,12 +50,3 @@
   display: block;
 }
 
-.actions-card:after {
-  content: "";
-  display: block;
-  width: 100%;
-  height: 3px;
-  position: absolute;
-  bottom: 0;
-  background: white;
-}

--- a/server/views/pages/profile/components/actions-card/actionCards.test.njk
+++ b/server/views/pages/profile/components/actions-card/actionCards.test.njk
@@ -1,0 +1,6 @@
+{% from "./macro.njk" import actionsCard %}
+
+{{ actionsCard({
+  prisonerSummary: prisonerSummary,
+  userHasPermissionTo: userHasPermissionTo
+}) }}

--- a/server/views/pages/profile/components/actions-card/actionsCard.test.ts
+++ b/server/views/pages/profile/components/actions-card/actionsCard.test.ts
@@ -1,0 +1,197 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import type { ActionsCardParams } from 'viewModels'
+import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
+
+nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+const userHasPermissionTo = jest.fn()
+const templateParams: ActionsCardParams = {
+  prisonerSummary: aValidPrisonerSummary(),
+  userHasPermissionTo,
+}
+
+const template = 'actionCards.test.njk'
+
+describe('Tests for Profile pages actions card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the actions card component given the user has permissions for all actions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(5) // expect all 5 links to be present
+    // Assert each one in turn
+    expect($('[data-qa=record-screener-results-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect($('[data-qa=add-challenge-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect($('[data-qa=add-strength-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect($('[data-qa=add-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect($('[data-qa=add-conditions-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user has permissions for no actions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(0) // expect 0 links to be present
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user only has permission to record ALN screeners', () => {
+    // Given
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(1) // expect 1 link to be present
+    expect($('[data-qa=record-screener-results-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user only has permission to record challenges', () => {
+    // Given
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(1) // expect 1 link to be present
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect($('[data-qa=add-challenge-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user only has permission to record strengths', () => {
+    // Given
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(1) // expect 1 link to be present
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect($('[data-qa=add-strength-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user only has permission to record support strategies', () => {
+    // Given
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(1) // expect 1 link to be present
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect($('[data-qa=add-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+
+  it('should render the actions card component given the user only has permission to record conditions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = nunjucks.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('li').length).toEqual(1) // expect 1 link to be present
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_ALN_SCREENER')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_STRENGTHS')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+    expect($('[data-qa=add-conditions-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SELF_DECLARED_CONDITIONS')
+  })
+})

--- a/server/views/pages/profile/components/actions-card/macro.njk
+++ b/server/views/pages/profile/components/actions-card/macro.njk
@@ -1,0 +1,11 @@
+{# Actions Card macro for the Profile pages
+
+Data supplied to this marco:
+  params: {
+    userHasPermissionTo
+    prisonerSummary
+  }
+#}
+{% macro actionsCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/pages/profile/components/actions-card/template.njk
+++ b/server/views/pages/profile/components/actions-card/template.njk
@@ -1,0 +1,60 @@
+{% set userHasPermissionTo = params.userHasPermissionTo %}
+{% set prisonerSummary = params.prisonerSummary %}
+
+<div class="govuk-summary-card actions-card govuk-!-display-none-print" data-qa="actions-card">
+  <div class="govuk-summary-card__title-wrapper govuk-!-padding-bottom-2">
+    <h2 class="govuk-summary-card__title">Actions</h2>
+  </div>
+
+
+  <div class="govuk-summary-card__content" data-qa="screening-and-assessment-actions">
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Screening and assessment</h3>
+    <ul class="govuk-list" data-qa="screening-and-assessment-action-items">
+      {% if userHasPermissionTo('RECORD_ALN_SCREENER') %}
+        <li>
+          <a class="govuk-link" data-qa="record-screener-results-button" href="/aln-screener/{{ prisonerSummary.prisonNumber }}/create/screener-date">
+            <span>
+              <img src="/assets/images/icon-edit.svg" role="presentation" alt="" class="action-icon" />
+              Record screener results
+            </span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </div>
+
+  <div class="govuk-summary-card__content" data-qa="additional-needs-actions">
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Additional needs</h3>
+    <ul class="govuk-list" data-qa="additional-needs-action-items">
+      {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+        <li>
+          <a class="govuk-link" data-qa="add-challenge-button" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add challenges
+          </a>
+        </li>
+      {% endif %}
+      {% if userHasPermissionTo('RECORD_STRENGTHS') %}
+        <li>
+          <a class="govuk-link" data-qa="add-strength-button" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add strengths
+          </a>
+        </li>
+      {% endif %}
+      {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
+        <li>
+          <a class="govuk-link" data-qa="add-support-strategy-button" href="/support-strategies/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add support strategies
+          </a>
+        </li>
+      {% endif %}
+      {% if userHasPermissionTo('RECORD_SELF_DECLARED_CONDITIONS') %}
+        <li>
+          <a class="govuk-link" data-qa="add-conditions-button" href="/conditions/{{ prisonerSummary.prisonNumber }}/create/select-conditions">
+            Add conditions
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </div>
+
+</div>

--- a/server/views/pages/profile/education-support-plan/index.njk
+++ b/server/views/pages/profile/education-support-plan/index.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 {% from "./components/macro.njk" import renderEducationSupportPlan %}
 {% from "./components/macro.njk" import noEducationSupportPlan %}
 {% from "./components/macro.njk" import declinedEducationSupportPlan %}
@@ -52,9 +53,12 @@
           {% endif %}
 
         {% endif %}
-        <div class="govuk-grid-column-one-third app-u-print-full-width">
-          {# column for the actions menu #}
-        </div>
+      </div>
+      <div class="govuk-grid-column-one-third app-u-print-full-width">
+        {{ actionsCard({
+          userHasPermissionTo: userHasPermissionTo,
+          prisonerSummary: prisonerSummary
+        }) }}
       </div>
 
     {% else %}


### PR DESCRIPTION
PR that adds the new Actions Bar component for the Profile pages
At the moment the actions bar items are only the ones that all users can access (aka "default access"); and I've only plumbed it into the Education Support Plan tab to make sure it works 👍 

I'll plumb it into the other tabs, and remove the old component, in my next PR

<img width="1274" height="1225" alt="Screenshot 2025-09-02 at 15 52 36" src="https://github.com/user-attachments/assets/f32fdd3c-8297-452c-b172-174a18dcc06c" />
