### PR TITLE
RR-1935 - Enable audit service in dev only

### DIFF
--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -49,7 +49,7 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: 'true'
     AUDIT_SQS_REGION: 'eu-west-2'
     AUDIT_SERVICE_NAME: 'DPS124' # Your audit service name
-    AUDIT_ENABLED: "true"
+    AUDIT_ENABLED: 'false'
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
     SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,9 +24,14 @@ generic-service:
     SUPPORT_ADDITIONAL_NEEDS_API_URL: 'https://support-for-additional-needs-api-dev.hmpps.service.justice.gov.uk'
     CURIOUS_API_URL: 'https://testservices.sequation.net/sequation-virtual-campus2-api'
     ENVIRONMENT_NAME: DEV
+    AUDIT_ENABLED: true
     DPS_URL: 'https://digital-dev.prison.service.justice.gov.uk'
     NEW_DPS_URL: 'https://dps-dev.prison.service.justice.gov.uk'
     COMPONENT_API_URL: 'https://frontend-components-dev.hmpps.service.justice.gov.uk'
+
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+      AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32


### PR DESCRIPTION
Disable audit in preprod and prod (because the Cloud Platform secrets are not set there yet)
Enable audit in dev and wire in the secrets (because the secrets are now setup in our dev namespace 👍 )