### PR TITLE
Fix the ALN Assessment mapping from Curious

### DIFF
--- a/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.test.ts
+++ b/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.test.ts
@@ -265,6 +265,7 @@ describe('curiousAlnAndLddAssessmentsDtoMapper', () => {
       { curiousValue: 'Substance Misuse Team', expected: AlnAssessmentReferral.SUBSTANCE_MISUSE_TEAM },
       { curiousValue: 'Safer Custody', expected: AlnAssessmentReferral.SAFER_CUSTODY },
       { curiousValue: 'Other', expected: AlnAssessmentReferral.OTHER },
+      { curiousValue: null, expected: undefined },
     ] as Array<{
       curiousValue:
         | 'Healthcare'

--- a/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.ts
+++ b/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.ts
@@ -45,6 +45,6 @@ const toAlnAssessmentReferral = (apiStakeholderReferral: string): AlnAssessmentR
     'substance misuse team': AlnAssessmentReferral.SUBSTANCE_MISUSE_TEAM,
     'safer custody': AlnAssessmentReferral.SAFER_CUSTODY,
     other: AlnAssessmentReferral.OTHER,
-  })[apiStakeholderReferral.toLowerCase().trim()]
+  })[apiStakeholderReferral?.toLowerCase().trim()]
 
 export default toCuriousAlnAndLddAssessmentsDto

--- a/server/testsupport/curiousAssessmentsTestDataBuilder.ts
+++ b/server/testsupport/curiousAssessmentsTestDataBuilder.ts
@@ -114,7 +114,8 @@ const anAlnLearnerAssessmentsDTO = (options?: {
   assessmentDate: options?.assessmentDate || '2025-10-01',
   assessmentOutcome: options?.assessmentOutcome || 'Yes',
   hasPrisonerConsent: options?.hasPrisonerConsent || 'Yes',
-  stakeholderReferral: options?.stakeholderReferral || 'Education Specialist',
+  stakeholderReferral:
+    options?.stakeholderReferral === null ? null : options?.stakeholderReferral || 'Education Specialist',
 })
 
 const aReadingLearnerAssessmentsDTO = (options?: {

--- a/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
+++ b/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
@@ -43,7 +43,7 @@
               Referred to
             </dt>
             <dd class="govuk-summary-list__value" data-qa="assessment-referral">
-              {{ alnAssessment.referral | formatAlnAssessmentReferralScreenValue }}
+              {{ alnAssessment.referral | formatAlnAssessmentReferralScreenValue | default('Not recorded in Curious') }}
             </dd>
           </div>
         </dl>


### PR DESCRIPTION
Fix the ALN Assessment mapping when `stakeholderReferral` is null

<img width="683" height="315" alt="Screenshot 2025-09-02 at 19 43 11" src="https://github.com/user-attachments/assets/a863ef23-b6d7-4d01-8e0e-1fc0fcda694d" />
