### PR TITLE
RR-1658 - Page title changes for non-journey pages

### DIFF
--- a/server/views/pages/profile/overview/index.njk
+++ b/server/views/pages/profile/overview/index.njk
@@ -2,7 +2,7 @@
 {% from "../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-overview' %}
-{% set pageTitle = "Support for additional needs" %}
+{% set pageTitle = "Support for additional needs - Overview" %}
 
 {% block content %}
   <div class="govuk-grid-row profile-overview">

--- a/server/views/pages/search/index.njk
+++ b/server/views/pages/search/index.njk
@@ -1,7 +1,7 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set pageId = 'search-page' %}
-{% set pageTitle = "Support for additional needs" %}
+{% set pageTitle = "Support for additional needs - Prisoner List" %}
 
 {% block beforeContent %}
   <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">


### PR DESCRIPTION
This PR corrects the page titles (html `<title>` elements) for the non-journey pages
The non-journey pages are:
* Prisoner List / Search
* Profile Overview
* Profile Strengths
* Profile Conditions
* Profile Challenges
* Profile Support Strategies
* Profile Education Support Plan

Of these 7 pages, only 2 needed correcting - Prisoner List and Overview. The rest were already correct 👍 