### PR TITLE
RR-1935 - Define HMPPS Audit event types and service methods

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
 import { Services } from './services'
-import { Page, PageViewEventDetails } from './services/auditService'
+import { Page, BaseAuditData } from './services/auditService'
 
 export default function createErrorHandler({ auditService }: Services, production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
@@ -21,7 +21,7 @@ export default function createErrorHandler({ auditService }: Services, productio
 
     res.status(error.status || 500)
 
-    const auditDetails: PageViewEventDetails = {
+    const auditDetails: BaseAuditData = {
       who: req.user?.username ?? 'UNKNOWN',
       correlationId: req.id,
       details: {

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, Router } from 'express'
 import { Services } from '../services'
-import { Page, PageViewEventDetails } from '../services/auditService'
+import { Page, BaseAuditData } from '../services/auditService'
 import asyncMiddleware from './asyncMiddleware'
 import logger from '../../logger'
 
@@ -100,7 +100,7 @@ export default function auditMiddleware({ auditService }: Services) {
 
       if (!page) return next()
 
-      const auditDetails: PageViewEventDetails = {
+      const auditDetails: BaseAuditData = {
         who: req.user?.username ?? 'UNKNOWN',
         correlationId: req.id,
         details: {

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -1,4 +1,4 @@
-import AuditService, { Page } from './auditService'
+import AuditService, { BaseAuditData, Page } from './auditService'
 import HmppsAuditClient from '../data/hmppsAuditClient'
 
 jest.mock('../data/hmppsAuditClient')
@@ -67,6 +67,223 @@ describe('Audit service', () => {
           subjectType: 'exampleType',
           correlationId: 'request123',
           details: { extraDetails: 'example' },
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logCreateEducationSupportPlan', () => {
+    it('should send ELSP Creation event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logCreateEducationSupportPlan(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_EDUCATION_LEARNER_SUPPORT_PLAN',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logReviewEducationSupportPlan', () => {
+    it('should send ELSP Review event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logReviewEducationSupportPlan(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logRecordAlnScreener', () => {
+    it('should send Record ALN Screener event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logRecordAlnScreener(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'RECORD_ALN_SCREENER',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logCreateChallenge', () => {
+    it('should send Create Challenge event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logCreateChallenge(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_CHALLENGE',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logCreateStrength', () => {
+    it('should send Create Strength event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logCreateStrength(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_STRENGTH',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logCreateCondition', () => {
+    it('should send Create Condition event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logCreateCondition(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_CONDITION',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logCreateSupportStrategy', () => {
+    it('should send Create Support Strategy event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logCreateSupportStrategy(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_SUPPORT_STRATEGY',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
         },
         expectedHmppsAuditClientToThrowOnError,
       )

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -46,9 +46,16 @@ export enum Page {
 enum AuditableUserAction {
   PAGE_VIEW_ATTEMPT = 'PAGE_VIEW_ATTEMPT',
   PAGE_VIEW = 'PAGE_VIEW',
+  CREATE_EDUCATION_LEARNER_SUPPORT_PLAN = 'CREATE_EDUCATION_LEARNER_SUPPORT_PLAN',
+  REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN = 'REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN',
+  RECORD_ALN_SCREENER = 'RECORD_ALN_SCREENER',
+  CREATE_STRENGTH = 'CREATE_STRENGTH',
+  CREATE_CHALLENGE = 'CREATE_CHALLENGE',
+  CREATE_CONDITION = 'CREATE_CONDITION',
+  CREATE_SUPPORT_STRATEGY = 'CREATE_SUPPORT_STRATEGY',
 }
 
-export interface PageViewEventDetails {
+export interface BaseAuditData {
   who: string
   subjectId?: string
   subjectType?: string
@@ -63,7 +70,7 @@ export default class AuditService {
     return this.hmppsAuditClient.sendMessage(event, false)
   }
 
-  async logPageViewAttempt(page: Page, eventDetails: PageViewEventDetails) {
+  async logPageViewAttempt(page: Page, eventDetails: BaseAuditData) {
     const event: AuditEvent = {
       ...eventDetails,
       what: `${AuditableUserAction.PAGE_VIEW_ATTEMPT}_${page}`,
@@ -71,11 +78,60 @@ export default class AuditService {
     return this.logAuditEvent(event)
   }
 
-  async logPageView(page: Page, eventDetails: PageViewEventDetails) {
+  async logPageView(page: Page, eventDetails: BaseAuditData) {
     const event: AuditEvent = {
       ...eventDetails,
       what: `${AuditableUserAction.PAGE_VIEW}_${page}`,
     }
     return this.logAuditEvent(event)
+  }
+
+  async logCreateEducationSupportPlan(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.CREATE_EDUCATION_LEARNER_SUPPORT_PLAN,
+    })
+  }
+
+  async logReviewEducationSupportPlan(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN,
+    })
+  }
+
+  async logCreateStrength(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.CREATE_STRENGTH,
+    })
+  }
+
+  async logCreateChallenge(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.CREATE_CHALLENGE,
+    })
+  }
+
+  async logCreateCondition(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.CREATE_CONDITION,
+    })
+  }
+
+  async logCreateSupportStrategy(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.CREATE_SUPPORT_STRATEGY,
+    })
+  }
+
+  async logRecordAlnScreener(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.RECORD_ALN_SCREENER,
+    })
   }
 }


### PR DESCRIPTION
Define the new audit event types and service methods for:
* Creating an ELSP
* Reviewing an ELSP
* Recording an ALN Screener
* Creating a Challenge
* Creating a Strength
* Creating a Condition
* Creating a Support Strategy