### PR TITLE
RR-1791 - Move challenges middleware so that it can be re-used by other routes

### DIFF
--- a/server/routes/middleware/retrieveChallenges.test.ts
+++ b/server/routes/middleware/retrieveChallenges.test.ts
@@ -1,14 +1,14 @@
 import { Request, Response } from 'express'
-import ChallengeService from '../../../services/challengeService'
-import retrieveCurrentChallenges from './retrieveCurrentChallenges'
-import { aValidChallengeResponse } from '../../../testsupport/challengeResponseTestDataBuilder'
+import ChallengeService from '../../services/challengeService'
+import retrieveChallenges from './retrieveChallenges'
+import { aValidChallengeResponse } from '../../testsupport/challengeResponseTestDataBuilder'
 
-jest.mock('../../../services/challengeService')
+jest.mock('../../services/challengeService')
 
-describe('retrieveCurrentChallenges', () => {
+describe('retrieveChallenges', () => {
   const mockedChallengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
 
-  const requestHandler = retrieveCurrentChallenges(mockedChallengeService)
+  const requestHandler = retrieveChallenges(mockedChallengeService)
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
 
@@ -28,7 +28,7 @@ describe('retrieveCurrentChallenges', () => {
     res.locals = { user: undefined, apiErrorCallback }
   })
 
-  it('should retrieve current challenges and store in res.locals', async () => {
+  it('should retrieve challenges and store in res.locals', async () => {
     // Given
     const expectedChallenge = [aValidChallengeResponse()]
     mockedChallengeService.getChallenges.mockResolvedValue(expectedChallenge)

--- a/server/routes/middleware/retrieveChallenges.ts
+++ b/server/routes/middleware/retrieveChallenges.ts
@@ -1,11 +1,11 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import { ChallengeService } from '../../../services'
-import { Result } from '../../../utils/result/result'
+import { ChallengeService } from '../../services'
+import { Result } from '../../utils/result/result'
 
 /**
- *  Function that returns a middleware function to retrieve the prisoner's current challenges
+ *  Function that returns a middleware function to retrieve the prisoner's challenges
  */
-const retrieveCurrentChallenges = (challengeService: ChallengeService): RequestHandler => {
+const retrieveChallenges = (challengeService: ChallengeService): RequestHandler => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
@@ -19,4 +19,4 @@ const retrieveCurrentChallenges = (challengeService: ChallengeService): RequestH
   }
 }
 
-export default retrieveCurrentChallenges
+export default retrieveChallenges

--- a/server/routes/profile/challenges/index.ts
+++ b/server/routes/profile/challenges/index.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ChallengesController from './challengesController'
 import { Services } from '../../../services'
-import retrieveCurrentChallenges from '../middleware/retrieveCurrentChallenges'
+import retrieveChallenges from '../../middleware/retrieveChallenges'
 import retrieveAlnScreeners from '../../middleware/retrieveAlnScreeners'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
 import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
@@ -15,7 +15,7 @@ const challengesRoutes = (services: Services): Router => {
     .get('/', [
       retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
       retrievePrisonsLookup(prisonService),
-      retrieveCurrentChallenges(challengeService),
+      retrieveChallenges(challengeService),
       retrieveAlnScreeners(additionalLearningNeedsService),
       asyncMiddleware(controller.getChallengesView),
     ])

--- a/server/routes/profile/overview/index.ts
+++ b/server/routes/profile/overview/index.ts
@@ -5,7 +5,7 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import retrieveConditions from '../middleware/retrieveConditions'
 import retrieveStrengths from '../../middleware/retrieveStrengths'
 import retrieveAlnScreeners from '../../middleware/retrieveAlnScreeners'
-import retrieveCurrentChallenges from '../middleware/retrieveCurrentChallenges'
+import retrieveChallenges from '../../middleware/retrieveChallenges'
 import retrieveCuriousAlnAndLddAssessments from '../middleware/retrieveCuriousAlnAndLddAssessments'
 import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
 import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
@@ -28,7 +28,7 @@ const overviewRoutes = (services: Services): Router => {
       retrieveAlnScreeners(additionalLearningNeedsService),
       retrieveConditions(conditionService),
       retrieveStrengths(strengthService),
-      retrieveCurrentChallenges(challengeService),
+      retrieveChallenges(challengeService),
       retrieveCuriousAlnAndLddAssessments(curiousService),
       retrievePrisonsLookup(prisonService),
       asyncMiddleware(controller.getOverviewView),


### PR DESCRIPTION
PR to refactor the middleware that retrieve the challenges from within the routes/profile/middleware subdirectory up one level to routes/middleware

This is so that this middleware can be re-used by other routes. At the moment only the profile pages/routes use them, hence where they are currently in the directory structure, but [RR-1791](https://dsdmoj.atlassian.net/browse/RR-1791) calls for challenges to be displayed as part of the Create ELSP journey, hence moving them to a place that is more convenient for both routes to be able to call them from.

Also, a minor rename in the middleware file and exported function - the previous use of the term "Current" in the name was wrong/misleading, and the middleware gets ALL challenges from the service (and subsequent code filters for the "current" / active ones )

[RR-1791]: https://dsdmoj.atlassian.net/browse/RR-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ