### PR TITLE
RR-2004 - Add Support Strategy action links

### DIFF
--- a/server/views/pages/profile/support-strategies/index.njk
+++ b/server/views/pages/profile/support-strategies/index.njk
@@ -36,10 +36,29 @@
                           <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text"
                              data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
                           </p>
-                          {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
-                          <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
-                            Added on {{ supportStrategy.updatedAt | formatDate('d MMMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
-                          </p>
+
+                          <div class="actions-wrapper">
+                            <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
+                              {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
+                              Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
+                            </p>
+
+                            {% if featureToggles.editAndArchiveEnabled %}
+                              <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                                {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
+                                  <li class="govuk-summary-card__action">
+                                    <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
+                                  </li>
+                                {% endif %}
+                                {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
+                                  <li class="govuk-summary-card__action">
+                                    <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive" data-qa="archive-support-strategy-button">Move to history</a>
+                                  </li>
+                                {% endif %}
+                              </ul>
+                            {% endif %}
+                          </div>
+
                         </div>
                       {% endfor %}
                     </div>


### PR DESCRIPTION
Add "Edit" and "Move to history" action links for Support Strategies

<img width="1262" height="1249" alt="Screenshot 2025-11-04 at 10 48 24" src="https://github.com/user-attachments/assets/ec1048e9-a7a8-4d42-9e10-27da71d64ef1" />
