### PR TITLE
RR-1890 Reorder middleware so caseLoadId is set

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -34,7 +34,6 @@ export default function createApp(services: Services): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
-  app.use(appInsightsMiddleware())
   app.use(setUpHealthChecks(services.applicationInfo))
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
@@ -45,6 +44,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(appInsightsMiddleware())
   app.use(apiErrorMiddleware())
   app.use(successMessageMiddleware)
   app.use(errorMessageMiddleware)


### PR DESCRIPTION
Insight is making use of activeCaseLoadId that's set by setUpCurrentUser middleware, this PR is to reorder the middleware such that the AppInsights middleware is after setUpCurrentUser