### PR TITLE
RR-1813 - Wire new Actions Bar into Overview, Conditions, Challenges and Strengths pages

### DIFF
--- a/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreener.cy.ts
+++ b/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreener.cy.ts
@@ -20,7 +20,7 @@ context('Record an Additional Learning Needs screener for a prisoner', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubChallengesReferenceData')
     cy.task('stubStrengthsReferenceData')
     cy.task('stubRecordAlnScreener', prisonNumber)

--- a/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreenerPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/additional-learning-needs-screener/create/recordAlnScreenerPreventOutOfSequenceNavigation.cy.ts
@@ -10,7 +10,7 @@ context('Prevent out of sequence navigation to pages in the Record ALN Screener 
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
   ;['add-challenges', 'add-strengths', 'check-your-answers'].forEach(page => {
     it(`should prevent direct navigation to ${page} page when the user has not started the Record ALN Screener journey`, () => {

--- a/integration_tests/e2e/challenges/create/createChallenge.cy.ts
+++ b/integration_tests/e2e/challenges/create/createChallenge.cy.ts
@@ -17,7 +17,7 @@ context('Create a Challenge', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateChallenges', prisonNumber)
   })
 

--- a/integration_tests/e2e/challenges/create/createChallengePreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/challenges/create/createChallengePreventOutOfSequenceNavigation.cy.ts
@@ -10,7 +10,7 @@ context('Prevent out of sequence navigation to pages in the Create Challenge jou
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
   ;['detail'].forEach(page => {
     it(`should prevent direct navigation to ${page} page when the user has not started the Create Challenge journey`, () => {

--- a/integration_tests/e2e/conditions/create/createConditions.cy.ts
+++ b/integration_tests/e2e/conditions/create/createConditions.cy.ts
@@ -15,7 +15,7 @@ describe('Create Conditions', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateConditions', prisonNumber)
     cy.task('stubGetConditions', { prisonNumber })
   })

--- a/integration_tests/e2e/conditions/create/createConditionsPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/conditions/create/createConditionsPreventOutOfSequenceNavigation.cy.ts
@@ -10,7 +10,7 @@ context('Prevent out of sequence navigation to pages in the Create Conditions jo
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
   ;['details'].forEach(page => {
     it(`should prevent direct navigation to ${page} page when the user has not started the Create Conditions journey`, () => {

--- a/integration_tests/e2e/education-support-plan/create/checkYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/checkYourAnswersChangeLinks.cy.ts
@@ -20,7 +20,7 @@ context(`Change links on the Check Your Answers page when creating an Education 
     cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] }) // user has the role that gives them permission to create ELSPs)
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateEducationSupportPlan', prisonNumber)
   })
 

--- a/integration_tests/e2e/education-support-plan/create/createEducationSupportPlan.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/createEducationSupportPlan.cy.ts
@@ -27,7 +27,7 @@ context('Create an Education Support Plan', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateEducationSupportPlan', prisonNumber)
   })
 

--- a/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/createEducationSupportPlanPreventOutOfSequenceNavigation.cy.ts
@@ -25,7 +25,7 @@ context('Prevent out of sequence navigation to pages in the Create Education Sup
   beforeEach(() => {
     cy.task('reset')
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
 
   pages.forEach(page => {

--- a/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
+++ b/integration_tests/e2e/education-support-plan/create/removeOtherPeopleConsulted.cy.ts
@@ -13,7 +13,7 @@ context('Add and remove Other People Consulted during creation of Education Supp
     cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] }) // user has the role that gives them permission to create ELSPs)
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
 
   it('should be able to add and remove other people consulted', () => {

--- a/integration_tests/e2e/education-support-plan/refuse-plan/refuseEducationSupportPlan.cy.ts
+++ b/integration_tests/e2e/education-support-plan/refuse-plan/refuseEducationSupportPlan.cy.ts
@@ -6,6 +6,7 @@ import { patchRequestedFor } from '../../../mockApis/wiremock/requestPatternBuil
 import { urlEqualTo } from '../../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../../mockApis/wiremock/matchers/content'
 import AuthorisationErrorPage from '../../../pages/authorisationError'
+import aPlanActionStatus from '../../../../server/testsupport/planActionStatusTestDataBuilder'
 
 context('Refuse an Education Support Plan', () => {
   const prisonNumber = 'H4115SD'
@@ -13,7 +14,17 @@ context('Refuse an Education Support Plan', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', {
+      prisonNumber,
+      planActionStatus: aPlanActionStatus({
+        status: 'PLAN_DUE',
+        reviewDeadlineDate: null,
+        exemptionReason: null,
+        exemptionDetail: null,
+        exemptionRecordedAt: null,
+        exemptionRecordedBy: null,
+      }),
+    })
     cy.task('stubUpdateEducationSupportPlanCreationStatus', prisonNumber)
   })
 
@@ -37,7 +48,7 @@ context('Refuse an Education Support Plan', () => {
     cy.visit(`/profile/${prisonNumber}/overview`)
     Page.verifyOnPage(OverviewPage) //
       .actionsCardContainsEducationSupportPlanActions()
-      .clickRefuseEducationSupportPlanButton()
+      .clickDeclineEducationSupportPlanButton()
 
     // When
     Page.verifyOnPage(ReasonPage) //
@@ -86,7 +97,7 @@ context('Refuse an Education Support Plan', () => {
     cy.visit(`/profile/${prisonNumber}/overview`)
     Page.verifyOnPage(OverviewPage) //
       .actionsCardContainsEducationSupportPlanActions()
-      .clickRefuseEducationSupportPlanButton()
+      .clickDeclineEducationSupportPlanButton()
     Page.verifyOnPage(ReasonPage) //
       .apiErrorBannerIsNotDisplayed()
 

--- a/integration_tests/e2e/profile/overview.cy.ts
+++ b/integration_tests/e2e/profile/overview.cy.ts
@@ -5,28 +5,37 @@
 import OverviewPage from '../../pages/profile/overviewPage'
 import Page from '../../pages/page'
 import Error404Page from '../../pages/error404'
-import PlanCreationScheduleStatus from '../../../server/enums/planCreationScheduleStatus'
 import SupportStrategiesPage from '../../pages/profile/supportStrategiesPage'
 import EducationSupportPlanPage from '../../pages/profile/educationSupportPlanPage'
 import ConditionsPage from '../../pages/profile/conditionsPage'
 import StrengthsPage from '../../pages/profile/strengthsPage'
 import ChallengesPage from '../../pages/profile/challengesPage'
+import aPlanActionStatus from '../../../server/testsupport/planActionStatusTestDataBuilder'
 
 context('Profile Overview Page', () => {
   const prisonNumber = 'H4115SD'
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] })
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
     cy.task('stubGetConditions', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })
     cy.task('stubGetStrengths', { prisonNumber })
     cy.task('stubGetCuriousV2Assessments', { prisonNumber })
     cy.task('stubGetEducationSupportPlan', prisonNumber)
-    cy.task('stubGetPlanActionStatus', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', {
+      prisonNumber,
+      planActionStatus: aPlanActionStatus({
+        status: 'PLAN_DUE',
+        reviewDeadlineDate: null,
+        exemptionReason: null,
+        exemptionDetail: null,
+        exemptionRecordedAt: null,
+        exemptionRecordedBy: null,
+      }),
+    })
   })
 
   it('should be able to navigate directly to the profile overview page', () => {
@@ -46,32 +55,15 @@ context('Profile Overview Page', () => {
       .apiErrorBannerIsNotDisplayed()
   })
 
-  it('should display overview page given prisoner already has an Education Support Plan', () => {
+  it('should display overview page given retrieving the prisoners plan action status returns an error', () => {
     // Given
-    cy.task('stubGetEducationSupportPlanCreationSchedules', {
-      prisonNumber,
-      status: PlanCreationScheduleStatus.COMPLETED,
-    })
+    cy.task('stubGetPlanActionStatus500Error', prisonNumber)
 
     // When
     cy.visit(`/profile/${prisonNumber}/overview`)
 
     // Then
     Page.verifyOnPage(OverviewPage) //
-      .actionsCardIsNotPresent()
-      .apiErrorBannerIsNotDisplayed()
-  })
-
-  it('should display overview page given retrieving the prisoners plan creation schedule returns an error', () => {
-    // Given
-    cy.task('stubGetEducationSupportPlanCreationSchedules500Error', { prisonNumber })
-
-    // When
-    cy.visit(`/profile/${prisonNumber}/overview`)
-
-    // Then
-    Page.verifyOnPage(OverviewPage) //
-      .actionsCardIsNotPresent()
       .apiErrorBannerIsDisplayed()
   })
 

--- a/integration_tests/e2e/profile/overviewChallenges.cy.ts
+++ b/integration_tests/e2e/profile/overviewChallenges.cy.ts
@@ -13,7 +13,7 @@ context('Profile Overview Page - Challenges section', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubGetConditions', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })

--- a/integration_tests/e2e/profile/overviewConditions.cy.ts
+++ b/integration_tests/e2e/profile/overviewConditions.cy.ts
@@ -13,7 +13,7 @@ context('Profile Overview Page - Conditions section', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubGetConditions', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })
     cy.task('stubGetStrengths', { prisonNumber })

--- a/integration_tests/e2e/profile/overviewScreeningAndAssessment.cy.ts
+++ b/integration_tests/e2e/profile/overviewScreeningAndAssessment.cy.ts
@@ -17,7 +17,7 @@ context('Profile Overview Page - Screening and Assessment section', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubGetConditions', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })
     cy.task('stubGetStrengths', { prisonNumber })

--- a/integration_tests/e2e/profile/overviewStrengths.cy.ts
+++ b/integration_tests/e2e/profile/overviewStrengths.cy.ts
@@ -13,7 +13,7 @@ context('Profile Overview Page - Strengths section', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubGetConditions', { prisonNumber })
     cy.task('stubGetChallenges', { prisonNumber })
     cy.task('stubGetStrengths', { prisonNumber })

--- a/integration_tests/e2e/search/search.cy.ts
+++ b/integration_tests/e2e/search/search.cy.ts
@@ -115,7 +115,7 @@ context(`Display the Search screen`, () => {
     // Given
     const firstPersonOnFirstPage: Person = peopleGroupedByPageRequest[0][0]
     cy.task('getPrisonerById', firstPersonOnFirstPage.prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber: firstPersonOnFirstPage.prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber: firstPersonOnFirstPage.prisonNumber })
     cy.visit('/search')
 
     // Then

--- a/integration_tests/e2e/strengths/create/createStrength.cy.ts
+++ b/integration_tests/e2e/strengths/create/createStrength.cy.ts
@@ -17,7 +17,7 @@ context('Create a Strength', () => {
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateStrengths', prisonNumber)
     cy.task('stubGetStrengths', { prisonNumber })
   })

--- a/integration_tests/e2e/strengths/create/createStrengthPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/strengths/create/createStrengthPreventOutOfSequenceNavigation.cy.ts
@@ -10,7 +10,7 @@ context('Prevent out of sequence navigation to pages in the Create Strength jour
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
   ;['detail'].forEach(page => {
     it(`should prevent direct navigation to ${page} page when the user has not started the Create Strength journey`, () => {

--- a/integration_tests/e2e/support-strategies/create/createSupportStrategy.cy.ts
+++ b/integration_tests/e2e/support-strategies/create/createSupportStrategy.cy.ts
@@ -17,6 +17,7 @@ context('Create a Support Strategy', () => {
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
     cy.task('stubCreateSupportStrategies', prisonNumber)
     cy.task('stubGetSupportStrategies', { prisonNumber })
   })

--- a/integration_tests/e2e/support-strategies/create/createSupportStrategyPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/support-strategies/create/createSupportStrategyPreventOutOfSequenceNavigation.cy.ts
@@ -10,7 +10,7 @@ context('Prevent out of sequence navigation to pages in the Create Support Strat
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
-    cy.task('stubGetEducationSupportPlanCreationSchedules', { prisonNumber })
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
   })
   ;['detail'].forEach(page => {
     it(`should prevent direct navigation to ${page} page when the user has not started the Create Support Strategy journey`, () => {

--- a/integration_tests/mockApis/supportAdditionalNeedsApi/planActionStatusEndpoints.ts
+++ b/integration_tests/mockApis/supportAdditionalNeedsApi/planActionStatusEndpoints.ts
@@ -19,6 +19,8 @@ const stubGetPlanActionStatus = (
         reviewDeadlineDate: null,
         exemptionReason: 'EXEMPT_REFUSED_TO_ENGAGE',
         exemptionDetail: 'Chris feels he does not need a support plan',
+        exemptionRecordedAt: '2025-10-02',
+        exemptionRecordedBy: 'Alex Smith',
       },
     },
   })

--- a/integration_tests/pages/profile/overviewPage.ts
+++ b/integration_tests/pages/profile/overviewPage.ts
@@ -1,6 +1,5 @@
-import Page, { PageElement } from '../page'
-import WhoCreatedThePlanPage from '../education-support-plan/whoCreatedThePlanPage'
-import ReasonPage from '../education-support-plan/refuse-plan/reasonPage'
+import { PageElement } from '../page'
+// eslint ignore-next-line import/no-cycle
 import ProfilePage from './profilePage'
 
 export default class OverviewPage extends ProfilePage {
@@ -98,31 +97,6 @@ export default class OverviewPage extends ProfilePage {
     return this
   }
 
-  actionsCardIsNotPresent(): OverviewPage {
-    // Technically the action card as a HTML element is always present. If it contains no `li` elements then we use CSS to hide it
-    // but because the runtime on CircleCI does not process/render the css we cannot use `.should('not.be.visible')`
-    // Instead we will ensure there are zero `li` elements within it, and trust that the css hides the element in this case.
-    this.actionsCard().should('exist')
-    this.educationSupportPlanActionItems().should('not.exist')
-    return this
-  }
-
-  actionsCardContainsEducationSupportPlanActions(): OverviewPage {
-    this.actionsCard().should('exist')
-    this.educationSupportPlanActionItems().should('exist')
-    return this
-  }
-
-  clickCreateEducationSupportPlanButton(): WhoCreatedThePlanPage {
-    this.createEducationSupportPlanButton().click()
-    return Page.verifyOnPage(WhoCreatedThePlanPage)
-  }
-
-  clickRefuseEducationSupportPlanButton(): ReasonPage {
-    this.refuseEducationSupportPlanButton().click()
-    return Page.verifyOnPage(ReasonPage)
-  }
-
   private alnAssessments = (): PageElement => cy.get('[data-qa=aln-assessments]')
 
   private lddAssessments = (): PageElement => cy.get('[data-qa=ldd-assessments]')
@@ -142,17 +116,6 @@ export default class OverviewPage extends ProfilePage {
 
   private supportRecommendationsSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=support-recommendations-summary-card] .govuk-summary-card__content')
-
-  private actionsCard = (): PageElement => cy.get('[data-qa=actions-card]')
-
-  private educationSupportPlanActionItems = (): PageElement =>
-    cy.get('[data-qa=education-support-plan-action-items] li')
-
-  private createEducationSupportPlanButton = (): PageElement =>
-    this.educationSupportPlanActionItems().find('[data-qa=create-education-support-plan-button]')
-
-  private refuseEducationSupportPlanButton = (): PageElement =>
-    this.educationSupportPlanActionItems().find('[data-qa=refuse-education-support-plan-button]')
 
   private challengesUnavailableMessage = (): PageElement => cy.get('[data-qa=challenges-unavailable-message]')
 }

--- a/integration_tests/pages/profile/profilePage.ts
+++ b/integration_tests/pages/profile/profilePage.ts
@@ -3,6 +3,8 @@ import SelectChallengeCategoryPage from '../challenges/selectChallengeCategoryPa
 import ScreenerDatePage from '../additional-learning-needs-screener/screenerDatePage'
 import SelectConditionsPage from '../conditions/selectConditionsPage'
 import SelectStrengthCategoryPage from '../strengths/selectStrengthCategoryPage'
+import WhoCreatedThePlanPage from '../education-support-plan/whoCreatedThePlanPage'
+import ReasonPage from '../education-support-plan/refuse-plan/reasonPage'
 
 export default abstract class ProfilePage extends Page {
   hasSuccessMessage<T extends ProfilePage>(message: string): T {
@@ -47,6 +49,22 @@ export default abstract class ProfilePage extends Page {
     return Page.verifyOnPage(SelectStrengthCategoryPage)
   }
 
+  clickCreateEducationSupportPlanButton(): WhoCreatedThePlanPage {
+    this.createEducationSupportPlanButton().click()
+    return Page.verifyOnPage(WhoCreatedThePlanPage)
+  }
+
+  clickDeclineEducationSupportPlanButton(): ReasonPage {
+    this.declineEducationSupportPlanButton().click()
+    return Page.verifyOnPage(ReasonPage)
+  }
+
+  actionsCardContainsEducationSupportPlanActions() {
+    this.actionsCard().should('exist')
+    this.educationSupportPlanActionItems().should('exist')
+    return this
+  }
+
   private tabBarLink = (targetTab: string): PageElement => cy.get(`.moj-sub-navigation__link:contains('${targetTab}')`)
 
   private activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
@@ -62,4 +80,14 @@ export default abstract class ProfilePage extends Page {
   private addConditionsButton = (): PageElement => cy.get('[data-qa=add-conditions-button]')
 
   private addStrengthButton = (): PageElement => cy.get('[data-qa=add-strength-button]')
+
+  private createEducationSupportPlanButton = (): PageElement => cy.get('[data-qa=create-education-support-plan-button]')
+
+  private declineEducationSupportPlanButton = (): PageElement =>
+    cy.get('[data-qa=decline-education-support-plan-button]')
+
+  private actionsCard = (): PageElement => cy.get('[data-qa=actions-card]')
+
+  private educationSupportPlanActionItems = (): PageElement =>
+    cy.get('[data-qa=education-support-plan-action-items] li')
 }

--- a/server/routes/profile/challenges/challengesController.test.ts
+++ b/server/routes/profile/challenges/challengesController.test.ts
@@ -9,6 +9,7 @@ import { Result } from '../../../utils/result/result'
 import { aValidAlnScreenerList, aValidAlnScreenerResponseDto } from '../../../testsupport/alnScreenerDtoTestDataBuilder'
 import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
 import ChallengeCategory from '../../../enums/challengeCategory'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 describe('challengesController', () => {
   const controller = new ChallengesController()
@@ -35,11 +36,12 @@ describe('challengesController', () => {
     }),
   )
   const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
 
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary, challenges, alnScreeners, prisonNamesById },
+    locals: { prisonerSummary, challenges, alnScreeners, prisonNamesById, educationSupportPlanLifecycleStatus },
   } as unknown as Response
   const next = jest.fn()
 
@@ -54,6 +56,7 @@ describe('challengesController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonNamesById,
       prisonerSummary,
+      educationSupportPlanLifecycleStatus,
       tab: 'challenges',
       groupedChallenges: expect.objectContaining({
         status: 'fulfilled',

--- a/server/routes/profile/challenges/challengesController.ts
+++ b/server/routes/profile/challenges/challengesController.ts
@@ -17,7 +17,9 @@ export type GroupedStructuredChallenges = Record<
 
 export default class ChallengesController {
   getChallengesView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary, challenges, alnScreeners, prisonNamesById } = res.locals
+    const { prisonerSummary, challenges, alnScreeners, prisonNamesById, educationSupportPlanLifecycleStatus } =
+      res.locals
+
     const alnScreenersResult = alnScreeners as Result<AlnScreenerList>
 
     let groupedChallengesPromise: Result<GroupedStructuredChallenges, Error>
@@ -35,6 +37,7 @@ export default class ChallengesController {
     const viewRenderArgs = {
       prisonNamesById,
       prisonerSummary,
+      educationSupportPlanLifecycleStatus,
       tab: 'challenges',
       groupedChallenges: groupedChallengesPromise,
     }

--- a/server/routes/profile/challenges/index.ts
+++ b/server/routes/profile/challenges/index.ts
@@ -5,15 +5,18 @@ import { Services } from '../../../services'
 import retrieveCurrentChallenges from '../middleware/retrieveCurrentChallenges'
 import retrieveAlnScreeners from '../middleware/retrieveAlnScreeners'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
 
 const challengesRoutes = (services: Services): Router => {
+  const { additionalLearningNeedsService, challengeService, educationSupportPlanService, prisonService } = services
   const controller = new ChallengesController()
 
   return Router({ mergeParams: true }) //
     .get('/', [
-      retrievePrisonsLookup(services.prisonService),
-      retrieveCurrentChallenges(services.challengeService),
-      retrieveAlnScreeners(services.additionalLearningNeedsService),
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
+      retrievePrisonsLookup(prisonService),
+      retrieveCurrentChallenges(challengeService),
+      retrieveAlnScreeners(additionalLearningNeedsService),
       asyncMiddleware(controller.getChallengesView),
     ])
 }

--- a/server/routes/profile/conditions/conditionsController.test.ts
+++ b/server/routes/profile/conditions/conditionsController.test.ts
@@ -3,6 +3,7 @@ import ConditionsController from './conditionsController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataBuilder'
 import { Result } from '../../../utils/result/result'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 describe('conditionsController', () => {
   const controller = new ConditionsController()
@@ -10,11 +11,12 @@ describe('conditionsController', () => {
   const prisonerSummary = aValidPrisonerSummary()
   const conditions = Result.fulfilled(aValidConditionsList())
   const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
 
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary, conditions, prisonNamesById },
+    locals: { prisonerSummary, conditions, prisonNamesById, educationSupportPlanLifecycleStatus },
   } as unknown as Response
   const next = jest.fn()
 
@@ -29,6 +31,7 @@ describe('conditionsController', () => {
       prisonerSummary,
       conditions,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       tab: 'conditions',
     }
 

--- a/server/routes/profile/conditions/conditionsController.ts
+++ b/server/routes/profile/conditions/conditionsController.ts
@@ -2,8 +2,14 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default class ConditionsController {
   getConditionsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary, conditions, prisonNamesById } = res.locals
-    const viewRenderArgs = { prisonerSummary, conditions, prisonNamesById, tab: 'conditions' }
+    const { prisonerSummary, conditions, prisonNamesById, educationSupportPlanLifecycleStatus } = res.locals
+    const viewRenderArgs = {
+      prisonerSummary,
+      conditions,
+      prisonNamesById,
+      educationSupportPlanLifecycleStatus,
+      tab: 'conditions',
+    }
     return res.render('pages/profile/conditions/index', viewRenderArgs)
   }
 }

--- a/server/routes/profile/conditions/index.ts
+++ b/server/routes/profile/conditions/index.ts
@@ -4,13 +4,15 @@ import ConditionsController from './conditionsController'
 import { Services } from '../../../services'
 import retrieveConditions from '../middleware/retrieveConditions'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
 
 const conditionsRoutes = (services: Services): Router => {
-  const { conditionService, prisonService } = services
+  const { conditionService, educationSupportPlanService, prisonService } = services
   const controller = new ConditionsController()
 
   return Router({ mergeParams: true }) //
     .get('/', [
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
       retrievePrisonsLookup(prisonService),
       retrieveConditions(conditionService),
       asyncMiddleware(controller.getConditionsView),

--- a/server/routes/profile/overview/index.ts
+++ b/server/routes/profile/overview/index.ts
@@ -2,13 +2,13 @@ import { Router } from 'express'
 import { Services } from '../../../services'
 import OverviewController from './overviewController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
-import retrieveCurrentEducationSupportPlanCreationSchedule from '../middleware/retrieveCurrentEducationSupportPlanCreationSchedule'
 import retrieveConditions from '../middleware/retrieveConditions'
 import retrieveStrengths from '../middleware/retrieveStrengths'
 import retrieveAlnScreeners from '../middleware/retrieveAlnScreeners'
 import retrieveCurrentChallenges from '../middleware/retrieveCurrentChallenges'
 import retrieveCuriousAlnAndLddAssessments from '../middleware/retrieveCuriousAlnAndLddAssessments'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
 
 const overviewRoutes = (services: Services): Router => {
   const {
@@ -16,7 +16,7 @@ const overviewRoutes = (services: Services): Router => {
     challengeService,
     conditionService,
     curiousService,
-    educationSupportPlanScheduleService,
+    educationSupportPlanService,
     prisonService,
     strengthService,
   } = services
@@ -24,7 +24,7 @@ const overviewRoutes = (services: Services): Router => {
 
   return Router({ mergeParams: true }) //
     .get('/', [
-      retrieveCurrentEducationSupportPlanCreationSchedule(educationSupportPlanScheduleService),
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
       retrieveAlnScreeners(additionalLearningNeedsService),
       retrieveConditions(conditionService),
       retrieveStrengths(strengthService),

--- a/server/routes/profile/overview/overviewController.test.ts
+++ b/server/routes/profile/overview/overviewController.test.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import OverviewController from './overviewController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import aValidPlanCreationScheduleDto from '../../../testsupport/planCreationScheduleDtoTestDataBuilder'
 import { Result } from '../../../utils/result/result'
 import { aValidConditionsList } from '../../../testsupport/conditionDtoTestDataBuilder'
 import {
@@ -17,12 +16,13 @@ import { aValidAlnScreenerResponseDto } from '../../../testsupport/alnScreenerDt
 import StrengthCategory from '../../../enums/strengthCategory'
 import ChallengeCategory from '../../../enums/challengeCategory'
 import { aCuriousAlnAndLddAssessmentsDto } from '../../../testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 describe('overviewController', () => {
   const controller = new OverviewController()
 
   const prisonerSummary = aValidPrisonerSummary()
-  const educationSupportPlanCreationSchedule = Result.fulfilled(aValidPlanCreationScheduleDto())
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
   const conditions = Result.fulfilled(aValidConditionsList())
 
   // Non-ALN strengths
@@ -85,7 +85,7 @@ describe('overviewController', () => {
     render: jest.fn(),
     locals: {
       prisonerSummary,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       strengths,
@@ -109,7 +109,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
@@ -150,7 +150,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
@@ -177,7 +177,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       tab: 'overview',
       challengeCategories: expect.objectContaining({
@@ -203,7 +203,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
@@ -232,7 +232,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
@@ -261,7 +261,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
@@ -299,7 +299,7 @@ describe('overviewController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',

--- a/server/routes/profile/overview/overviewController.ts
+++ b/server/routes/profile/overview/overviewController.ts
@@ -18,7 +18,7 @@ export default class OverviewController {
       conditions,
       challenges,
       curiousAlnAndLddAssessments,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       prisonNamesById,
       strengths,
     } = res.locals
@@ -61,7 +61,7 @@ export default class OverviewController {
     const viewRenderArgs = {
       prisonerSummary,
       conditions,
-      educationSupportPlanCreationSchedule,
+      educationSupportPlanLifecycleStatus,
       strengthCategories: strengthCategoriesPromise,
       challengeCategories: challengeCategoriesPromise,
       curiousAlnAndLddAssessments,

--- a/server/routes/profile/strengths/index.ts
+++ b/server/routes/profile/strengths/index.ts
@@ -5,13 +5,15 @@ import { Services } from '../../../services'
 import retrieveStrengths from '../middleware/retrieveStrengths'
 import retrieveAlnScreeners from '../middleware/retrieveAlnScreeners'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
 
 const strengthsRoutes = (services: Services): Router => {
-  const { additionalLearningNeedsService, prisonService, strengthService } = services
+  const { additionalLearningNeedsService, educationSupportPlanService, prisonService, strengthService } = services
   const controller = new StrengthsController()
 
   return Router({ mergeParams: true }) //
     .get('/', [
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
       retrievePrisonsLookup(prisonService),
       retrieveStrengths(strengthService),
       retrieveAlnScreeners(additionalLearningNeedsService),

--- a/server/routes/profile/strengths/strengthsController.test.ts
+++ b/server/routes/profile/strengths/strengthsController.test.ts
@@ -10,6 +10,7 @@ import {
   setupNonAlnStrengthsPromise,
 } from '../profileTestSupportFunctions'
 import { aValidAlnScreenerResponseDto } from '../../../testsupport/alnScreenerDtoTestDataBuilder'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 describe('strengthsController', () => {
   const controller = new StrengthsController()
@@ -18,6 +19,7 @@ describe('strengthsController', () => {
 
   const prisonId = 'MDI'
   const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
 
   // Non-ALN strengths
   const { numeracy, numeracy2, literacy, emotionsNonActive, attention, speaking } = setupNonAlnStrengths()
@@ -40,7 +42,7 @@ describe('strengthsController', () => {
   const req = {} as unknown as Request
   const res = {
     render,
-    locals: { prisonerSummary, strengths, alnScreeners, prisonNamesById },
+    locals: { prisonerSummary, strengths, alnScreeners, prisonNamesById, educationSupportPlanLifecycleStatus },
   } as unknown as Response
   const next = jest.fn()
 
@@ -98,6 +100,7 @@ describe('strengthsController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       tab: 'strengths',
       groupedStrengths: expect.objectContaining({
         status: 'fulfilled',
@@ -125,6 +128,7 @@ describe('strengthsController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       tab: 'strengths',
       groupedStrengths: expect.objectContaining({
         status: 'rejected',
@@ -149,6 +153,7 @@ describe('strengthsController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       tab: 'strengths',
       groupedStrengths: expect.objectContaining({
         status: 'rejected',
@@ -175,6 +180,7 @@ describe('strengthsController', () => {
     const expectedViewModel = expect.objectContaining({
       prisonerSummary,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       tab: 'strengths',
       groupedStrengths: expect.objectContaining({
         status: 'rejected',

--- a/server/routes/profile/strengths/strengthsController.ts
+++ b/server/routes/profile/strengths/strengthsController.ts
@@ -23,7 +23,8 @@ export type GroupedStrengths = Record<
 
 export default class StrengthsController {
   getStrengthsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { alnScreeners, prisonerSummary, prisonNamesById, strengths } = res.locals
+    const { alnScreeners, educationSupportPlanLifecycleStatus, prisonerSummary, prisonNamesById, strengths } =
+      res.locals
 
     let groupedStrengthsPromise: Result<GroupedStrengths, Error>
     if (alnScreeners.isFulfilled() && strengths.isFulfilled()) {
@@ -63,6 +64,7 @@ export default class StrengthsController {
     const viewRenderArgs = {
       prisonerSummary,
       prisonNamesById,
+      educationSupportPlanLifecycleStatus,
       groupedStrengths: groupedStrengthsPromise,
       tab: 'strengths',
     }

--- a/server/views/pages/profile/challenges/index.njk
+++ b/server/views/pages/profile/challenges/index.njk
@@ -12,6 +12,10 @@
   </div>
 
   <div class="govuk-grid-row">
+
+    {% set educationSupportPlanLifecycleStatusFulFilled = educationSupportPlanLifecycleStatus.isFulfilled() %}
+    {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value if educationSupportPlanLifecycleStatusFulFilled else {} %}
+
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       {% if groupedChallenges.isFulfilled() %}
@@ -31,7 +35,9 @@
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
         userHasPermissionTo: userHasPermissionTo,
-        prisonerSummary: prisonerSummary
+        prisonerSummary: prisonerSummary,
+        planStatus: educationSupportPlanLifecycleStatus.status,
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -13,6 +13,10 @@
   </div>
 
   <div class="govuk-grid-row">
+
+    {% set educationSupportPlanLifecycleStatusFulFilled = educationSupportPlanLifecycleStatus.isFulfilled() %}
+    {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value if educationSupportPlanLifecycleStatusFulFilled else {} %}
+
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       {% if conditions.isFulfilled() %}
@@ -51,7 +55,9 @@
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
         userHasPermissionTo: userHasPermissionTo,
-        prisonerSummary: prisonerSummary
+        prisonerSummary: prisonerSummary,
+        planStatus: educationSupportPlanLifecycleStatus.status,
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/conditions/index.test.ts
+++ b/server/views/pages/profile/conditions/index.test.ts
@@ -10,6 +10,7 @@ import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnProper
 import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
 import ConditionType from '../../../../enums/conditionType'
 import ConditionSource from '../../../../enums/conditionSource'
+import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -46,6 +47,7 @@ const templateParams = {
   tab: 'conditions',
   conditions: Result.fulfilled(aValidConditionsList()),
   prisonNamesById: Result.fulfilled(prisonNamesById),
+  educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
   pageHasApiErrors: false,
 }
 

--- a/server/views/pages/profile/overview/index.njk
+++ b/server/views/pages/profile/overview/index.njk
@@ -1,11 +1,15 @@
 {% extends "../layout.njk" %}
-{% from "../../../components/actions-card/macro.njk" import actionsCard %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-overview' %}
 {% set pageTitle = "Support for additional needs" %}
 
 {% block content %}
   <div class="govuk-grid-row profile-overview">
+
+    {% set educationSupportPlanLifecycleStatusFulFilled = educationSupportPlanLifecycleStatus.isFulfilled() %}
+    {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value if educationSupportPlanLifecycleStatusFulFilled else {} %}
+
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       <div class="two-column-summary-cards">
@@ -19,9 +23,10 @@
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
-        prisonerSummary: prisonerSummary,
         userHasPermissionTo: userHasPermissionTo,
-        educationSupportPlanCreationSchedule: educationSupportPlanCreationSchedule.value if educationSupportPlanCreationSchedule.isFulfilled()
+        prisonerSummary: prisonerSummary,
+        planStatus: educationSupportPlanLifecycleStatus.status,
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/overview/index.test.ts
+++ b/server/views/pages/profile/overview/index.test.ts
@@ -4,7 +4,6 @@ import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDa
 import formatDate from '../../../../filters/formatDateFilter'
 import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
 import { Result } from '../../../../utils/result/result'
-import aValidPlanCreationScheduleDto from '../../../../testsupport/planCreationScheduleDtoTestDataBuilder'
 import { aValidConditionsList } from '../../../../testsupport/conditionDtoTestDataBuilder'
 import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnPropertyFilter'
 import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
@@ -14,6 +13,7 @@ import ChallengeCategory from '../../../../enums/challengeCategory'
 import formatChallengeCategoryScreenValueFilter from '../../../../filters/formatChallengeCategoryFilter'
 import { aCuriousAlnAndLddAssessmentsDto } from '../../../../testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder'
 import formatAlnAssessmentReferralScreenValueFilter from '../../../../filters/formatAlnAssessmentReferralFilter'
+import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -50,7 +50,7 @@ const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary,
   tab: 'overview',
-  educationSupportPlanCreationSchedule: Result.fulfilled(aValidPlanCreationScheduleDto()),
+  educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
   conditions: Result.fulfilled(aValidConditionsList()),
   strengthCategories: Result.fulfilled([StrengthCategory.LITERACY_SKILLS, StrengthCategory.NUMERACY_SKILLS]),
   challengeCategories: Result.fulfilled([ChallengeCategory.LITERACY_SKILLS, ChallengeCategory.NUMERACY_SKILLS]),
@@ -70,7 +70,7 @@ describe('Profile overview page', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
-      educationSupportPlanCreationSchedule: Result.fulfilled(aValidPlanCreationScheduleDto()),
+      educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
       pageHasApiErrors: false,
     }
 
@@ -87,15 +87,15 @@ describe('Profile overview page', () => {
     expect($('[data-qa=challenges-summary-card]').length).toEqual(1)
     expect($('[data-qa=support-recommendations-summary-card]').length).toEqual(1)
     expect($('[data-qa=actions-card]').length).toEqual(1)
-    expect($('[data-qa=actions-card] li').length).toEqual(2)
+    expect($('[data-qa=actions-card] li').length).toEqual(6)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
-  it('should render the profile overview page given the plan creation schedule service API promise is not resolved', () => {
+  it('should render the profile overview page given the plan action status service API promise is not resolved', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
-      educationSupportPlanCreationSchedule: Result.rejected(new Error('Failed to get plan creation schedule')),
+      educationSupportPlanLifecycleStatus: Result.rejected(new Error('Failed to get plan action status')),
       pageHasApiErrors: true,
     }
 
@@ -112,7 +112,7 @@ describe('Profile overview page', () => {
     expect($('[data-qa=challenges-summary-card]').length).toEqual(1)
     expect($('[data-qa=support-recommendations-summary-card]').length).toEqual(1)
     expect($('[data-qa=actions-card]').length).toEqual(1)
-    expect($('[data-qa=actions-card] li').length).toEqual(0)
+    expect($('[data-qa=actions-card] li').length).toEqual(5)
     expect($('[data-qa=api-error-banner]').length).toEqual(1)
   })
 })

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -13,6 +13,10 @@
   </div>
 
   <div class="govuk-grid-row">
+
+    {% set educationSupportPlanLifecycleStatusFulFilled = educationSupportPlanLifecycleStatus.isFulfilled() %}
+    {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value if educationSupportPlanLifecycleStatusFulFilled else {} %}
+
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
       {% if groupedStrengths.isFulfilled() %}
@@ -44,7 +48,9 @@
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
         userHasPermissionTo: userHasPermissionTo,
-        prisonerSummary: prisonerSummary
+        prisonerSummary: prisonerSummary,
+        planStatus: educationSupportPlanLifecycleStatus.status,
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/strengths/index.test.ts
+++ b/server/views/pages/profile/strengths/index.test.ts
@@ -11,6 +11,7 @@ import formatStrengthIdentificationSourceScreenValueFilter from '../../../../fil
 import { formatStrengthTypeScreenValueFilter } from '../../../../filters/formatStrengthTypeFilter'
 import StrengthType from '../../../../enums/strengthType'
 import StrengthCategory from '../../../../enums/strengthCategory'
+import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -48,6 +49,7 @@ const templateParams = {
   tab: 'strengths',
   groupedStrengths: Result.fulfilled({}),
   prisonNamesById: Result.fulfilled(prisonNamesById),
+  educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
   pageHasApiErrors: false,
 }
 


### PR DESCRIPTION
PR to wire the new Actions Bar into the Overview, Conditions, Challenges and Strengths pages
(It was already wired into the Education Support Plan page; and as per my earlier PR I'm leaving the Support Strategies page for the time being as @srowlands-moj is working on that page in a different branch/PR)

This is quite a big PR (sorry!), but many of the changes are to the integration tests. Using the new Actions Bar on the Overview page has meant that the route no longer calls the current plan schedule endpoint, and instead calls the new plan actions status endpoint. And because of that, every cypress test that uses/goes via the Overview page has had to change the stubs that it uses.

https://github.com/user-attachments/assets/4805030e-b6c6-4281-9030-1762c3e8f938


