### PR TITLE
RR-1776 - Refactor DTO; introduce DTO specifically for the Review journey

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -52,9 +52,21 @@ declare module 'dto' {
     reviewDate?: Date
     individualSupport?: string
     additionalInformation?: string
+  }
+
+  export interface ReviewEducationSupportPlanDto extends ReferencedAndAuditable {
+    prisonNumber: string
+    prisonId: string
     planReviewedByLoggedInUser?: boolean
     planReviewedByOtherFullName?: string
     planReviewedByOtherJobRole?: string
+    wereOtherPeopleConsulted?: boolean
+    otherPeopleConsulted?: Array<{
+      name: string
+      jobRole: string
+    }>
+    reviewExistingNeeds?: boolean
+    reviewDate?: Date
   }
 
   export interface PlanCreationScheduleDto {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,6 +1,7 @@
 import type {
   ChallengeDto,
   EducationSupportPlanDto,
+  ReviewEducationSupportPlanDto,
   StrengthDto,
   SupportStrategyDto,
   RefuseEducationSupportPlanDto,
@@ -26,6 +27,7 @@ export declare global {
 
     interface JourneyData {
       educationSupportPlanDto?: EducationSupportPlanDto
+      reviewEducationSupportPlanDto?: ReviewEducationSupportPlanDto
       refuseEducationSupportPlanDto?: RefuseEducationSupportPlanDto
       challengeDto?: ChallengeDto
       conditionsList?: ConditionsList

--- a/server/data/mappers/educationSupportPlanDtoMapper.test.ts
+++ b/server/data/mappers/educationSupportPlanDtoMapper.test.ts
@@ -38,7 +38,6 @@ describe('educationSupportPlanDtoMapper', () => {
         prisonId: null,
         reviewDate: null,
         reviewBeforeCreatingPlan: null,
-        planReviewedByOther: null,
       })
 
       // When
@@ -77,7 +76,6 @@ describe('educationSupportPlanDtoMapper', () => {
         prisonId: null,
         reviewDate: null,
         reviewBeforeCreatingPlan: null,
-        planReviewedByOther: null,
       })
 
       // When

--- a/server/data/mappers/educationSupportPlanDtoMapper.ts
+++ b/server/data/mappers/educationSupportPlanDtoMapper.ts
@@ -36,9 +36,6 @@ const toEducationSupportPlanDto = (
         prisonId: null,
         reviewDate: null,
         reviewBeforeCreatingPlan: null,
-        planReviewedByLoggedInUser: null,
-        planReviewedByOtherFullName: null,
-        planReviewedByOtherJobRole: null,
       }
     : null
 }

--- a/server/routes/education-support-plan/review/index.ts
+++ b/server/routes/education-support-plan/review/index.ts
@@ -25,6 +25,7 @@ import reviewSupportPlanSchema from '../validationSchemas/reviewSupportPlanSchem
 import retrieveEducationSupportPlan from './middleware/retrieveEducationSupportPlan'
 import WhoReviewedThePlanController from './who-reviewed-the-plan/whoReviewedThePlanController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData from './middleware/createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData'
 
 const reviewEducationSupportPlanRoutes = (services: Services): Router => {
   const {
@@ -49,6 +50,7 @@ const reviewEducationSupportPlanRoutes = (services: Services): Router => {
 
   router.get('/:journeyId/who-reviewed-the-plan', [
     retrieveEducationSupportPlan(educationSupportPlanService),
+    createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData,
     asyncMiddleware(whoReviewedThePlanController.getWhoReviewedThePlanView),
   ])
   router.post('/:journeyId/who-reviewed-the-plan', [

--- a/server/routes/education-support-plan/review/middleware/createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData.test.ts
+++ b/server/routes/education-support-plan/review/middleware/createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData.test.ts
@@ -1,0 +1,77 @@
+import { Request, Response } from 'express'
+import type { ReviewEducationSupportPlanDto } from 'dto'
+import createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData from './createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData'
+
+describe('createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const prisonId = 'MDI'
+
+  const req = {
+    params: { prisonNumber },
+  } as unknown as Request
+  const res = {
+    locals: {
+      user: { activeCaseLoadId: prisonId },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+  })
+
+  it('should create an empty ReviewEducationSupportPlanDto for the prisoner given there is no ReviewEducationSupportPlanDto in the journeyData', async () => {
+    // Given
+    req.journeyData.reviewEducationSupportPlanDto = undefined
+
+    const expectedReviewEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as ReviewEducationSupportPlanDto
+
+    // When
+    await createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.reviewEducationSupportPlanDto).toEqual(expectedReviewEducationSupportPlanDto)
+  })
+
+  it('should create an empty ReviewEducationSupportPlanDto for a prisoner given there is an ReviewEducationSupportPlanDto in the journeyData for a different prisoner', async () => {
+    // Given
+    req.journeyData.reviewEducationSupportPlanDto = {
+      prisonNumber: 'Z1234ZZ',
+      prisonId,
+    } as ReviewEducationSupportPlanDto
+
+    const expectedReviewEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as ReviewEducationSupportPlanDto
+
+    // When
+    await createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.reviewEducationSupportPlanDto).toEqual(expectedReviewEducationSupportPlanDto)
+  })
+
+  it('should not create an empty ReviewEducationSupportPlanDto for the prisoner given there is already an ReviewEducationSupportPlanDto in the journeyData for the prisoner', async () => {
+    // Given
+    const expectedReviewEducationSupportPlanDto = {
+      prisonNumber,
+      prisonId,
+    } as ReviewEducationSupportPlanDto
+
+    req.journeyData.reviewEducationSupportPlanDto = expectedReviewEducationSupportPlanDto
+
+    // When
+    await createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.journeyData.reviewEducationSupportPlanDto).toEqual(expectedReviewEducationSupportPlanDto)
+  })
+})

--- a/server/routes/education-support-plan/review/middleware/createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData.ts
+++ b/server/routes/education-support-plan/review/middleware/createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData.ts
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from 'express'
+import type { ReviewEducationSupportPlanDto } from 'dto'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+/**
+ * Middleware function that returns a request handler function to check whether a [ReviewEducationSupportPlanDto] exists in the journeyData for
+ * the prisoner referenced in the request URL.
+ * If one does not exist, or it is for a different prisoner, create a new empty [ReviewEducationSupportPlanDto] for the prisoner.
+ */
+const createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { prisonNumber } = req.params
+  const { activeCaseLoadId } = res.locals.user as PrisonUser
+
+  // Either no ReviewEducationSupportPlanDto in the journeyData, or it's for a different prisoner. Create a new one.
+  if (req.journeyData?.reviewEducationSupportPlanDto?.prisonNumber !== prisonNumber) {
+    req.journeyData = {
+      ...req.journeyData,
+      reviewEducationSupportPlanDto: {
+        prisonNumber,
+        prisonId: activeCaseLoadId,
+      } as ReviewEducationSupportPlanDto,
+    }
+  }
+
+  next()
+}
+
+export default createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData

--- a/server/routes/education-support-plan/review/middleware/retrieveEducationSupportPlan.ts
+++ b/server/routes/education-support-plan/review/middleware/retrieveEducationSupportPlan.ts
@@ -30,7 +30,10 @@ const retrieveEducationSupportPlan = (educationSupportPlanService: EducationSupp
         prisonNumber,
       )
       if (educationSupportPlanDto) {
-        req.journeyData = { educationSupportPlanDto }
+        req.journeyData = {
+          ...req.journeyData,
+          educationSupportPlanDto,
+        }
         return next()
       }
 

--- a/server/routes/education-support-plan/review/who-reviewed-the-plan/whoReviewedThePlanController.test.ts
+++ b/server/routes/education-support-plan/review/who-reviewed-the-plan/whoReviewedThePlanController.test.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express'
 import WhoReviewedThePlanController from './whoReviewedThePlanController'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
-import aValidEducationSupportPlanDto from '../../../../testsupport/educationSupportPlanDtoTestDataBuilder'
 import PlanReviewedByValue from '../../../../enums/planReviewedByValue'
+import aValidReviewEducationSupportPlanDto from '../../../../testsupport/reviewEducationSupportPlanDtoTestDataBuilder'
 
 describe('whoReviewedThePlanController', () => {
   const controller = new WhoReviewedThePlanController()
@@ -16,7 +16,6 @@ describe('whoReviewedThePlanController', () => {
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
-    redirectWithErrors: jest.fn(),
     render: jest.fn(),
     locals: { prisonerSummary },
   } as unknown as Response
@@ -26,8 +25,8 @@ describe('whoReviewedThePlanController', () => {
     jest.resetAllMocks()
     req.body = {}
     req.journeyData = {
-      educationSupportPlanDto: {
-        ...aValidEducationSupportPlanDto(),
+      reviewEducationSupportPlanDto: {
+        ...aValidReviewEducationSupportPlanDto(),
         planReviewedByLoggedInUser: false,
         planReviewedByOtherFullName: 'A user',
         planReviewedByOtherJobRole: 'A job role',
@@ -77,7 +76,7 @@ describe('whoReviewedThePlanController', () => {
   it('should submit form and redirect to next route given previous page was not check your answers', async () => {
     // Given
     req.query = {}
-    req.journeyData = { educationSupportPlanDto: aValidEducationSupportPlanDto() }
+    req.journeyData = { reviewEducationSupportPlanDto: aValidReviewEducationSupportPlanDto() }
     req.body = {
       reviewedBy: PlanReviewedByValue.SOMEBODY_ELSE,
       reviewedByOtherFullName: 'A user',
@@ -85,8 +84,8 @@ describe('whoReviewedThePlanController', () => {
     }
 
     const expectedNextRoute = 'other-people-consulted'
-    const expectedEducationSupportPlanDto = {
-      ...aValidEducationSupportPlanDto(),
+    const expectedReviewEducationSupportPlanDto = {
+      ...aValidReviewEducationSupportPlanDto(),
       planReviewedByLoggedInUser: false,
       planReviewedByOtherFullName: 'A user',
       planReviewedByOtherJobRole: 'A job role',
@@ -97,18 +96,15 @@ describe('whoReviewedThePlanController', () => {
 
     // Then
     expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
-    expect(req.journeyData.educationSupportPlanDto).toEqual(expectedEducationSupportPlanDto)
+    expect(req.journeyData.reviewEducationSupportPlanDto).toEqual(expectedReviewEducationSupportPlanDto)
   })
 
   it('should submit form and redirect to next route given previous page was check your answers', async () => {
     // Given
     req.query = { submitToCheckAnswers: 'true' }
     req.journeyData = {
-      educationSupportPlanDto: {
-        ...aValidEducationSupportPlanDto(),
-        planReviewedByLoggedInUser: true,
-        planReviewedByOtherFullName: undefined,
-        planReviewedByOtherJobRole: undefined,
+      reviewEducationSupportPlanDto: {
+        ...aValidReviewEducationSupportPlanDto(),
       },
     }
     req.body = {
@@ -118,8 +114,8 @@ describe('whoReviewedThePlanController', () => {
     }
 
     const expectedNextRoute = 'check-your-answers'
-    const expectedEducationSupportPlanDto = {
-      ...aValidEducationSupportPlanDto(),
+    const expectedReviewEducationSupportPlanDto = {
+      ...aValidReviewEducationSupportPlanDto(),
       planReviewedByLoggedInUser: false,
       planReviewedByOtherFullName: 'A user',
       planReviewedByOtherJobRole: 'A job role',
@@ -130,6 +126,6 @@ describe('whoReviewedThePlanController', () => {
 
     // Then
     expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
-    expect(req.journeyData.educationSupportPlanDto).toEqual(expectedEducationSupportPlanDto)
+    expect(req.journeyData.reviewEducationSupportPlanDto).toEqual(expectedReviewEducationSupportPlanDto)
   })
 })

--- a/server/routes/education-support-plan/review/who-reviewed-the-plan/whoReviewedThePlanController.ts
+++ b/server/routes/education-support-plan/review/who-reviewed-the-plan/whoReviewedThePlanController.ts
@@ -1,13 +1,13 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import type { EducationSupportPlanDto } from 'dto'
+import type { ReviewEducationSupportPlanDto } from 'dto'
 import PlanReviewedByValue from '../../../../enums/planReviewedByValue'
 
 export default class WhoReviewedThePlanController {
   getWhoReviewedThePlanView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
     const { prisonerSummary, invalidForm } = res.locals
-    const { educationSupportPlanDto } = req.journeyData
+    const { reviewEducationSupportPlanDto } = req.journeyData
 
-    const whoReviewedThePlanForm = invalidForm ?? this.populateFormFromDto(educationSupportPlanDto)
+    const whoReviewedThePlanForm = invalidForm ?? this.populateFormFromDto(reviewEducationSupportPlanDto)
 
     const viewRenderArgs = { prisonerSummary, form: whoReviewedThePlanForm, mode: 'review' }
     return res.render('pages/education-support-plan/who-reviewed-the-plan/index', viewRenderArgs)
@@ -20,7 +20,7 @@ export default class WhoReviewedThePlanController {
     return res.redirect(req.query?.submitToCheckAnswers !== 'true' ? 'other-people-consulted' : 'check-your-answers')
   }
 
-  private populateFormFromDto = (dto: EducationSupportPlanDto) => {
+  private populateFormFromDto = (dto: ReviewEducationSupportPlanDto) => {
     if (dto.planReviewedByLoggedInUser == null) {
       return {}
     }
@@ -35,10 +35,10 @@ export default class WhoReviewedThePlanController {
     req: Request,
     form: { reviewedBy: PlanReviewedByValue; reviewedByOtherFullName?: string; reviewedByOtherJobRole?: string },
   ) => {
-    const { educationSupportPlanDto } = req.journeyData
-    educationSupportPlanDto.planReviewedByLoggedInUser = form.reviewedBy === PlanReviewedByValue.MYSELF
-    educationSupportPlanDto.planReviewedByOtherFullName = form.reviewedByOtherFullName
-    educationSupportPlanDto.planReviewedByOtherJobRole = form.reviewedByOtherJobRole
-    req.journeyData.educationSupportPlanDto = educationSupportPlanDto
+    const { reviewEducationSupportPlanDto } = req.journeyData
+    reviewEducationSupportPlanDto.planReviewedByLoggedInUser = form.reviewedBy === PlanReviewedByValue.MYSELF
+    reviewEducationSupportPlanDto.planReviewedByOtherFullName = form.reviewedByOtherFullName
+    reviewEducationSupportPlanDto.planReviewedByOtherJobRole = form.reviewedByOtherJobRole
+    req.journeyData.reviewEducationSupportPlanDto = reviewEducationSupportPlanDto
   }
 }

--- a/server/services/educationSupportPlanService.test.ts
+++ b/server/services/educationSupportPlanService.test.ts
@@ -51,7 +51,6 @@ describe('educationSupportPlanService', () => {
         reviewDate: null,
         prisonId: null,
         reviewBeforeCreatingPlan: null,
-        planReviewedByOther: null,
       })
 
       // When
@@ -109,7 +108,6 @@ describe('educationSupportPlanService', () => {
         reviewDate: null,
         reviewBeforeCreatingPlan: null,
         planCreatedByOther: { name: 'Alan Teacher', jobRole: 'Education Instructor' },
-        planReviewedByOther: null,
       })
 
       // When

--- a/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/educationSupportPlanDtoTestDataBuilder.ts
@@ -25,10 +25,6 @@ const aValidEducationSupportPlanDto = (
     reviewDate?: Date
     individualSupport?: string
     additionalInformation?: string
-    planReviewedByOther?: {
-      name: string
-      jobRole: string
-    }
   },
 ): EducationSupportPlanDto => ({
   prisonNumber: options?.prisonNumber ?? 'A1234BC',
@@ -71,9 +67,6 @@ const aValidEducationSupportPlanDto = (
     options?.additionalInformation === null
       ? null
       : options?.additionalInformation || 'Chris is very open about his issues and is a pleasure to talk to.',
-  planReviewedByLoggedInUser: options?.planReviewedByOther === null ? null : options?.planReviewedByOther == null,
-  planReviewedByOtherFullName: options?.planReviewedByOther === null ? null : options?.planReviewedByOther?.name,
-  planReviewedByOtherJobRole: options?.planReviewedByOther === null ? null : options?.planReviewedByOther?.jobRole,
   ...validDtoAuditFields(options),
 })
 

--- a/server/testsupport/reviewEducationSupportPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/reviewEducationSupportPlanDtoTestDataBuilder.ts
@@ -1,0 +1,36 @@
+import { addMonths, startOfToday } from 'date-fns'
+import type { ReviewEducationSupportPlanDto } from 'dto'
+import aValidPlanContributor from './planContributorTestDataBuilder'
+import { DtoAuditFields, validDtoAuditFields } from './auditFieldsTestDataBuilder'
+
+const aValidReviewEducationSupportPlanDto = (
+  options?: DtoAuditFields & {
+    prisonNumber?: string
+    prisonId?: string
+    reviewExistingNeeds?: boolean
+    planReviewedByOther?: {
+      name: string
+      jobRole: string
+    }
+    otherPeopleConsulted?: Array<{
+      name: string
+      jobRole: string
+    }>
+    reviewDate?: Date
+  },
+): ReviewEducationSupportPlanDto => ({
+  prisonNumber: options?.prisonNumber ?? 'A1234BC',
+  prisonId: options?.prisonId === null ? null : options?.prisonId || 'BXI',
+  reviewExistingNeeds: options?.reviewExistingNeeds === null ? null : options?.reviewExistingNeeds || true,
+  planReviewedByLoggedInUser: options?.planReviewedByOther == null,
+  planReviewedByOtherFullName: options?.planReviewedByOther?.name,
+  planReviewedByOtherJobRole: options?.planReviewedByOther?.jobRole,
+  wereOtherPeopleConsulted: !(options?.otherPeopleConsulted === null || options?.otherPeopleConsulted?.length === 0),
+  otherPeopleConsulted: !(options?.otherPeopleConsulted === null || options?.otherPeopleConsulted?.length === 0)
+    ? options?.otherPeopleConsulted || [aValidPlanContributor()]
+    : null,
+  reviewDate: options?.reviewDate === null ? null : options?.reviewDate || addMonths(startOfToday(), 2),
+  ...validDtoAuditFields(options),
+})
+
+export default aValidReviewEducationSupportPlanDto


### PR DESCRIPTION
PR that refactors the way the Review journey will store the data from screen to screen.

Originally I thought that the journey was close enough to the Create ELSP journey that we could use the existing `EducationSupportPlanDto` and just add a couple of fields - thats what I did for screen 1 (Who reviewed the plan? screen)

Now I'm about to start on the 2nd screen (who else was consulted? screen) its become clear that there are more differences than I thought, and we'll be adding lots of new fields to the `EducationSupportPlanDto`

This PR refactors this approach. It puts the `EducationSupportPlanDto` and associated mappers etc back to how they were (ie. without the fields for the review journey), and creates a new DTO `ReviewEducationSupportPlanDto` that contains just the additional fields in the review journey.

The new design is that on starting the Review journey it retrieves the ELSP from the API and maps it into the `EducationSupportPlanDto` (without any extra fields for the Review journey); and also creates an empty `ReviewEducationSupportPlanDto`. Both objects are added to the journeyData and carried from page to page. Each page in the Review journey will update fields in either the `EducationSupportPlanDto` or `ReviewEducationSupportPlanDto` as appropriate, and at the end (on Check Your Answers) it will combine the data from both objects into the API request object to save the Review.
