### PR TITLE
Exclude curious and prison register APIs from health check

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -101,7 +101,7 @@ export default {
     },
     prisonRegister: {
       url: get('PRISON_REGISTER_API_URL', 'http://localhost:8083', requiredInProduction),
-      healthPath: '/health/ping',
+      healthPath: null,
       timeout: {
         response: Number(get('PRISON_REGISTER_API_TIMEOUT_RESPONSE', 5000)),
         deadline: Number(get('PRISON_REGISTER_API_TIMEOUT_DEADLINE', 5000)),
@@ -128,7 +128,7 @@ export default {
     },
     curious: {
       url: get('CURIOUS_API_URL', 'http://localhost:8083', requiredInProduction),
-      healthPath: '/ping',
+      healthPath: null,
       timeout: {
         response: Number(get('CURIOUS_API_TIMEOUT_RESPONSE', 5000)),
         deadline: Number(get('CURIOUS_API_TIMEOUT_DEADLINE', 5000)),

--- a/server/data/curiousApiClient.test.ts
+++ b/server/data/curiousApiClient.test.ts
@@ -13,7 +13,7 @@ describe('curiousApiClient', () => {
   } as unknown as jest.Mocked<AuthenticationClient>
   const curiousApiClient = new CuriousApiClient(mockAuthenticationClient)
 
-  config.apis.prisonerSearch.url = 'http://localhost:8200'
+  config.apis.curious.url = 'http://localhost:8200'
   const curiousApi = nock(config.apis.curious.url)
 
   beforeEach(() => {

--- a/server/data/supportAdditionalNeedsApiClient.test.ts
+++ b/server/data/supportAdditionalNeedsApiClient.test.ts
@@ -36,7 +36,7 @@ describe('supportAdditionalNeedsApiClient', () => {
   } as unknown as jest.Mocked<AuthenticationClient>
   const supportAdditionalNeedsApiClient = new SupportAdditionalNeedsApiClient(mockAuthenticationClient)
 
-  config.apis.prisonerSearch.url = 'http://localhost:8200'
+  config.apis.supportAdditionalNeedsApi.url = 'http://localhost:8200'
   const supportAdditionalNeedsApi = nock(config.apis.supportAdditionalNeedsApi.url)
 
   beforeEach(() => {


### PR DESCRIPTION
This PR excludes Curious and Prison Register APIs from health check as they are not core to the operation of the service, and suitable error handling already exists in the codebase for if these APIs are down.

Currently in our preprod environment SAN is being reported and down by the healthcheck endpoint because the Curious preprod environment is apparently down:

https://support-for-additional-needs-preprod.hmpps.service.justice.gov.uk/health
```
{
  "status": "DOWN",
  "components": {
    "hmppsAuth": {
      "status": "UP"
    },
    "tokenVerification": {
      "status": "UP"
    },
    "prisonerSearch": {
      "status": "UP"
    },
    "prisonRegister": {
      "status": "UP"
    },
    "manageUsersApi": {
      "status": "UP"
    },
    "supportAdditionalNeedsApi": {
      "status": "UP"
    },
    "curious": {
      "status": "DOWN",
      "details": {
        "status": 503,
        "message": "Service Unavailable",
        "attempts": 3
      }
    }
  },
  "build": {
    "buildNumber": "2025-10-01.988.d72a622",
    "gitRef": "d72a62225bea3c05d894ded2c596dbdc89ce7053"
  },
  "version": "2025-10-01.988.d72a622",
  "uptime": 2210
}
```

We should not include Curious in our healthcheck config because it is not core to the operation of SAN UI and we have suitable error handling in place for when Curious is down. The SAN service does not become unusable.

The same is true of the Prison Register API that we use for prison name lookups. We very rarely call it because the prison data is cached for 1 day; and in the unlikely event that it is down when we need to call it we have suitable error handling (we display the prison ID rather than the prison name). As with Curious, the SAN service does not become unusable.