### PR TITLE
RR-2007 - Refactor conditional fields for Conditions

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -52,3 +52,8 @@ dl.app-u-description-list {
   pointer-events: none;
   cursor: default;
 }
+
+// Ensure that govuk checkbox conditional elements are not displayed if they have no content / are empty
+.govuk-checkboxes__conditional:not(:has(*)) {
+  display: none;
+}

--- a/server/routes/conditions/conditionsThatRequireNaming.ts
+++ b/server/routes/conditions/conditionsThatRequireNaming.ts
@@ -1,0 +1,16 @@
+import ConditionType from '../../enums/conditionType'
+
+const conditionsThatRequireNaming = [
+  ConditionType.LD_OTHER,
+  ConditionType.MENTAL_HEALTH,
+  ConditionType.NEURODEGEN,
+  ConditionType.PHYSICAL_OTHER,
+  ConditionType.VISUAL_IMPAIR,
+  ConditionType.OTHER,
+  ConditionType.DLD_OTHER,
+  ConditionType.LEARN_DIFF_OTHER,
+  ConditionType.LONG_TERM_OTHER,
+  ConditionType.NEURO_OTHER,
+]
+
+export default conditionsThatRequireNaming

--- a/server/routes/conditions/create/details/detailsController.ts
+++ b/server/routes/conditions/create/details/detailsController.ts
@@ -15,11 +15,11 @@ export default class DetailsController {
     const { invalidForm, prisonerSummary } = res.locals
     const { conditionsList } = req.journeyData
 
-    const selectDetailsForm = invalidForm ?? this.populateFormFromDto(conditionsList)
+    const detailsForm = invalidForm ?? this.populateFormFromDto(conditionsList)
 
     const viewRenderArgs = {
       prisonerSummary,
-      form: selectDetailsForm,
+      form: detailsForm,
       dto: conditionsList,
       errorRecordingConditions: req.flash('pageHasApiErrors')[0] != null,
     }

--- a/server/routes/conditions/create/select-conditions/selectConditionsController.test.ts
+++ b/server/routes/conditions/create/select-conditions/selectConditionsController.test.ts
@@ -5,6 +5,7 @@ import { aValidConditionDto } from '../../../../testsupport/conditionDtoTestData
 import ConditionType from '../../../../enums/conditionType'
 import ConditionSource from '../../../../enums/conditionSource'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import conditionsThatRequireNaming from '../../conditionsThatRequireNaming'
 
 describe('selectConditionsController', () => {
   const controller = new SelectConditionsController()
@@ -53,6 +54,7 @@ describe('selectConditionsController', () => {
         conditions: ['ADHD'],
       },
       prisonerSummary,
+      conditionsThatRequireNaming,
     }
 
     // When
@@ -73,6 +75,7 @@ describe('selectConditionsController', () => {
     const expectedViewModel = {
       form: invalidForm,
       prisonerSummary,
+      conditionsThatRequireNaming,
     }
 
     // When

--- a/server/routes/conditions/create/select-conditions/selectConditionsController.ts
+++ b/server/routes/conditions/create/select-conditions/selectConditionsController.ts
@@ -4,6 +4,7 @@ import { asArray } from '../../../../utils/utils'
 import ConditionType from '../../../../enums/conditionType'
 import ConditionSource from '../../../../enums/conditionSource'
 import { PrisonUser } from '../../../../interfaces/hmppsUser'
+import conditionsThatRequireNaming from '../../conditionsThatRequireNaming'
 
 export default class SelectConditionsController {
   getSelectConditionsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -17,7 +18,7 @@ export default class SelectConditionsController {
         }
       : this.populateFormFromDto(conditionsList)
 
-    const viewRenderArgs = { prisonerSummary, form: selectConditionsForm }
+    const viewRenderArgs = { prisonerSummary, form: selectConditionsForm, conditionsThatRequireNaming }
     return res.render('pages/conditions/select-conditions/index', viewRenderArgs)
   }
 

--- a/server/routes/conditions/validationSchemas/selectConditionsSchema.ts
+++ b/server/routes/conditions/validationSchemas/selectConditionsSchema.ts
@@ -3,20 +3,9 @@ import { createSchema } from '../../../middleware/validationMiddleware'
 import { asArray } from '../../../utils/utils'
 import ConditionType from '../../../enums/conditionType'
 import { textValueExceedsLength } from '../../../utils/validation/textValueValidator'
+import conditionsThatRequireNaming from '../conditionsThatRequireNaming'
 
 const selectConditionsSchema = async () => {
-  const CONDITION_TYPES_REQUIRING_NAME = [
-    ConditionType.LD_OTHER,
-    ConditionType.MENTAL_HEALTH,
-    ConditionType.NEURODEGEN,
-    ConditionType.PHYSICAL_OTHER,
-    ConditionType.VISUAL_IMPAIR,
-    ConditionType.OTHER,
-    ConditionType.DLD_OTHER,
-    ConditionType.LEARN_DIFF_OTHER,
-    ConditionType.LONG_TERM_OTHER,
-    ConditionType.NEURO_OTHER,
-  ]
   const CONDITION_NAME_MAX_LENGTH = 200
 
   const conditionTypeCodeMandatoryMessage = 'Select all conditions that the person has'
@@ -37,7 +26,7 @@ const selectConditionsSchema = async () => {
     const { conditions, conditionNames } = ctx.value
 
     asArray(conditions).forEach(conditionType => {
-      if (CONDITION_TYPES_REQUIRING_NAME.includes(conditionType)) {
+      if (conditionsThatRequireNaming.includes(conditionType)) {
         // this condition is one that requires the additional detail field
         if (
           !conditionNames ||

--- a/server/views/pages/conditions/select-conditions/index.njk
+++ b/server/views/pages/conditions/select-conditions/index.njk
@@ -20,17 +20,19 @@
         <div class="govuk-form-group">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-          {% macro conditionNameInput(conditionType, value) %}
-            {{ govukInput({
-              id: conditionType + "_conditionNames",
-              name: "conditionNames[" + conditionType + "]",
-              value: value,
-              maxlength: 200,
-              label: {
-                text: "Specify condition"
-              },
-              errorMessage: errors | findError(conditionType + "_conditionNames")
-            }) }}
+          {% macro conditionalNameInput(conditionType, values) %}
+            {% if conditionsThatRequireNaming.includes(conditionType) %}
+              {{ govukInput({
+                id: conditionType + "_conditionNames",
+                name: "conditionNames[" + conditionType + "]",
+                value: values[conditionType],
+                maxlength: 200,
+                label: {
+                  text: "Specify condition"
+                },
+                errorMessage: errors | findError(conditionType + "_conditionNames")
+              }) }}
+            {% endif %}
           {% endmacro %}
 
           <div class="govuk-grid-row">
@@ -46,112 +48,98 @@
                   {
                     value: "ABI",
                     text: "ABI" | formatConditionTypeScreenValue | default("ABI", true),
-                    checked: form.conditions.includes("ABI")
+                    checked: form.conditions.includes("ABI"),
+                    conditional: { html: conditionalNameInput("ABI", form.conditionNames) }
                   },
                   {
                     value: "ADHD",
                     text: "ADHD" | formatConditionTypeScreenValue | default("ADHD", true),
-                    checked: form.conditions.includes("ADHD")
+                    checked: form.conditions.includes("ADHD"),
+                    conditional: { html: conditionalNameInput("ADHD", form.conditionNames) }
                   },
                   {
                     value: "ASC",
                     text: "ASC" | formatConditionTypeScreenValue | default("ASC", true),
-                    checked: form.conditions.includes("ASC")
+                    checked: form.conditions.includes("ASC"),
+                    conditional: { html: conditionalNameInput("ASC", form.conditionNames) }
                   },
                   {
                     value: "DLD_LANG",
                     text: "DLD_LANG" | formatConditionTypeScreenValue | default("DLD_LANG", true),
-                    checked: form.conditions.includes("DLD_LANG")
+                    checked: form.conditions.includes("DLD_LANG"),
+                    conditional: { html: conditionalNameInput("DLD_LANG", form.conditionNames) }
                   },
                   {
                     value: "LD_DOWN",
                     text: "LD_DOWN" | formatConditionTypeScreenValue | default("LD_DOWN", true),
-                    checked: form.conditions.includes("LD_DOWN")
+                    checked: form.conditions.includes("LD_DOWN"),
+                    conditional: { html: conditionalNameInput("LD_DOWN", form.conditionNames) }
                   },
                   {
                     value: "DYSCALCULIA",
                     text: "DYSCALCULIA" | formatConditionTypeScreenValue | default("DYSCALCULIA", true),
-                    checked: form.conditions.includes("DYSCALCULIA")
+                    checked: form.conditions.includes("DYSCALCULIA"),
+                    conditional: { html: conditionalNameInput("DYSCALCULIA", form.conditionNames) }
                   },
                   {
                     value: "DYSLEXIA",
                     text: "DYSLEXIA" | formatConditionTypeScreenValue | default("DYSLEXIA", true),
-                    checked: form.conditions.includes("DYSLEXIA")
+                    checked: form.conditions.includes("DYSLEXIA"),
+                    conditional: { html: conditionalNameInput("DYSLEXIA", form.conditionNames) }
                   },
                   {
                     value: "DYSPRAXIA",
                     text: "DYSPRAXIA" | formatConditionTypeScreenValue | default("DYSPRAXIA", true),
-                    checked: form.conditions.includes("DYSPRAXIA")
+                    checked: form.conditions.includes("DYSPRAXIA"),
+                    conditional: { html: conditionalNameInput("DYSPRAXIA", form.conditionNames) }
                   },
                   {
                     value: "FASD",
                     text: "FASD" | formatConditionTypeScreenValue | default("FASD", true),
-                    checked: form.conditions.includes("FASD")
+                    checked: form.conditions.includes("FASD"),
+                    conditional: { html: conditionalNameInput("FASD", form.conditionNames) }
                   },
                   {
                     value: "DLD_HEAR",
                     text: "DLD_HEAR" | formatConditionTypeScreenValue | default("DLD_HEAR", true),
-                    checked: form.conditions.includes("DLD_HEAR")
+                    checked: form.conditions.includes("DLD_HEAR"),
+                    conditional: { html: conditionalNameInput("DLD_HEAR", form.conditionNames) }
                   },
                   {
                     value: "LD_OTHER",
                     text: "LD_OTHER" | formatConditionTypeScreenValue | default("LD_OTHER", true),
                     checked: form.conditions.includes("LD_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "LD_OTHER",
-                        form.conditionNames["LD_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("LD_OTHER", form.conditionNames) }
                   },
                   {
                     value: "MENTAL_HEALTH",
                     text: "MENTAL_HEALTH" | formatConditionTypeScreenValue | default("MENTAL_HEALTH", true),
                     checked: form.conditions.includes("MENTAL_HEALTH"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "MENTAL_HEALTH",
-                        form.conditionNames["MENTAL_HEALTH"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("MENTAL_HEALTH", form.conditionNames) }
                   },
                   {
                     value: "NEURODEGEN",
                     text: "NEURODEGEN" | formatConditionTypeScreenValue | default("NEURODEGEN", true),
                     checked: form.conditions.includes("NEURODEGEN"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "NEURODEGEN",
-                        form.conditionNames["NEURODEGEN"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("NEURODEGEN", form.conditionNames) }
                   },
                   {
                     value: "PHYSICAL_OTHER",
                     text: "PHYSICAL_OTHER" | formatConditionTypeScreenValue | default("PHYSICAL_OTHER", true),
                     checked: form.conditions.includes("PHYSICAL_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "PHYSICAL_OTHER",
-                        form.conditionNames["PHYSICAL_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("PHYSICAL_OTHER", form.conditionNames) }
                   },
                   {
                     value: "TOURETTES",
                     text: "TOURETTES" | formatConditionTypeScreenValue | default("TOURETTES", true),
-                    checked: form.conditions.includes("TOURETTES")
+                    checked: form.conditions.includes("TOURETTES"),
+                    conditional: { html: conditionalNameInput("TOURETTES", form.conditionNames) }
                   },
                   {
                     value: "VISUAL_IMPAIR",
                     text: "VISUAL_IMPAIR" | formatConditionTypeScreenValue | default("VISUAL_IMPAIR", true),
                     checked: form.conditions.includes("VISUAL_IMPAIR"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "VISUAL_IMPAIR",
-                        form.conditionNames["VISUAL_IMPAIR"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("VISUAL_IMPAIR", form.conditionNames) }
                   }
                 ],
                 errorMessage: errors | findError('conditions')
@@ -171,56 +159,31 @@
                     value: "OTHER",
                     text: "OTHER" | formatConditionTypeScreenValue | default("OTHER", true),
                     checked: form.conditions.includes("OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "OTHER",
-                        form.conditionNames["OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("OTHER", form.conditionNames) }
                   },
                   {
                     value: "DLD_OTHER",
                     text: "DLD_OTHER" | formatConditionTypeScreenValue | default("DLD_OTHER", true),
                     checked: form.conditions.includes("DLD_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "DLD_OTHER",
-                        form.conditionNames["DLD_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("DLD_OTHER", form.conditionNames) }
                   },
                   {
                     value: "LEARN_DIFF_OTHER",
                     text: "LEARN_DIFF_OTHER" | formatConditionTypeScreenValue | default("LEARN_DIFF_OTHER", true),
                     checked: form.conditions.includes("LEARN_DIFF_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "LEARN_DIFF_OTHER",
-                        form.conditionNames["LEARN_DIFF_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("LEARN_DIFF_OTHER", form.conditionNames) }
                   },
                   {
                     value: "LONG_TERM_OTHER",
                     text: "LONG_TERM_OTHER" | formatConditionTypeScreenValue | default("LONG_TERM_OTHER", true),
                     checked: form.conditions.includes("LONG_TERM_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "LONG_TERM_OTHER",
-                        form.conditionNames["LONG_TERM_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("LONG_TERM_OTHER", form.conditionNames) }
                   },
                   {
                     value: "NEURO_OTHER",
                     text: "NEURO_OTHER" | formatConditionTypeScreenValue | default("NEURO_OTHER", true),
                     checked: form.conditions.includes("NEURO_OTHER"),
-                    conditional: {
-                      html: conditionNameInput(
-                        "NEURO_OTHER",
-                        form.conditionNames["NEURO_OTHER"]
-                      )
-                    }
+                    conditional: { html: conditionalNameInput("NEURO_OTHER", form.conditionNames) }
                   }
                 ]
               }) }}

--- a/server/views/pages/conditions/select-conditions/index.test.ts
+++ b/server/views/pages/conditions/select-conditions/index.test.ts
@@ -4,6 +4,7 @@ import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDa
 import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
 import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
 import findErrorFilter from '../../../../filters/findErrorFilter'
+import conditionsThatRequireNaming from '../../../../routes/conditions/conditionsThatRequireNaming'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/dist/',
@@ -25,6 +26,7 @@ const templateParams = {
   form: {
     conditions: [] as Array<string>,
   },
+  conditionsThatRequireNaming,
 }
 
 describe('Select Conditions', () => {


### PR DESCRIPTION
This PR refactors how the conditional display of the 'condition name' field works; IE. the bit on the "Add condition" form where some condition types have a 'condition name' field and others dont:

https://github.com/user-attachments/assets/c1d55d7e-1397-4207-a752-bedd90c403c6

Before this change, this logic actually lived in 2 places:
* In the nunjucks view template (ie. each field that required the extra field had it hard coded in the template)
* In the form validator (because the validator has to know what condition type has been selected, and if it is one of the ones that requires the condition name then it needs to validate that field as well)

As part of doing Edit Conditions,  we will need the same logic in the Edit Condition nunjucks template, so I'm taking this opportunity to refactor it first.

The basic idea is that there is a single array export `conditionsThatRequireNaming` that contains the list of condition types that also require a name. IE. it is defined once.
And the validator now imports that array (rather than having it's own copy), and the Add Condition controller now imports the array and puts it on the view model for the nunjucks view to use.
Within the nunjucks view, rather than add the field to just the condition types that require it (ie. hard code it), we now have a macro that is used on every condition type radio, and the macro decides whether to render the additional condition name field based on the `conditionsThatRequireNaming` array.
