### PR TITLE
RR-1890 - Update middlewares so that app insights logs username and activeCaseloadId

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -34,6 +34,7 @@ export default function createApp(services: Services): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  app.use(appInsightsMiddleware())
   app.use(setUpHealthChecks(services.applicationInfo))
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
@@ -44,7 +45,6 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
-  app.use(appInsightsMiddleware())
   app.use(apiErrorMiddleware())
   app.use(successMessageMiddleware)
   app.use(errorMessageMiddleware)

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -66,14 +66,14 @@ export function appInsightsMiddleware(): RequestHandler {
 export function addUserDataToRequests(envelope: EnvelopeTelemetry, contextObjects: ContextObject | undefined): boolean {
   const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
   if (isRequest) {
-    const { username } = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
-    const { activeCaseLoadId } = contextObjects?.['http.ServerRequest']?.res?.locals?.activeCaseLoadId || {}
+    const user = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
+    const { username, activeCaseLoadId } = user
     if (username) {
       const { properties } = envelope.data.baseData
       // eslint-disable-next-line no-param-reassign
       envelope.data.baseData.properties = {
         username,
-        activeCaseLoadId,
+        activeCaseLoadId: activeCaseLoadId || 'N/A',
         ...properties,
       }
     }


### PR DESCRIPTION
This PR updates the middlewares so that app insights logs username and activeCaseloadId

Tested locally by setting the appInsights connection string from `dev` in my local `.env` file:
<img width="1412" height="860" alt="Screenshot 2025-09-30 at 15 53 01" src="https://github.com/user-attachments/assets/26962457-2f77-42b3-b53f-a6ef9718b8b9" />
