### PR TITLE
RR-2004 - Add links to create support strategy

### DIFF
--- a/server/views/pages/profile/challenges/index.njk
+++ b/server/views/pages/profile/challenges/index.njk
@@ -19,43 +19,53 @@
 
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
-      {% if groupedChallenges.isFulfilled() %}
-        {% set groupedChallenges = groupedChallenges.value %}
+      <section>
+        {% if groupedChallenges.isFulfilled() %}
+          {% set groupedChallenges = groupedChallenges.value %}
 
-        {% if groupedChallenges | length %}
-          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-          {% for challengeCategory, challengesData in groupedChallenges %}
-            {{ challengesSummaryCard({
-              challengesData: challengesData,
-              prisonNamesById: prisonNamesById,
-              showActions: true,
-              userHasPermissionTo: userHasPermissionTo,
-              title: challengeCategory | formatChallengeCategoryScreenValue,
-              attributes: {
-                'data-qa': 'challenges-summary-card-' + challengeCategory
-              }
-            }) }}
-          {% endfor %}
+          {% if groupedChallenges | length %}
+            {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+            {% for challengeCategory, challengesData in groupedChallenges %}
+              {{ challengesSummaryCard({
+                challengesData: challengesData,
+                prisonNamesById: prisonNamesById,
+                showActions: true,
+                userHasPermissionTo: userHasPermissionTo,
+                title: challengeCategory | formatChallengeCategoryScreenValue,
+                attributes: {
+                  'data-qa': 'challenges-summary-card-' + challengeCategory
+                }
+              }) }}
+            {% endfor %}
+
+          {% else %}
+
+            <div class="govuk-summary-card" data-qa="no-challenges-summary-card">
+              <div class="govuk-summary-card__content">
+                <p class="govuk-body">
+                  No challenges recorded
+                </p>
+                {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+                  <a class="govuk-link govuk-body govuk-!-display-none-print" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category">Add challenge</a>
+                {% endif %}
+              </div>
+            </div>
+
+          {% endif %}
 
         {% else %}
-
-          <div class="govuk-summary-card" data-qa="no-challenges-summary-card">
-            <div class="govuk-summary-card__content">
-              <p class="govuk-body">
-                No challenges recorded
-              </p>
-              {% if userHasPermissionTo('RECORD_CHALLENGES') %}
-                <a class="govuk-link govuk-body govuk-!-display-none-print" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category">Add challenge</a>
-              {% endif %}
-            </div>
-          </div>
-
+          <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
+          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
         {% endif %}
+      </section>
 
-      {% else %}
-        <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
-        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
-      {% endif %}
+      <p class="govuk-body">
+        {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+          <a class="govuk-link govuk-!-display-none-print" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add a challenge
+          </a>
+        {% endif %}
+      </p>
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -19,43 +19,53 @@
 
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
-      {% if groupedStrengths.isFulfilled() %}
-        {% set groupedStrengths = groupedStrengths.value %}
+      <section>
+        {% if groupedStrengths.isFulfilled() %}
+          {% set groupedStrengths = groupedStrengths.value %}
 
-        {% if groupedStrengths | length %}
-          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-          {% for strengthCategory, strengthsData in groupedStrengths %}
-            {{ strengthsSummaryCard({
-              title: strengthCategory | formatStrengthCategoryScreenValue | default(strengthCategory, true),
-              strengthsData: strengthsData,
-              prisonNamesById: prisonNamesById,
-              showActions: true,
-              userHasPermissionTo: userHasPermissionTo,
-              attributes: {
-                'data-qa': 'strengths-summary-card_' + strengthCategory
-              }
-            }) }}
-          {% endfor %}
+          {% if groupedStrengths | length %}
+            {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+            {% for strengthCategory, strengthsData in groupedStrengths %}
+              {{ strengthsSummaryCard({
+                title: strengthCategory | formatStrengthCategoryScreenValue | default(strengthCategory, true),
+                strengthsData: strengthsData,
+                prisonNamesById: prisonNamesById,
+                showActions: true,
+                userHasPermissionTo: userHasPermissionTo,
+                attributes: {
+                  'data-qa': 'strengths-summary-card_' + strengthCategory
+                }
+              }) }}
+            {% endfor %}
+
+          {% else %}
+
+            <div class="govuk-summary-card" data-qa="no-strengths-summary-card">
+              <div class="govuk-summary-card__content">
+                <p class="govuk-body">
+                  No strengths recorded
+                </p>
+                {% if userHasPermissionTo('RECORD_STRENGTHS') %}
+                  <a class="govuk-link govuk-body govuk-!-display-none-print" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">Add strength</a>
+                {% endif %}
+              </div>
+            </div>
+
+          {% endif %}
 
         {% else %}
-
-          <div class="govuk-summary-card" data-qa="no-strengths-summary-card">
-            <div class="govuk-summary-card__content">
-              <p class="govuk-body">
-                No strengths recorded
-              </p>
-              {% if userHasPermissionTo('RECORD_STRENGTHS') %}
-                <a class="govuk-link govuk-body govuk-!-display-none-print" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">Add strength</a>
-              {% endif %}
-            </div>
-          </div>
-
+          <h3 class="govuk-heading-s" data-qa="strengths-unavailable-message">We cannot show these details right now</h3>
+          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
         {% endif %}
+      </section>
 
-      {% else %}
-        <h3 class="govuk-heading-s" data-qa="strengths-unavailable-message">We cannot show these details right now</h3>
-        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
-      {% endif %}
+      <p class="govuk-body">
+        {% if userHasPermissionTo('RECORD_STRENGTHS') %}
+          <a class="govuk-link govuk-!-display-none-print" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add a strength
+          </a>
+        {% endif %}
+      </p>
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">

--- a/server/views/pages/profile/support-strategies/index.njk
+++ b/server/views/pages/profile/support-strategies/index.njk
@@ -18,60 +18,70 @@
 
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
-      {% if supportStrategies.isFulfilled() %}
-        {% set supportStrategies = supportStrategies.value %}
-        {% if supportStrategies | length == 0 %}
-          {% include "./_noSupportStrategiesSummaryCard.njk" %}
-        {% else %}
-          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-          {% for groupName, supportStrategyData in supportStrategies %}
-                <div class="govuk-summary-card" data-qa="support-strategy-summary-card-{{ groupName }}">
-                  <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">{{ groupName | formatSupportStrategyTypeScreenValue }}</h2>
-                  </div>
-                  <div class="govuk-summary-card__content govuk-!-padding-top-0">
-                    <div class="govuk-summary-list">
-                      {% for supportStrategy in supportStrategyData %}
-                        <div class="govuk-summary-list__row" data-qa="support-strategy-summary-list-row">
-                          <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text"
-                             data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
-                          </p>
-
-                          <div class="actions-wrapper">
-                            <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
-                              {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
-                              Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
+      <section>
+        {% if supportStrategies.isFulfilled() %}
+          {% set supportStrategies = supportStrategies.value %}
+          {% if supportStrategies | length == 0 %}
+            {% include "./_noSupportStrategiesSummaryCard.njk" %}
+          {% else %}
+            {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+            {% for groupName, supportStrategyData in supportStrategies %}
+                  <div class="govuk-summary-card" data-qa="support-strategy-summary-card-{{ groupName }}">
+                    <div class="govuk-summary-card__title-wrapper">
+                      <h2 class="govuk-summary-card__title">{{ groupName | formatSupportStrategyTypeScreenValue }}</h2>
+                    </div>
+                    <div class="govuk-summary-card__content govuk-!-padding-top-0">
+                      <div class="govuk-summary-list">
+                        {% for supportStrategy in supportStrategyData %}
+                          <div class="govuk-summary-list__row" data-qa="support-strategy-summary-list-row">
+                            <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text"
+                               data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
                             </p>
 
-                            {% if featureToggles.editAndArchiveEnabled %}
-                              <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-                                {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
-                                  <li class="govuk-summary-card__action">
-                                    <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
-                                  </li>
-                                {% endif %}
-                                {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
-                                  <li class="govuk-summary-card__action">
-                                    <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive" data-qa="archive-support-strategy-button">Move to history</a>
-                                  </li>
-                                {% endif %}
-                              </ul>
-                            {% endif %}
-                          </div>
+                            <div class="actions-wrapper">
+                              <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
+                                {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
+                                Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
+                              </p>
 
-                        </div>
-                      {% endfor %}
+                              {% if featureToggles.editAndArchiveEnabled %}
+                                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                                  {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
+                                    <li class="govuk-summary-card__action">
+                                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
+                                    </li>
+                                  {% endif %}
+                                  {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
+                                    <li class="govuk-summary-card__action">
+                                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive" data-qa="archive-support-strategy-button">Move to history</a>
+                                    </li>
+                                  {% endif %}
+                                </ul>
+                              {% endif %}
+                            </div>
+
+                          </div>
+                        {% endfor %}
+                      </div>
                     </div>
                   </div>
-                </div>
-            {% endfor %}
+              {% endfor %}
+          {% endif %}
+        {% else %}
+            <h3 class="govuk-heading-s" data-qa="support-strategies-unavailable-message">We cannot show these details
+              right now</h3>
+            <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be
+              available.</p>
         {% endif %}
-      {% else %}
-          <h3 class="govuk-heading-s" data-qa="support-strategies-unavailable-message">We cannot show these details
-            right now</h3>
-          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be
-            available.</p>
-      {% endif %}
+      </section>
+
+      <p class="govuk-body">
+        {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
+          <a class="govuk-link govuk-!-display-none-print" href="/support-strategies/{{ prisonerSummary.prisonNumber }}/create/select-category">
+            Add a support strategy
+          </a>
+        {% endif %}
+      </p>
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">


### PR DESCRIPTION
PR to add the link at the bottom of the Support Strategies page to be able to create a new support strategy
(and also the same for Strengths and Challenges)

<img width="963" height="886" alt="Screenshot 2025-11-05 at 11 35 12" src="https://github.com/user-attachments/assets/0ec65abf-8d75-428d-a6b7-080d43aa66b1" />
