### PR TITLE
RR-1956 - Set default sort order on prisoner list page

### DIFF
--- a/integration_tests/e2e/search/search.cy.ts
+++ b/integration_tests/e2e/search/search.cy.ts
@@ -2,6 +2,7 @@ import type { Person } from 'supportAdditionalNeedsApiClient'
 import Page from '../../pages/page'
 import SearchPage from '../../pages/search/searchPage'
 import OverviewPage from '../../pages/profile/overviewPage'
+import SearchSortField from '../../../server/enums/searchSortField'
 
 /**
  * Cypress scenarios for the Search page.
@@ -18,7 +19,6 @@ context('Search screen', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] })
-    cy.signIn()
 
     // Generate 725 Prisoner Search Summaries that will be displayed on the Search page by virtue of using them in the search API stub.
     // 725 is a very specific number and is used because it will mean we have 15 pages (14 pages of 50, plus 1 of 25)
@@ -33,6 +33,7 @@ context('Search screen', () => {
           page: idx + 1,
           pageOfPrisoners: pageOfPeople,
           totalRecords: 725,
+          sortBy: SearchSortField.DEADLINE_DATE,
         })
       })
     })
@@ -40,6 +41,7 @@ context('Search screen', () => {
 
   it('should be able to navigate directly to the search page', () => {
     // Given
+    cy.signIn()
     const expectedResultCount = 725
 
     // When
@@ -54,7 +56,8 @@ context('Search screen', () => {
 
   it('should display service unavailable message given search API returns a 500', () => {
     // Given
-    cy.task('stubSearchByPrison500Error')
+    cy.signIn()
+    cy.task('stubSearchByPrison500Error', { sortBy: SearchSortField.DEADLINE_DATE })
 
     // When
     cy.visit('/search')
@@ -68,6 +71,7 @@ context('Search screen', () => {
   describe('pagination', () => {
     it('should display pagination controls, displaying 1 to 10 with the next link, on the first page of the search results', () => {
       // Given
+      cy.signIn()
 
       // When
       cy.visit('/search')
@@ -88,6 +92,7 @@ context('Search screen', () => {
 
     it('should display pagination controls, displaying 2 to 11 with the next and previous links, on the 7th page of the search results', () => {
       // Given
+      cy.signIn()
       cy.visit('/search')
       const searchPage = Page.verifyOnPage(SearchPage)
 
@@ -113,6 +118,7 @@ context('Search screen', () => {
 
   it('should be able to click a prisoner on the search page to arrive on the Overview page', () => {
     // Given
+    cy.signIn()
     const firstPersonOnFirstPage: Person = peopleGroupedByPageRequest[0][0]
     cy.task('getPrisonerById', firstPersonOnFirstPage.prisonNumber)
     cy.task('stubGetPlanActionStatus', { prisonNumber: firstPersonOnFirstPage.prisonNumber })
@@ -125,34 +131,40 @@ context('Search screen', () => {
     // When
     Page.verifyOnPage(OverviewPage)
   })
-})
 
-context('Search screen for users with different permissions', () => {
-  it('should show the basic search page given user does not have the manager role', () => {
-    // Given
-    cy.task('reset')
-    cy.task('stubSignIn', { roles: ['ROLE_SOME_ROLE_THAT_IS_NOT_SAN_MANAGER'] })
-    cy.signIn()
+  context('Search screen for users with different permissions', () => {
+    it('should show the basic search page given user does not have the manager role', () => {
+      // Given
+      cy.task('stubSignIn', { roles: ['ROLE_SOME_ROLE_THAT_IS_NOT_SAN_MANAGER'] })
+      cy.signIn()
+      peopleGroupedByPageRequest.forEach((pageOfPeople, idx) => {
+        cy.task('stubSearchByPrison', {
+          page: idx + 1,
+          pageOfPrisoners: pageOfPeople,
+          totalRecords: 725,
+          sortBy: SearchSortField.PRISONER_NAME,
+        })
+      })
 
-    // When
-    cy.visit('/search')
+      // When
+      cy.visit('/search')
 
-    // Then
-    Page.verifyOnPage(SearchPage) //
-      .doesNotHaveStatusAndDueDateColumnsDisplayed()
-  })
+      // Then
+      Page.verifyOnPage(SearchPage) //
+        .doesNotHaveStatusAndDueDateColumnsDisplayed()
+    })
 
-  it('should show the search page with all columns given user does have the manager role', () => {
-    // Given
-    cy.task('reset')
-    cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] })
-    cy.signIn()
+    it('should show the search page with all columns given user does have the manager role', () => {
+      // Given
+      cy.task('stubSignIn', { roles: ['ROLE_SAN_EDUCATION_MANAGER'] })
+      cy.signIn()
 
-    // When
-    cy.visit('/search')
+      // When
+      cy.visit('/search')
 
-    // Then
-    Page.verifyOnPage(SearchPage) //
-      .hasStatusAndDueDateColumnsDisplayed()
+      // Then
+      Page.verifyOnPage(SearchPage) //
+        .hasStatusAndDueDateColumnsDisplayed()
+    })
   })
 })

--- a/server/routes/search/index.ts
+++ b/server/routes/search/index.ts
@@ -7,9 +7,7 @@ import SearchSortDirection from '../../enums/searchSortDirection'
 import config from '../../config'
 import { Result } from '../../utils/result/result'
 import { PrisonUser } from '../../interfaces/hmppsUser'
-
-const DEFAULT_SORT_FIELD = SearchSortField.PRISONER_NAME
-const DEFAULT_SORT_DIRECTION = SearchSortDirection.ASC
+import ApplicationAction from '../../enums/applicationAction'
 
 const searchRoutes = (services: Services): Router => {
   const router = Router({ mergeParams: true })
@@ -17,13 +15,20 @@ const searchRoutes = (services: Services): Router => {
   const searchController = new SearchController()
 
   const performSearch = async (req: Request, res: Response, next: NextFunction) => {
-    const sortOptions = ((req.query.sort as string) || `${DEFAULT_SORT_FIELD},${DEFAULT_SORT_DIRECTION}`)
+    const { defaultSortField, defaultSortDirection } = res.locals.userHasPermissionTo(
+      ApplicationAction.VIEW_ELSP_DEADLINES_AND_STATUSES_ON_SEARCH,
+    )
+      ? { defaultSortField: SearchSortField.DEADLINE_DATE, defaultSortDirection: SearchSortDirection.ASC }
+      : { defaultSortField: SearchSortField.PRISONER_NAME, defaultSortDirection: SearchSortDirection.ASC }
+
+    const sortOptions = ((req.query.sort as string) || `${defaultSortField},${defaultSortDirection}`)
       .trim()
       .split(',')
       .map(value => value.trim().toUpperCase())
-    const sortField = Object.values(SearchSortField).find(value => value === sortOptions[0]) || DEFAULT_SORT_FIELD
+
+    const sortField = Object.values(SearchSortField).find(value => value === sortOptions[0]) || defaultSortField
     const sortDirection =
-      Object.values(SearchSortDirection).find(value => value === sortOptions[1]) || DEFAULT_SORT_DIRECTION
+      Object.values(SearchSortDirection).find(value => value === sortOptions[1]) || defaultSortDirection
 
     const searchTerm = (req.query.searchTerm as string) || ''
     const page = parseInt((req.query.page as string) || '1', 10)

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -29,6 +29,8 @@ export const user: HmppsUser = {
 
 export const flashProvider = jest.fn()
 
+const userHasPermissionTo = jest.fn()
+
 function appSetup(services: Services, production: boolean, userSupplier: () => HmppsUser): Express {
   const app = express()
 
@@ -41,6 +43,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
     req.flash = flashProvider
     res.locals = {
       user: { ...req.user } as HmppsUser,
+      userHasPermissionTo,
     }
     next()
   })


### PR DESCRIPTION
Set default sort order on prisoner list page depending on what the user is allowed to do in the system

If the user is not allowed to see the Plan Statuses and Deadline Dates on the prisoner list search results screen ("default" access), then the default order should be on prisoner name ascending.

If the user is allowed to see the Plan Statuses and Deadline Dates on the prisoner list search results screen (users with editor or manager roles), then the default order should be on deadline date ascending.

### "default" access (user does not have permission to see plan statuses or deadline dates
<img width="1187" height="1170" alt="Screenshot 2025-10-08 at 14 23 41" src="https://github.com/user-attachments/assets/3cc46ea7-a1f5-4a8f-b809-3c8bcf7b9c0e" />

### User does have permission to see plan statuses and deadline dates
<img width="1194" height="885" alt="Screenshot 2025-10-08 at 14 21 18" src="https://github.com/user-attachments/assets/69eab82c-671c-4573-9056-ae694fdc2e0e" />

