### PR TITLE
RR-1909 - Hide plan review date when it is 2099-12-31

### DIFF
--- a/server/views/pages/profile/challenges/index.njk
+++ b/server/views/pages/profile/challenges/index.njk
@@ -70,7 +70,8 @@
         userHasPermissionTo: userHasPermissionTo,
         prisonerSummary: prisonerSummary,
         planStatus: educationSupportPlanLifecycleStatus.status,
-        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/components/actions-card/actionsCard.test.ts
+++ b/server/views/pages/profile/components/actions-card/actionsCard.test.ts
@@ -593,13 +593,13 @@ describe('Tests for Profile pages actions card component', () => {
     '2099-12-30',
     '2100-01-01',
   ])(
-    'it should render the action cards component with a plan creation date given the plan is due and the plan creation date is %s',
+    'it should render the action cards component with a plan review date given the plan is active and the plan review date is %s',
     date => {
       // Given
       const params = {
         ...templateParams,
-        planStatus: PlanActionStatus.PLAN_DUE,
-        planCreationDeadlineDate: startOfDay(date),
+        planStatus: PlanActionStatus.ACTIVE_PLAN,
+        planReviewDeadlineDate: startOfDay(date),
       }
 
       // When
@@ -607,19 +607,17 @@ describe('Tests for Profile pages actions card component', () => {
       const $ = cheerio.load(content)
 
       // Then
-      expect($('[data-qa=plan-due-tag]').length).toEqual(1)
-      expect($('[data-qa=plan-creation-due-date]').text().trim()).toEqual(
-        `Create plan by ${format(date, 'd MMM yyyy')}`,
-      )
+      expect($('[data-qa=active-plan-tag]').length).toEqual(1)
+      expect($('[data-qa=plan-review-due-date]').text().trim()).toEqual(`Review due ${format(date, 'd MMM yyyy')}`)
     },
   )
 
-  it('it should render the action cards component without a plan creation date given the plan is due and the plan creation date is 2099-12-31', () => {
+  it('it should render the action cards component without a plan review date given the plan is active and the plan review date is 2099-12-31', () => {
     // Given
     const params = {
       ...templateParams,
-      planStatus: PlanActionStatus.PLAN_DUE,
-      planCreationDeadlineDate: startOfDay('2099-12-31'),
+      planStatus: PlanActionStatus.ACTIVE_PLAN,
+      planReviewDeadlineDate: startOfDay('2099-12-31'),
     }
 
     // When
@@ -627,7 +625,7 @@ describe('Tests for Profile pages actions card component', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=plan-due-tag]').length).toEqual(1)
-    expect($('[data-qa=plan-creation-due-date]').length).toEqual(0)
+    expect($('[data-qa=active-plan-tag]').length).toEqual(1)
+    expect($('[data-qa=plan-review-due-date]').length).toEqual(0)
   })
 })

--- a/server/views/pages/profile/components/actions-card/template.njk
+++ b/server/views/pages/profile/components/actions-card/template.njk
@@ -25,16 +25,16 @@
           <span class="govuk-tag govuk-tag--yellow govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="plan-due-tag">
             Plan Due
           </span>
-          {% if planCreationDeadlineDate | formatDate('yyyy-MM-dd') != '2099-12-31' %}
-            <p class="govuk-body" data-qa="plan-creation-due-date">Create plan by {{ planCreationDeadlineDate | formatDate('d MMM yyyy') }}</p>
-          {% endif %}
+          <p class="govuk-body" data-qa="plan-creation-due-date">Create plan by {{ planCreationDeadlineDate | formatDate('d MMM yyyy') }}</p>
         {% endif %}
 
         {% if planStatus == 'ACTIVE_PLAN' %}
           <span class="govuk-tag govuk-tag--green govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="active-plan-tag">
             Active plan
           </span>
-          <p class="govuk-body" data-qa="plan-review-due-date">Review due {{ planReviewDeadlineDate | formatDate('d MMM yyyy') }}</p>
+          {% if planReviewDeadlineDate | formatDate('yyyy-MM-dd') != '2099-12-31' %}
+            <p class="govuk-body" data-qa="plan-review-due-date">Review due {{ planReviewDeadlineDate | formatDate('d MMM yyyy') }}</p>
+          {% endif %}
         {% endif %}
 
         {% if planStatus == 'PLAN_OVERDUE' %}

--- a/server/views/pages/profile/conditions/index.njk
+++ b/server/views/pages/profile/conditions/index.njk
@@ -68,7 +68,8 @@
         userHasPermissionTo: userHasPermissionTo,
         prisonerSummary: prisonerSummary,
         planStatus: educationSupportPlanLifecycleStatus.status,
-        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/education-support-plan/index.njk
+++ b/server/views/pages/profile/education-support-plan/index.njk
@@ -67,7 +67,8 @@
         userHasPermissionTo: userHasPermissionTo,
         prisonerSummary: prisonerSummary,
         planStatus: educationSupportPlanLifecycleStatus.status,
-        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
       }) }}
     </div>
 

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -62,7 +62,8 @@
         userHasPermissionTo: userHasPermissionTo,
         prisonerSummary: prisonerSummary,
         planStatus: educationSupportPlanLifecycleStatus.status,
-        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
       }) }}
     </div>
   </div>

--- a/server/views/pages/profile/support-strategies/index.njk
+++ b/server/views/pages/profile/support-strategies/index.njk
@@ -60,7 +60,8 @@
         userHasPermissionTo: userHasPermissionTo,
         prisonerSummary: prisonerSummary,
         planStatus: educationSupportPlanLifecycleStatus.status,
-        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
       }) }}
     </div>
   </div>


### PR DESCRIPTION
My previous PR for this ticket was wrong!
I hid the plan **creation** date when the plan status was **due**

Actually, it should have been to hide the plan **review** date (when it is 2099-12-31) when the plan status is **active**

This PR corrects that.