### PR TITLE
RR-1852 - Improve Conditions API client handling of 404s

### DIFF
--- a/server/data/supportAdditionalNeedsApiClient.test.ts
+++ b/server/data/supportAdditionalNeedsApiClient.test.ts
@@ -774,212 +774,256 @@ describe('supportAdditionalNeedsApiClient', () => {
       expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
       expect(nock.isDone()).toBe(true)
     })
+  })
 
-    describe('getStrengths', () => {
-      it('should get strengths for a prisoner', async () => {
-        // Given
-        const expectedResponse = aValidStrengthListResponse()
-        supportAdditionalNeedsApi
-          .get(`/profile/${prisonNumber}/strengths`)
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .reply(200, expectedResponse)
+  describe('getStrengths', () => {
+    it('should get strengths for a prisoner', async () => {
+      // Given
+      const expectedResponse = aValidStrengthListResponse()
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/strengths`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, expectedResponse)
 
-        // When
-        const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username)
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username)
 
-        // Then
-        expect(actual).toEqual(expectedResponse)
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
-
-      it('should return null given API returns a not found error', async () => {
-        // Given
-        const apiErrorResponse = {
-          status: 404,
-          userMessage: 'Not found',
-          developerMessage: 'Not found',
-        }
-
-        supportAdditionalNeedsApi
-          .get(`/profile/${prisonNumber}/strengths`)
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .reply(404, apiErrorResponse)
-
-        // When
-        const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username)
-
-        // Then
-        expect(actual).toBeNull()
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
-
-      it('should rethrow error given API returns an error', async () => {
-        // Given
-        const apiErrorResponse = {
-          status: 500,
-          userMessage: 'Service unavailable',
-          developerMessage: 'Service unavailable',
-        }
-        supportAdditionalNeedsApi
-          .get(`/profile/${prisonNumber}/strengths`)
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .thrice()
-          .reply(500, apiErrorResponse)
-
-        const expectedError = new Error('Internal Server Error')
-
-        // When
-        const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username).catch(e => e)
-
-        // Then
-        expect(actual).toEqual(expectedError)
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
+      // Then
+      expect(actual).toEqual(expectedResponse)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
     })
 
-    describe('createSupportStrategies', () => {
-      it('should create support strategies for a prisoner', async () => {
-        // Given
-        const createSupportStrategiesRequest = aValidCreateSupportStrategiesRequest()
+    it('should return null given API returns a not found error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 404,
+        userMessage: 'Not found',
+        developerMessage: 'Not found',
+      }
 
-        const expectedResponse = aValidSupportStrategyListResponse()
-        supportAdditionalNeedsApi
-          .post(`/profile/${prisonNumber}/support-strategies`, requestBody =>
-            isMatch(requestBody, createSupportStrategiesRequest),
-          )
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .reply(200, expectedResponse)
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/strengths`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(404, apiErrorResponse)
 
-        // When
-        const actual = await supportAdditionalNeedsApiClient.createSupportStrategies(
-          prisonNumber,
-          username,
-          createSupportStrategiesRequest,
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username)
+
+      // Then
+      expect(actual).toBeNull()
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should rethrow error given API returns an error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 500,
+        userMessage: 'Service unavailable',
+        developerMessage: 'Service unavailable',
+      }
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/strengths`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .thrice()
+        .reply(500, apiErrorResponse)
+
+      const expectedError = new Error('Internal Server Error')
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getStrengths(prisonNumber, username).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
+  describe('createSupportStrategies', () => {
+    it('should create support strategies for a prisoner', async () => {
+      // Given
+      const createSupportStrategiesRequest = aValidCreateSupportStrategiesRequest()
+
+      const expectedResponse = aValidSupportStrategyListResponse()
+      supportAdditionalNeedsApi
+        .post(`/profile/${prisonNumber}/support-strategies`, requestBody =>
+          isMatch(requestBody, createSupportStrategiesRequest),
         )
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, expectedResponse)
 
-        // Then
-        expect(actual).toEqual(expectedResponse)
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
+      // When
+      const actual = await supportAdditionalNeedsApiClient.createSupportStrategies(
+        prisonNumber,
+        username,
+        createSupportStrategiesRequest,
+      )
 
-      it('should rethrow error given API returns an error', async () => {
-        // Given
-        const createSupportStrategiesRequest = aValidCreateSupportStrategiesRequest()
-
-        const apiErrorResponse = {
-          status: 500,
-          userMessage: 'Service unavailable',
-          developerMessage: 'Service unavailable',
-        }
-        supportAdditionalNeedsApi
-          .post(`/profile/${prisonNumber}/support-strategies`, requestBody =>
-            isMatch(requestBody, createSupportStrategiesRequest),
-          )
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .reply(500, apiErrorResponse)
-
-        const expectedError = new Error('Internal Server Error')
-
-        // When
-        const actual = await supportAdditionalNeedsApiClient
-          .createSupportStrategies(prisonNumber, username, createSupportStrategiesRequest)
-          .catch(e => e)
-
-        // Then
-        expect(actual).toEqual(expectedError)
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
-
-      describe('getSupportStrategies', () => {
-        it('should get support strategies for a prisoner', async () => {
-          // Given
-          const expectedResponse = aValidSupportStrategyListResponse()
-          supportAdditionalNeedsApi
-            .get(`/profile/${prisonNumber}/support-strategies`)
-            .matchHeader('authorization', `Bearer ${systemToken}`)
-            .reply(200, expectedResponse)
-
-          // When
-          const actual = await supportAdditionalNeedsApiClient.getSupportStrategies(prisonNumber, username)
-
-          // Then
-          expect(actual).toEqual(expectedResponse)
-          expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-          expect(nock.isDone()).toBe(true)
-        })
-
-        it('should return null given API returns a not found error', async () => {
-          // Given
-          const apiErrorResponse = {
-            status: 404,
-            userMessage: 'Not found',
-            developerMessage: 'Not found',
-          }
-
-          supportAdditionalNeedsApi
-            .get(`/profile/${prisonNumber}/support-strategies`)
-            .matchHeader('authorization', `Bearer ${systemToken}`)
-            .reply(404, apiErrorResponse)
-
-          // When
-          const actual = await supportAdditionalNeedsApiClient.getSupportStrategies(prisonNumber, username)
-
-          // Then
-          expect(actual).toBeNull()
-          expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-          expect(nock.isDone()).toBe(true)
-        })
-
-        it('should rethrow error given API returns an error', async () => {
-          // Given
-          const apiErrorResponse = {
-            status: 500,
-            userMessage: 'Service unavailable',
-            developerMessage: 'Service unavailable',
-          }
-          supportAdditionalNeedsApi
-            .get(`/profile/${prisonNumber}/support-strategies`)
-            .matchHeader('authorization', `Bearer ${systemToken}`)
-            .thrice()
-            .reply(500, apiErrorResponse)
-
-          const expectedError = new Error('Internal Server Error')
-
-          // When
-          const actual = await supportAdditionalNeedsApiClient
-            .getSupportStrategies(prisonNumber, username)
-            .catch(e => e)
-
-          // Then
-          expect(actual).toEqual(expectedError)
-          expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-          expect(nock.isDone()).toBe(true)
-        })
-      })
+      // Then
+      expect(actual).toEqual(expectedResponse)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
     })
 
-    describe('getChallenges', () => {
-      it('should get challenges for a prisoner', async () => {
-        // Given
-        const expectedResponse = aValidChallengeListResponse()
-        supportAdditionalNeedsApi
-          .get(`/profile/${prisonNumber}/challenges`)
-          .matchHeader('authorization', `Bearer ${systemToken}`)
-          .reply(200, expectedResponse)
+    it('should rethrow error given API returns an error', async () => {
+      // Given
+      const createSupportStrategiesRequest = aValidCreateSupportStrategiesRequest()
 
-        // When
-        const actual = await supportAdditionalNeedsApiClient.getChallenges(prisonNumber, username)
+      const apiErrorResponse = {
+        status: 500,
+        userMessage: 'Service unavailable',
+        developerMessage: 'Service unavailable',
+      }
+      supportAdditionalNeedsApi
+        .post(`/profile/${prisonNumber}/support-strategies`, requestBody =>
+          isMatch(requestBody, createSupportStrategiesRequest),
+        )
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(500, apiErrorResponse)
 
-        // Then
-        expect(actual).toEqual(expectedResponse)
-        expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
-        expect(nock.isDone()).toBe(true)
-      })
+      const expectedError = new Error('Internal Server Error')
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient
+        .createSupportStrategies(prisonNumber, username, createSupportStrategiesRequest)
+        .catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
+  describe('getSupportStrategies', () => {
+    it('should get support strategies for a prisoner', async () => {
+      // Given
+      const expectedResponse = aValidSupportStrategyListResponse()
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/support-strategies`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, expectedResponse)
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getSupportStrategies(prisonNumber, username)
+
+      // Then
+      expect(actual).toEqual(expectedResponse)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should return null given API returns a not found error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 404,
+        userMessage: 'Not found',
+        developerMessage: 'Not found',
+      }
+
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/support-strategies`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(404, apiErrorResponse)
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getSupportStrategies(prisonNumber, username)
+
+      // Then
+      expect(actual).toBeNull()
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should rethrow error given API returns an error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 500,
+        userMessage: 'Service unavailable',
+        developerMessage: 'Service unavailable',
+      }
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/support-strategies`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .thrice()
+        .reply(500, apiErrorResponse)
+
+      const expectedError = new Error('Internal Server Error')
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getSupportStrategies(prisonNumber, username).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
+  describe('getChallenges', () => {
+    it('should get challenges for a prisoner', async () => {
+      // Given
+      const expectedResponse = aValidChallengeListResponse()
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/challenges`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, expectedResponse)
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getChallenges(prisonNumber, username)
+
+      // Then
+      expect(actual).toEqual(expectedResponse)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should return null given API returns a not found error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 404,
+        userMessage: 'Not found',
+        developerMessage: 'Not found',
+      }
+
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/challenges`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(404, apiErrorResponse)
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getChallenges(prisonNumber, username)
+
+      // Then
+      expect(actual).toBeNull()
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should rethrow error given API returns an error', async () => {
+      // Given
+      const apiErrorResponse = {
+        status: 500,
+        userMessage: 'Service unavailable',
+        developerMessage: 'Service unavailable',
+      }
+      supportAdditionalNeedsApi
+        .get(`/profile/${prisonNumber}/challenges`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .thrice()
+        .reply(500, apiErrorResponse)
+
+      const expectedError = new Error('Internal Server Error')
+
+      // When
+      const actual = await supportAdditionalNeedsApiClient.getChallenges(prisonNumber, username).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith(username)
+      expect(nock.isDone()).toBe(true)
     })
   })
 

--- a/server/data/supportAdditionalNeedsApiClient.ts
+++ b/server/data/supportAdditionalNeedsApiClient.ts
@@ -146,6 +146,7 @@ export default class SupportAdditionalNeedsApiClient extends RestClient {
     return this.get<ChallengeListResponse>(
       {
         path: `/profile/${prisonNumber}/challenges`,
+        errorHandler: restClientErrorHandler({ ignore404: true }),
       },
       asSystem(username),
     )


### PR DESCRIPTION
PR to improve the 404 handling for the `GET /conditions` API request method (as per all our other API requests)
Also tidied the indentation and grouping of the API client tests