### PR TITLE
RR-1755 Cypress tests for Support Strategies on Overview page

### DIFF
--- a/integration_tests/e2e/profile/overviewSupportStrategies.cy.ts
+++ b/integration_tests/e2e/profile/overviewSupportStrategies.cy.ts
@@ -1,0 +1,49 @@
+/**
+ * Cypress scenarios for the Support Strategies section of the Profile Overview page.
+ */
+
+import OverviewPage from '../../pages/profile/overviewPage'
+import Page from '../../pages/page'
+
+context('Profile Overview Page - Support Strategies section', () => {
+  const prisonNumber = 'H4115SD'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetPlanActionStatus', { prisonNumber })
+    cy.task('stubGetConditions', { prisonNumber })
+    cy.task('stubGetChallenges', { prisonNumber })
+    cy.task('stubGetStrengths', { prisonNumber })
+    cy.task('stubGetCuriousV2Assessments', { prisonNumber })
+    cy.task('stubGetSupportStrategies', { prisonNumber, supportStrategies: [] })
+  })
+
+  it('should display overview page given the prisoner has no support strategies recorded', () => {
+    // Given
+    cy.task('stubGetSupportStrategies', { prisonNumber, supportStrategies: [] })
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/overview`)
+
+    // Then
+    Page.verifyOnPage(OverviewPage) //
+      .hasNoSupportStrategiesRecorded()
+      .apiErrorBannerIsNotDisplayed()
+  })
+
+  it('should display overview page given retrieving the prisoners support strategies returns an error', () => {
+    // Given
+    cy.task('stubGetSupportStrategies500Error', prisonNumber)
+
+    // When
+    cy.visit(`/profile/${prisonNumber}/overview`)
+
+    // Then
+    Page.verifyOnPage(OverviewPage) //
+      .hasSupportStrategiesUnavailableMessage()
+      .apiErrorBannerIsDisplayed()
+  })
+})

--- a/integration_tests/pages/profile/overviewPage.ts
+++ b/integration_tests/pages/profile/overviewPage.ts
@@ -63,6 +63,11 @@ export default class OverviewPage extends ProfilePage {
     return this
   }
 
+  hasSupportStrategiesUnavailableMessage(): OverviewPage {
+    this.supportStrategiesUnavailableMessage().should('be.visible')
+    return this
+  }
+
   hasNoConditionsRecorded(): OverviewPage {
     this.conditionsSummaryCardContent().should('contain', 'No conditions recorded')
     this.conditionsUnavailableMessage().should('not.exist')
@@ -113,6 +118,8 @@ export default class OverviewPage extends ProfilePage {
     cy.get('[data-qa=strengths-summary-card] .govuk-summary-card__content')
 
   private strengthsUnavailableMessage = (): PageElement => cy.get('[data-qa=strengths-unavailable-message]')
+
+  private supportStrategiesUnavailableMessage = (): PageElement => cy.get('[data-qa=support-strategies-unavailable-message]')
 
   private supportStrategiesSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=support-strategies-summary-card] .govuk-summary-card__content')

--- a/integration_tests/pages/profile/overviewPage.ts
+++ b/integration_tests/pages/profile/overviewPage.ts
@@ -119,7 +119,8 @@ export default class OverviewPage extends ProfilePage {
 
   private strengthsUnavailableMessage = (): PageElement => cy.get('[data-qa=strengths-unavailable-message]')
 
-  private supportStrategiesUnavailableMessage = (): PageElement => cy.get('[data-qa=support-strategies-unavailable-message]')
+  private supportStrategiesUnavailableMessage = (): PageElement =>
+    cy.get('[data-qa=support-strategies-unavailable-message]')
 
   private supportStrategiesSummaryCardContent = (): PageElement =>
     cy.get('[data-qa=support-strategies-summary-card] .govuk-summary-card__content')


### PR DESCRIPTION
* Add initial cypress tests for Support strategies on the overview page.
* More detailed tests to be added for the overview page once completed.