### PR TITLE
RR-1935 - Set serviceAccount name in helm deploy to get audit working

### DIFF
--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -1,9 +1,7 @@
 generic-service:
   nameOverride: hmpps-support-additional-needs-ui
   productId: 'DPS124' # productId for the product that this belongs too, i.e. DPS001, see README.md for details
-
-  # the IRSA service account name for accessing AWS resources
-  # serviceAccountName: "hmpps-support-additional-needs-ui"
+  serviceAccountName: hmpps-support-additional-needs # Needed to access AWS resources like SQS queues and SNS topics
 
   replicaCount: 4
 

--- a/server/views/pages/support-strategies/detail/index.njk
+++ b/server/views/pages/support-strategies/detail/index.njk
@@ -24,7 +24,7 @@
               attributes: { "aria-live": "polite" }
             },
             hint: {
-              text: category | formatSupportStrategyTypeHintText
+              text: 'Specify what support is needed and where, for example in a workshop or on the wing'
             },
             attributes: { "aria-label" : "Enter the description of the support strategy" },
             errorMessage: errors | findError('description')


### PR DESCRIPTION
Set serviceAccount name in helm deploy to get audit working; plus a minor (unrelated) content change