### PR TITLE
RR-1872 prevent Oct 2025 review dates

### DIFF
--- a/server/routes/education-support-plan/validationSchemas/reviewSupportPlanSchema.ts
+++ b/server/routes/education-support-plan/validationSchemas/reviewSupportPlanSchema.ts
@@ -1,4 +1,4 @@
-import { addMonths, startOfToday } from 'date-fns'
+import { addMonths, startOfToday, parse } from 'date-fns'
 import { createSchema, dateIsWithinInterval } from '../../../middleware/validationMiddleware'
 
 const reviewSupportPlanSchema = async () => {
@@ -14,7 +14,14 @@ const reviewSupportPlanSchema = async () => {
       start: startOfToday(),
       end: addMonths(startOfToday(), 3),
     }),
-  })
+  }).refine(
+    reviewDate => {
+      const date = parse(reviewDate.reviewDate as string, 'dd/MM/yyyy', new Date())
+      const isOctober2025 = date.getFullYear() === 2025 && date.getMonth() === 9
+      return !isOctober2025
+    },
+    { path: ['reviewDate'], message: 'Review date cannot be in October 2025' },
+  )
 }
 
 export default reviewSupportPlanSchema

--- a/server/views/pages/education-support-plan/review-support-plan/index.njk
+++ b/server/views/pages/education-support-plan/review-support-plan/index.njk
@@ -21,7 +21,7 @@
               text: "Review date"
             },
             hint: {
-              text: "Must be within 3 months of plan creation"
+              text: "Must be within 3 months of plan creation. Cannot be in the month of October 2025"
             },
             errorMessage: errors | findError('reviewDate')
           }) }}


### PR DESCRIPTION
* Updates review date validation schema to prevent to fail with appropriate message if an October 2025 date is selected.
* Add a temporary workaround for one of the existing validation tests to prevent it from failing when the test is run in Oct.