### PR TITLE
Correct "Review due" display for Active Plans that do not have a review date

### DIFF
--- a/server/views/pages/profile/components/actions-card/template.njk
+++ b/server/views/pages/profile/components/actions-card/template.njk
@@ -32,7 +32,9 @@
           <span class="govuk-tag govuk-tag--green govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="active-plan-tag">
             Active plan
           </span>
-          <p class="govuk-body" data-qa="plan-review-due-date">Review due {{ planReviewDeadlineDate | formatDate('d MMM yyyy') }}</p>
+          {% if planReviewDeadlineDate %}
+            <p class="govuk-body" data-qa="plan-review-due-date">Review due {{ planReviewDeadlineDate | formatDate('d MMM yyyy') }}</p>
+          {% endif %}
         {% endif %}
 
         {% if planStatus == 'PLAN_OVERDUE' %}


### PR DESCRIPTION
PR to correct the display of the "Review due" in the Action Bar for Active Plans that do not have a review date

### Before the fix
<img width="958" height="602" alt="Screenshot 2025-10-22 at 08 06 05" src="https://github.com/user-attachments/assets/baf6cd42-4322-4de6-ac2f-8e43691a1b23" />

### With the fix
<img width="957" height="355" alt="Screenshot 2025-10-22 at 08 05 24" src="https://github.com/user-attachments/assets/8c1187c4-75fb-4ac0-9c49-9db293fe51e8" />
