### PR TITLE
RR-1935 - Wire in auditService so that HMPPS Audit event messages are sent

### DIFF
--- a/server/routes/additional-learning-needs-screener/create/check-your-answers/checkYourAnswersController.ts
+++ b/server/routes/additional-learning-needs-screener/create/check-your-answers/checkYourAnswersController.ts
@@ -3,9 +3,13 @@ import type { ReferenceDataItemDto } from 'dto'
 import { asArray } from '../../../../utils/utils'
 import { AdditionalLearningNeedsScreenerService } from '../../../../services'
 import { Result } from '../../../../utils/result/result'
+import AuditService, { BaseAuditData } from '../../../../services/auditService'
 
 export default class CheckYourAnswersController {
-  constructor(private readonly alnService: AdditionalLearningNeedsScreenerService) {}
+  constructor(
+    private readonly alnService: AdditionalLearningNeedsScreenerService,
+    private readonly auditService: AuditService,
+  ) {}
 
   getCheckYourAnswersView = async (req: Request, res: Response, next: NextFunction) => {
     const { invalidForm, challengesReferenceData, strengthsReferenceData } = res.locals
@@ -38,7 +42,18 @@ export default class CheckYourAnswersController {
     }
 
     req.journeyData.alnScreenerDto = undefined
+    this.auditService.logRecordAlnScreener(this.createRecordAlnScreenerAuditData(req)) // no need to wait for response
     return res.redirect(`/profile/${prisonNumber}/overview`)
+  }
+
+  private createRecordAlnScreenerAuditData = (req: Request): BaseAuditData => {
+    return {
+      details: {},
+      subjectType: 'PRISONER_ID',
+      subjectId: req.params.prisonNumber,
+      who: req.user?.username ?? 'UNKNOWN',
+      correlationId: req.id,
+    }
   }
 }
 

--- a/server/routes/additional-learning-needs-screener/create/index.ts
+++ b/server/routes/additional-learning-needs-screener/create/index.ts
@@ -20,13 +20,13 @@ import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessCon
 import ApplicationAction from '../../../enums/applicationAction'
 
 const createAlnRoutes = (services: Services): Router => {
-  const { additionalLearningNeedsService, journeyDataService, referenceDataService } = services
+  const { additionalLearningNeedsService, auditService, journeyDataService, referenceDataService } = services
   const router = Router({ mergeParams: true })
 
   const screenerDateController = new ScreenerDateController()
   const addChallengesController = new AddChallengesController()
   const addStrengthsController = new AddStrengthsController()
-  const checkYourAnswersController = new CheckYourAnswersController(additionalLearningNeedsService)
+  const checkYourAnswersController = new CheckYourAnswersController(additionalLearningNeedsService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_ALN_SCREENER),

--- a/server/routes/challenges/create/index.ts
+++ b/server/routes/challenges/create/index.ts
@@ -14,11 +14,11 @@ import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessCon
 import ApplicationAction from '../../../enums/applicationAction'
 
 const createChallengeRoutes = (services: Services): Router => {
-  const { journeyDataService, challengeService } = services
+  const { auditService, challengeService, journeyDataService } = services
   const router = Router({ mergeParams: true })
 
   const selectCategoryController = new SelectCategoryController()
-  const detailController = new DetailController(challengeService)
+  const detailController = new DetailController(challengeService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_CHALLENGES),

--- a/server/routes/conditions/create/index.ts
+++ b/server/routes/conditions/create/index.ts
@@ -14,11 +14,11 @@ import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessCon
 import ApplicationAction from '../../../enums/applicationAction'
 
 const createConditionsRoutes = (services: Services): Router => {
-  const { conditionService, journeyDataService } = services
+  const { auditService, conditionService, journeyDataService } = services
   const router = Router({ mergeParams: true })
 
   const selectConditionsController = new SelectConditionsController()
-  const detailsController = new DetailsController(conditionService)
+  const detailsController = new DetailsController(conditionService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_SELF_DECLARED_CONDITIONS),

--- a/server/routes/education-support-plan/create/check-your-answers/checkYourAnswersController.test.ts
+++ b/server/routes/education-support-plan/create/check-your-answers/checkYourAnswersController.test.ts
@@ -2,12 +2,15 @@ import { Request, Response } from 'express'
 import aValidEducationSupportPlanDto from '../../../../testsupport/educationSupportPlanDtoTestDataBuilder'
 import CheckYourAnswersController from './checkYourAnswersController'
 import EducationSupportPlanService from '../../../../services/educationSupportPlanService'
+import AuditService from '../../../../services/auditService'
 
+jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/educationSupportPlanService')
 
 describe('checkYourAnswersController', () => {
   const educationSupportPlanService = new EducationSupportPlanService(null) as jest.Mocked<EducationSupportPlanService>
-  const controller = new CheckYourAnswersController(educationSupportPlanService)
+  const auditService = new AuditService(null) as jest.Mocked<AuditService>
+  const controller = new CheckYourAnswersController(educationSupportPlanService, auditService)
 
   const username = 'A_USER'
   const prisonNumber = 'A1234BC'
@@ -20,6 +23,7 @@ describe('checkYourAnswersController', () => {
     journeyData: {},
     body: {},
     user: { username },
+    params: { prisonNumber },
     flash,
   } as unknown as Request
   const res = {
@@ -92,6 +96,13 @@ describe('checkYourAnswersController', () => {
       username,
       educationSupportPlanDto,
     )
+    expect(auditService.logCreateEducationLearnerSupportPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subjectId: prisonNumber,
+        subjectType: 'PRISONER_ID',
+        who: username,
+      }),
+    )
   })
 
   it('should submit form and redirect to next route given calling API is not successful', async () => {
@@ -111,5 +122,6 @@ describe('checkYourAnswersController', () => {
       username,
       educationSupportPlanDto,
     )
+    expect(auditService.logCreateEducationLearnerSupportPlan).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/education-support-plan/create/index.ts
+++ b/server/routes/education-support-plan/create/index.ts
@@ -48,6 +48,7 @@ import reviewExistingNeedsSchema from '../validationSchemas/reviewExistingNeedsS
 const createEducationSupportPlanRoutes = (services: Services): Router => {
   const {
     additionalLearningNeedsService,
+    auditService,
     challengeService,
     conditionService,
     educationSupportPlanService,
@@ -75,7 +76,7 @@ const createEducationSupportPlanRoutes = (services: Services): Router => {
   const lnspController = new LearningNeedsSupportPractitionerSupportController()
   const additionalInformationController = new AdditionalInformationController()
   const reviewSupportPlanController = new ReviewSupportPlanController()
-  const checkYourAnswersController = new CheckYourAnswersController(educationSupportPlanService)
+  const checkYourAnswersController = new CheckYourAnswersController(educationSupportPlanService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_EDUCATION_LEARNER_SUPPORT_PLAN),

--- a/server/routes/education-support-plan/refuse-plan/index.ts
+++ b/server/routes/education-support-plan/refuse-plan/index.ts
@@ -12,10 +12,10 @@ import ApplicationAction from '../../../enums/applicationAction'
 import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 
 const refuseEducationSupportPlanRoutes = (services: Services): Router => {
-  const { educationSupportPlanScheduleService, journeyDataService } = services
+  const { auditService, educationSupportPlanScheduleService, journeyDataService } = services
   const router = Router({ mergeParams: true })
 
-  const reasonController = new ReasonController(educationSupportPlanScheduleService)
+  const reasonController = new ReasonController(educationSupportPlanScheduleService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_DECLINED_EDUCATION_LEARNER_SUPPORT_PLAN),

--- a/server/routes/strengths/create/index.ts
+++ b/server/routes/strengths/create/index.ts
@@ -14,11 +14,11 @@ import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessCon
 import ApplicationAction from '../../../enums/applicationAction'
 
 const createStrengthRoutes = (services: Services): Router => {
-  const { journeyDataService, strengthService } = services
+  const { auditService, journeyDataService, strengthService } = services
   const router = Router({ mergeParams: true })
 
   const selectCategoryController = new SelectCategoryController()
-  const detailController = new DetailController(strengthService)
+  const detailController = new DetailController(strengthService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_STRENGTHS),

--- a/server/routes/support-strategies/create/detail/detailController.test.ts
+++ b/server/routes/support-strategies/create/detail/detailController.test.ts
@@ -3,12 +3,15 @@ import DetailController from './detailController'
 import aValidSupportStrategyDto from '../../../../testsupport/supportStrategyDtoTestDataBuilder'
 import SupportStrategyType from '../../../../enums/supportStrategyType'
 import SupportStrategyService from '../../../../services/supportStrategyService'
+import AuditService from '../../../../services/auditService'
 
 jest.mock('../../../../services/supportStrategyService')
+jest.mock('../../../../services/auditService')
 
 describe('detailController', () => {
   const supportStrategyService = new SupportStrategyService(null) as jest.Mocked<SupportStrategyService>
-  const controller = new DetailController(supportStrategyService)
+  const auditService = new AuditService(null) as jest.Mocked<AuditService>
+  const controller = new DetailController(supportStrategyService, auditService)
 
   const username = 'A_USER'
   const prisonId = 'MDI'
@@ -21,6 +24,7 @@ describe('detailController', () => {
     user: { username },
     journeyData: {},
     body: {},
+    params: { prisonNumber },
     flash,
   } as unknown as Request
   const res = {
@@ -140,6 +144,13 @@ describe('detailController', () => {
     expect(req.journeyData.supportStrategyDto).toBeUndefined()
     expect(flash).not.toHaveBeenCalled()
     expect(supportStrategyService.createSupportStrategies).toHaveBeenCalledWith(username, [expectedSupportStrategyDto])
+    expect(auditService.logCreateSupportStrategy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subjectId: prisonNumber,
+        subjectType: 'PRISONER_ID',
+        who: username,
+      }),
+    )
   })
 
   it('should submit form and redirect to next route given calling API is not successful', async () => {
@@ -172,5 +183,6 @@ describe('detailController', () => {
     expect(req.journeyData.supportStrategyDto).toEqual(supportStrategyDto)
     expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
     expect(supportStrategyService.createSupportStrategies).toHaveBeenCalledWith(username, [expectedSupportStrategyDto])
+    expect(auditService.logCreateSupportStrategy).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/support-strategies/create/index.ts
+++ b/server/routes/support-strategies/create/index.ts
@@ -14,11 +14,11 @@ import DetailController from './detail/detailController'
 import detailSchema from '../validationSchemas/detailSchema'
 
 const createSupportStrategiesRoutes = (services: Services): Router => {
-  const { journeyDataService, supportStrategyService } = services
+  const { auditService, journeyDataService, supportStrategyService } = services
   const router = Router({ mergeParams: true })
 
   const selectCategoryController = new SelectCategoryController()
-  const detailController = new DetailController(supportStrategyService)
+  const detailController = new DetailController(supportStrategyService, auditService)
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_SUPPORT_STRATEGIES),

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -73,7 +73,7 @@ describe('Audit service', () => {
     })
   })
 
-  describe('logCreateEducationSupportPlan', () => {
+  describe('logCreateEducationLearnerSupportPlan', () => {
     it('should send ELSP Creation event audit message', async () => {
       // Given
 
@@ -86,7 +86,7 @@ describe('Audit service', () => {
       }
 
       // When
-      const actual = await auditService.logCreateEducationSupportPlan(baseArchiveAuditData)
+      const actual = await auditService.logCreateEducationLearnerSupportPlan(baseArchiveAuditData)
 
       // Then
       expect(actual).toEqual(expectedSqsMessageResponse)
@@ -104,7 +104,7 @@ describe('Audit service', () => {
     })
   })
 
-  describe('logReviewEducationSupportPlan', () => {
+  describe('logReviewEducationLearnerSupportPlan', () => {
     it('should send ELSP Review event audit message', async () => {
       // Given
 
@@ -117,7 +117,7 @@ describe('Audit service', () => {
       }
 
       // When
-      const actual = await auditService.logReviewEducationSupportPlan(baseArchiveAuditData)
+      const actual = await auditService.logReviewEducationLearnerSupportPlan(baseArchiveAuditData)
 
       // Then
       expect(actual).toEqual(expectedSqsMessageResponse)
@@ -279,6 +279,37 @@ describe('Audit service', () => {
       expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
         {
           what: 'CREATE_SUPPORT_STRATEGY',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {},
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
+    })
+  })
+
+  describe('logUpdateEducationLearnerSupportPlanAsRefused', () => {
+    it('should send Update ELSP As Refused event audit message', async () => {
+      // Given
+
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {},
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      const actual = await auditService.logUpdateEducationLearnerSupportPlanAsRefused(baseArchiveAuditData)
+
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'UPDATE_EDUCATION_LEARNER_SUPPORT_PLAN_SCHEDULE',
           correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
           details: {},
           subjectId: 'A1234BC',

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -48,6 +48,7 @@ enum AuditableUserAction {
   PAGE_VIEW = 'PAGE_VIEW',
   CREATE_EDUCATION_LEARNER_SUPPORT_PLAN = 'CREATE_EDUCATION_LEARNER_SUPPORT_PLAN',
   REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN = 'REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN',
+  UPDATE_EDUCATION_LEARNER_SUPPORT_PLAN_SCHEDULE = 'UPDATE_EDUCATION_LEARNER_SUPPORT_PLAN_SCHEDULE',
   RECORD_ALN_SCREENER = 'RECORD_ALN_SCREENER',
   CREATE_STRENGTH = 'CREATE_STRENGTH',
   CREATE_CHALLENGE = 'CREATE_CHALLENGE',
@@ -86,14 +87,14 @@ export default class AuditService {
     return this.logAuditEvent(event)
   }
 
-  async logCreateEducationSupportPlan(baseAuditData: BaseAuditData) {
+  async logCreateEducationLearnerSupportPlan(baseAuditData: BaseAuditData) {
     return this.logAuditEvent({
       ...baseAuditData,
       what: AuditableUserAction.CREATE_EDUCATION_LEARNER_SUPPORT_PLAN,
     })
   }
 
-  async logReviewEducationSupportPlan(baseAuditData: BaseAuditData) {
+  async logReviewEducationLearnerSupportPlan(baseAuditData: BaseAuditData) {
     return this.logAuditEvent({
       ...baseAuditData,
       what: AuditableUserAction.REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN,
@@ -132,6 +133,13 @@ export default class AuditService {
     return this.logAuditEvent({
       ...baseAuditData,
       what: AuditableUserAction.RECORD_ALN_SCREENER,
+    })
+  }
+
+  async logUpdateEducationLearnerSupportPlanAsRefused(baseAuditData: BaseAuditData) {
+    return this.logAuditEvent({
+      ...baseAuditData,
+      what: AuditableUserAction.UPDATE_EDUCATION_LEARNER_SUPPORT_PLAN_SCHEDULE,
     })
   }
 }


### PR DESCRIPTION
PR to wire the auditService into the relevant controllers, so that audit events are sent on:

* Creating an ELSP
* Refusing/declining an ELSP
**I had to add this as a new event type as I forgot to do it in my previous PR that defined event types**
* Recording an ALN Screener
* Creating a Challenge
* Creating a Strength
* Creating a Condition
* Creating a Support Strategy