### PR TITLE
RR-1843 - Use Profile page Action Bar component on Strengths, Challenges and Conditions pages

### DIFF
--- a/integration_tests/e2e/conditions/create/createConditions.cy.ts
+++ b/integration_tests/e2e/conditions/create/createConditions.cy.ts
@@ -40,7 +40,7 @@ describe('Create Conditions', () => {
     cy.visit(`/profile/${prisonNumber}/overview`)
     Page.verifyOnPage(OverviewPage) //
       .selectTab('Conditions', ConditionsPage)
-      .clickRecordConditionsButton()
+      .clickAddConditionsButton()
 
     // When
     Page.verifyOnPage(SelectConditionsPage) //
@@ -116,7 +116,7 @@ describe('Create Conditions', () => {
     cy.visit(`/profile/${prisonNumber}/overview`)
     Page.verifyOnPage(OverviewPage) //
       .selectTab('Conditions', ConditionsPage)
-      .clickRecordConditionsButton()
+      .clickAddConditionsButton()
 
     // When
     Page.verifyOnPage(SelectConditionsPage) //

--- a/integration_tests/pages/profile/challengesPage.ts
+++ b/integration_tests/pages/profile/challengesPage.ts
@@ -1,7 +1,5 @@
 import ProfilePage from './profilePage'
-import Page, { PageElement } from '../page'
-import SelectChallengeCategoryPage from '../challenges/selectChallengeCategoryPage'
-import ScreenerDatePage from '../additional-learning-needs-screener/screenerDatePage'
+import { PageElement } from '../page'
 import ChallengeCategory from '../../../server/enums/challengeCategory'
 import ChallengeType from '../../../server/enums/challengeType'
 
@@ -10,23 +8,6 @@ export default class ChallengesPage extends ProfilePage {
     super('profile-challenges')
     this.activeTabIs('Challenges')
   }
-
-  clickAddChallengesButton(): SelectChallengeCategoryPage {
-    this.addChallengeButton().click()
-    return Page.verifyOnPage(SelectChallengeCategoryPage)
-  }
-
-  clickRecordAlnScreenerButton(): ScreenerDatePage {
-    this.recordAlnScreenerButton().click()
-    return Page.verifyOnPage(ScreenerDatePage)
-  }
-
-  private challengesActionItems = (): PageElement => cy.get('[data-qa=challenges-action-items] li')
-
-  private addChallengeButton = (): PageElement => this.challengesActionItems().find('[data-qa=add-challenge-button]')
-
-  private recordAlnScreenerButton = (): PageElement =>
-    this.challengesActionItems().find('[data-qa=record-screener-results-button]')
 
   hasChallengesSummaryCard(category: ChallengeCategory): ChallengesPage {
     this.challengeCategorySummaryCard(category).should('be.visible')

--- a/integration_tests/pages/profile/conditionsPage.ts
+++ b/integration_tests/pages/profile/conditionsPage.ts
@@ -1,6 +1,5 @@
 import ProfilePage from './profilePage'
-import Page, { PageElement } from '../page'
-import SelectConditionsPage from '../conditions/selectConditionsPage'
+import { PageElement } from '../page'
 import ConditionType from '../../../server/enums/conditionType'
 
 export default class ConditionsPage extends ProfilePage {
@@ -37,16 +36,6 @@ export default class ConditionsPage extends ProfilePage {
     this.diagnosedConditionsSummaryCard().should('not.exist')
     return this
   }
-
-  clickRecordConditionsButton(): SelectConditionsPage {
-    this.recordConditionsButton().click()
-    return Page.verifyOnPage(SelectConditionsPage)
-  }
-
-  private conditionsActionItems = (): PageElement => cy.get('[data-qa=conditions-actions] li')
-
-  private recordConditionsButton = (): PageElement =>
-    this.conditionsActionItems().find('[data-qa=record-conditions-button]')
 
   private diagnosedConditionsSummaryCard = (): PageElement => cy.get('[data-qa=diagnosed-conditions-summary-card]')
 

--- a/integration_tests/pages/profile/overviewPage.ts
+++ b/integration_tests/pages/profile/overviewPage.ts
@@ -130,26 +130,18 @@ export default class OverviewPage extends ProfilePage {
   private curiousScreenersUnavailableMessage = (): PageElement =>
     cy.get('[data-qa=curious-screeners-unavailable-message]')
 
-  private recordAlnScreenerButton = (): PageElement => cy.get('[data-qa=record-screener-results-button]')
-
   private conditionsSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=conditions-summary-card] .govuk-summary-card__content')
 
   private conditionsUnavailableMessage = (): PageElement => cy.get('[data-qa=conditions-unavailable-message]')
-
-  private addConditionButton = (): PageElement => cy.get('[data-qa=add-condition-button]')
 
   private strengthsSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=strengths-summary-card] .govuk-summary-card__content')
 
   private strengthsUnavailableMessage = (): PageElement => cy.get('[data-qa=strengths-unavailable-message]')
 
-  private addStrengthButton = (): PageElement => cy.get('[data-qa=add-strength-button]')
-
   private supportRecommendationsSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=support-recommendations-summary-card] .govuk-summary-card__content')
-
-  private addSupportRecommendationButton = (): PageElement => cy.get('[data-qa=add-support-recommendation-button]')
 
   private actionsCard = (): PageElement => cy.get('[data-qa=actions-card]')
 

--- a/integration_tests/pages/profile/profilePage.ts
+++ b/integration_tests/pages/profile/profilePage.ts
@@ -1,4 +1,8 @@
 import Page, { PageElement } from '../page'
+import SelectChallengeCategoryPage from '../challenges/selectChallengeCategoryPage'
+import ScreenerDatePage from '../additional-learning-needs-screener/screenerDatePage'
+import SelectConditionsPage from '../conditions/selectConditionsPage'
+import SelectStrengthCategoryPage from '../strengths/selectStrengthCategoryPage'
 
 export default abstract class ProfilePage extends Page {
   hasSuccessMessage<T extends ProfilePage>(message: string): T {
@@ -23,6 +27,26 @@ export default abstract class ProfilePage extends Page {
     return this as unknown as T
   }
 
+  clickAddChallengesButton(): SelectChallengeCategoryPage {
+    this.addChallengeButton().click()
+    return Page.verifyOnPage(SelectChallengeCategoryPage)
+  }
+
+  clickRecordAlnScreenerButton(): ScreenerDatePage {
+    this.recordAlnScreenerButton().click()
+    return Page.verifyOnPage(ScreenerDatePage)
+  }
+
+  clickAddConditionsButton(): SelectConditionsPage {
+    this.addConditionsButton().click()
+    return Page.verifyOnPage(SelectConditionsPage)
+  }
+
+  clickAddStrengthButton(): SelectStrengthCategoryPage {
+    this.addStrengthButton().click()
+    return Page.verifyOnPage(SelectStrengthCategoryPage)
+  }
+
   private tabBarLink = (targetTab: string): PageElement => cy.get(`.moj-sub-navigation__link:contains('${targetTab}')`)
 
   private activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
@@ -30,4 +54,12 @@ export default abstract class ProfilePage extends Page {
   private prisonerSummaryBanner = (): PageElement => cy.get('.prisoner-summary-banner')
 
   private successMessage = (): PageElement => cy.get('[data-qa=success-message]')
+
+  private addChallengeButton = (): PageElement => cy.get('[data-qa=add-challenge-button]')
+
+  private recordAlnScreenerButton = (): PageElement => cy.get('[data-qa=record-screener-results-button]')
+
+  private addConditionsButton = (): PageElement => cy.get('[data-qa=add-conditions-button]')
+
+  private addStrengthButton = (): PageElement => cy.get('[data-qa=add-strength-button]')
 }

--- a/integration_tests/pages/profile/strengthsPage.ts
+++ b/integration_tests/pages/profile/strengthsPage.ts
@@ -1,6 +1,5 @@
 import ProfilePage from './profilePage'
-import Page, { PageElement } from '../page'
-import SelectStrengthCategoryPage from '../strengths/selectStrengthCategoryPage'
+import { PageElement } from '../page'
 import StrengthCategory from '../../../server/enums/strengthCategory'
 import StrengthType from '../../../server/enums/strengthType'
 
@@ -48,15 +47,6 @@ export default class StrengthsPage extends ProfilePage {
     this.noStrengthsSummaryCard().should('be.visible')
     return this
   }
-
-  clickAddStrengthButton(): SelectStrengthCategoryPage {
-    this.addStrengthButton().click()
-    return Page.verifyOnPage(SelectStrengthCategoryPage)
-  }
-
-  private strengthsActionItems = (): PageElement => cy.get('[data-qa=strengths-action-items] li')
-
-  private addStrengthButton = (): PageElement => this.strengthsActionItems().find('[data-qa=add-strength-button]')
 
   private noStrengthsSummaryCard = (): PageElement => cy.get('[data-qa=no-strengths-summary-card]')
 

--- a/server/views/pages/profile/challenges/index.njk
+++ b/server/views/pages/profile/challenges/index.njk
@@ -1,32 +1,37 @@
 {% extends "../layout.njk" %}
-{% from "../../../components/actions-card/macro.njk" import actionsCard %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-challenges' %}
 {% set pageTitle = "Support for additional needs - Challenges" %}
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
+    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Challenges</h2>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
+
       {% if groupedChallenges.isFulfilled() %}
         {% set groupedChallenges = groupedChallenges.value %}
-          {% if groupedChallenges | length == 0 %}
-            {% include "./components/_noChallengesSummaryCard.njk" %}
-          {% else %}
-            {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-            {% include "./_challenges.njk" %}
-          {% endif %}
+        {% if groupedChallenges | length == 0 %}
+          {% include "./components/_noChallengesSummaryCard.njk" %}
+        {% else %}
+          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+          {% include "./_challenges.njk" %}
+        {% endif %}
       {% else %}
-            <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
-            <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+        <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
+        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
       {% endif %}
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
-        prisonerSummary: prisonerSummary,
         userHasPermissionTo: userHasPermissionTo,
-        actionMenuType: 'challenges'
+        prisonerSummary: prisonerSummary
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -1,14 +1,19 @@
 {% extends "../layout.njk" %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 {% from "./components/conditions-summary-card/macro.njk" import conditionsSummaryCard %}
-{% from "../../../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-conditions' %}
 {% set pageTitle = "Support for additional needs - Conditions" %}
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
+    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Conditions</h2>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       {% if conditions.isFulfilled() %}
         {% set activeConditions = conditions.value.conditions | filterArrayOnProperty('active', true) | sort(attribute = 'updatedAt', reverse = true) %}
@@ -45,9 +50,8 @@
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
-        prisonerSummary: prisonerSummary,
         userHasPermissionTo: userHasPermissionTo,
-        actionMenuType: 'conditions'
+        prisonerSummary: prisonerSummary
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -1,14 +1,19 @@
 {% extends "../layout.njk" %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 {% from "./components/strengths-summary-card/macro.njk" import strengthsSummaryCard %}
-{% from "../../../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-strengths' %}
 {% set pageTitle = "Support for additional needs - Strengths" %}
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
+    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Strengths</h2>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       {% if groupedStrengths.isFulfilled() %}
         {% set groupedStrengths = groupedStrengths.value %}
@@ -38,9 +43,8 @@
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
-        prisonerSummary: prisonerSummary,
         userHasPermissionTo: userHasPermissionTo,
-        actionMenuType: 'strengths'
+        prisonerSummary: prisonerSummary
       }) }}
     </div>
   </div>


### PR DESCRIPTION
PR to use the new Actions Bar component on the Strengths, Challenges and Conditions pages
This component was already added to the Education Support Page in my last page, so once this PR is merged it leaves us with just the main Overview page and the Support Strategies page.

I am holding off adding it to the Support Strategies page just yet as @srowlands-moj is working on that page in his ticket. I'll add it to that page after his work is merged.

Re: the Overview page, that will come once we do the next stories in this epic that add the Record and Decline Education Support Plan action links.