### PR TITLE
RR-2011 - Initial refactoring of grouped strength and challenge mappers

### DIFF
--- a/server/routes/profile/overview/overviewController.test.ts
+++ b/server/routes/profile/overview/overviewController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import type { ChallengeResponseDto, StrengthResponseDto } from 'dto'
 import OverviewController from './overviewController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { Result } from '../../../utils/result/result'
@@ -13,8 +14,6 @@ import {
   setupNonAlnStrengthsPromise,
 } from '../profileTestSupportFunctions'
 import { aValidAlnScreenerResponseDto } from '../../../testsupport/alnScreenerDtoTestDataBuilder'
-import StrengthCategory from '../../../enums/strengthCategory'
-import ChallengeCategory from '../../../enums/challengeCategory'
 import { aCuriousAlnAndLddAssessmentsDto } from '../../../testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder'
 import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
@@ -86,6 +85,76 @@ describe('overviewController', () => {
   const curiousAlnAndLddAssessments = Result.fulfilled(aCuriousAlnAndLddAssessmentsDto())
   const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
 
+  const expectedGroupedStrengths = {
+    ATTENTION_ORGANISING_TIME: {
+      nonAlnStrengths: [attention],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        strengths: [focussing, tidiness],
+      },
+    },
+    LANGUAGE_COMM_SKILLS: {
+      nonAlnStrengths: [speaking],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        strengths: [] as Array<StrengthResponseDto>,
+      },
+    },
+    LITERACY_SKILLS: {
+      nonAlnStrengths: [literacy],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        strengths: [alphabetOrdering, reading, writing],
+      },
+    },
+    NUMERACY_SKILLS: {
+      nonAlnStrengths: [numeracy2, numeracy],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        strengths: [arithmetic],
+      },
+    },
+  }
+
+  const expectedGroupedChallenges = {
+    ATTENTION_ORGANISING_TIME: {
+      nonAlnChallenges: [attentionChallenge],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        challenges: [focussingChallenge, tidinessChallenge],
+      },
+    },
+    LANGUAGE_COMM_SKILLS: {
+      nonAlnChallenges: [speakingChallenge],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        challenges: [] as Array<ChallengeResponseDto>,
+      },
+    },
+    LITERACY_SKILLS: {
+      nonAlnChallenges: [literacyChallenge],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        challenges: [alphabetOrderingChallenge, readingChallenge, writingChallenge],
+      },
+    },
+    NUMERACY_SKILLS: {
+      nonAlnChallenges: [numeracy2Challenge, numeracyChallenge],
+      latestAlnScreener: {
+        screenerDate: latestScreener.screenerDate,
+        createdAtPrison: latestScreener.createdAtPrison,
+        challenges: [arithmeticChallenge],
+      },
+    },
+  }
+
   const req = {} as unknown as Request
   const res = {
     render: jest.fn(),
@@ -122,23 +191,13 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'fulfilled',
-        value: [
-          StrengthCategory.ATTENTION_ORGANISING_TIME,
-          StrengthCategory.LANGUAGE_COMM_SKILLS,
-          StrengthCategory.LITERACY_SKILLS,
-          StrengthCategory.NUMERACY_SKILLS,
-        ],
+        value: expectedGroupedStrengths,
       }),
-      challengeCategories: expect.objectContaining({
+      groupedChallenges: expect.objectContaining({
         status: 'fulfilled',
-        value: [
-          ChallengeCategory.ATTENTION_ORGANISING_TIME,
-          ChallengeCategory.LANGUAGE_COMM_SKILLS,
-          ChallengeCategory.LITERACY_SKILLS,
-          ChallengeCategory.NUMERACY_SKILLS,
-        ],
+        value: expectedGroupedChallenges,
       }),
       groupedSupportStrategies: expect.objectContaining({
         status: 'fulfilled',
@@ -167,7 +226,7 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
@@ -197,7 +256,7 @@ describe('overviewController', () => {
       educationSupportPlanLifecycleStatus,
       conditions,
       tab: 'overview',
-      challengeCategories: expect.objectContaining({
+      groupedChallenges: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
@@ -228,7 +287,7 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
@@ -261,7 +320,7 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
@@ -294,18 +353,13 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
-      challengeCategories: expect.objectContaining({
+      groupedChallenges: expect.objectContaining({
         status: 'fulfilled',
-        value: [
-          ChallengeCategory.ATTENTION_ORGANISING_TIME,
-          ChallengeCategory.LANGUAGE_COMM_SKILLS,
-          ChallengeCategory.LITERACY_SKILLS,
-          ChallengeCategory.NUMERACY_SKILLS,
-        ],
+        value: expectedGroupedChallenges,
       }),
       groupedSupportStrategies: expect.objectContaining({
         status: 'fulfilled',
@@ -336,18 +390,13 @@ describe('overviewController', () => {
       conditions,
       curiousAlnAndLddAssessments,
       tab: 'overview',
-      challengeCategories: expect.objectContaining({
+      groupedChallenges: expect.objectContaining({
         status: 'rejected',
         reason: expectedError,
       }),
-      strengthCategories: expect.objectContaining({
+      groupedStrengths: expect.objectContaining({
         status: 'fulfilled',
-        value: [
-          ChallengeCategory.ATTENTION_ORGANISING_TIME,
-          ChallengeCategory.LANGUAGE_COMM_SKILLS,
-          ChallengeCategory.LITERACY_SKILLS,
-          ChallengeCategory.NUMERACY_SKILLS,
-        ],
+        value: expectedGroupedStrengths,
       }),
       groupedSupportStrategies: expect.objectContaining({
         status: 'fulfilled',

--- a/server/routes/profile/overview/overviewController.ts
+++ b/server/routes/profile/overview/overviewController.ts
@@ -1,16 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import { Result } from '../../../utils/result/result'
-import StrengthCategory from '../../../enums/strengthCategory'
-import {
-  getActiveStrengthsFromAlnScreener,
-  getLatestAlnScreener,
-  getNonAlnActiveStrengths,
-  getActiveChallengesFromAlnScreener,
-  getNonAlnActiveChallenges,
-} from '../../utils'
-import enumComparator from '../../enumComparator'
-import ChallengeCategory from '../../../enums/challengeCategory'
 import toGroupedSupportStrategiesPromise from '../../utils/groupedSupportStrategiesMapper'
+import toGroupedStrengthsPromise from '../../utils/groupedStrengthsMapper'
+import toGroupedChallengesPromise from '../../utils/groupedChallengesMapper'
 
 export default class OverviewController {
   getOverviewView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -26,49 +17,16 @@ export default class OverviewController {
       supportStrategies,
     } = res.locals
 
-    let strengthCategoriesPromise: Result<Array<StrengthCategory>, Error>
-    let challengeCategoriesPromise: Result<Array<ChallengeCategory>, Error>
-
-    // Set Strengths categories or passthrough error if screener or strength api call has an error
-    if (alnScreeners.isFulfilled() && strengths.isFulfilled()) {
-      const nonAlnStrengths = getNonAlnActiveStrengths(strengths)
-      const latestAlnScreener = getLatestAlnScreener(alnScreeners)
-      const strengthsFromLatestAlnScreener = getActiveStrengthsFromAlnScreener(latestAlnScreener)
-
-      const strengthCategories = Array.from(
-        new Set(nonAlnStrengths.concat(strengthsFromLatestAlnScreener).map(strength => strength.strengthCategory)),
-      ).sort(enumComparator)
-      strengthCategoriesPromise = Result.fulfilled(strengthCategories)
-    } else {
-      // At least one of the API calls has failed; we need data from all APIs in order to properly render the data on the overview page
-      // Set the strength result to be a rejected Result containing the error message(s) from the original rejected promise(s)
-      strengthCategoriesPromise = Result.rewrapRejected(alnScreeners, strengths)
-    }
-
-    // Set Challenges categories or passthrough error if screener or challenges api call has an error
-    if (alnScreeners.isFulfilled() && challenges.isFulfilled()) {
-      const latestAlnScreener = getLatestAlnScreener(alnScreeners)
-      const nonAlnChallenges = getNonAlnActiveChallenges(challenges)
-      const challengesFromLatestAlnScreener = getActiveChallengesFromAlnScreener(latestAlnScreener)
-
-      const challengeCategories = Array.from(
-        new Set(nonAlnChallenges.concat(challengesFromLatestAlnScreener).map(challenge => challenge.challengeCategory)),
-      ).sort(enumComparator)
-      challengeCategoriesPromise = Result.fulfilled(challengeCategories)
-    } else {
-      // At least one of the API calls has failed; we need data from all APIs in order to properly render the data on the overview page
-      // Set the challenges result to be a rejected Result containing the error message(s) from the original rejected promise(s)
-      challengeCategoriesPromise = Result.rewrapRejected(alnScreeners, challenges)
-    }
-
+    const groupedStrengthsPromise = toGroupedStrengthsPromise(strengths, alnScreeners)
+    const groupedChallengesPromise = toGroupedChallengesPromise(challenges, alnScreeners)
     const supportStrategiesPromise = toGroupedSupportStrategiesPromise(supportStrategies)
 
     const viewRenderArgs = {
       prisonerSummary,
       conditions,
       educationSupportPlanLifecycleStatus,
-      strengthCategories: strengthCategoriesPromise,
-      challengeCategories: challengeCategoriesPromise,
+      groupedStrengths: groupedStrengthsPromise,
+      groupedChallenges: groupedChallengesPromise,
       curiousAlnAndLddAssessments,
       prisonNamesById,
       groupedSupportStrategies: supportStrategiesPromise,

--- a/server/routes/utils/groupedChallengesMapper.ts
+++ b/server/routes/utils/groupedChallengesMapper.ts
@@ -1,6 +1,6 @@
 import type { AlnScreenerList, ChallengeResponseDto } from 'dto'
 import { Result } from '../../utils/result/result'
-import { getActiveChallengesFromAlnScreener, getLatestAlnScreener, getNonAlnActiveChallenges } from './index'
+import { getChallengesFromAlnScreener, getLatestAlnScreener, getNonAlnChallenges } from './index'
 import dateComparator from '../dateComparator'
 import enumComparator from '../enumComparator'
 
@@ -22,11 +22,11 @@ const toGroupedChallengesPromise = (
 ): Result<GroupedChallenges, Error> => {
   if (alnScreeners.isFulfilled() && challenges.isFulfilled()) {
     // Group and sort the data from the prisoner's non-ALN Challenges, and the Challenges from their latest ALN Screener
-    const nonAlnChallenges = getNonAlnActiveChallenges(challenges).sort((left, right) =>
+    const nonAlnChallenges = getNonAlnChallenges(challenges, true).sort((left, right) =>
       dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
     )
     const latestAlnScreener = getLatestAlnScreener(alnScreeners)
-    const challengesFromLatestAlnScreener = getActiveChallengesFromAlnScreener(latestAlnScreener).sort((left, right) =>
+    const challengesFromLatestAlnScreener = getChallengesFromAlnScreener(latestAlnScreener, true).sort((left, right) =>
       enumComparator(left.challengeTypeCode, right.challengeTypeCode),
     )
     const screenerDate = latestAlnScreener?.screenerDate

--- a/server/routes/utils/groupedStrengthsMapper.ts
+++ b/server/routes/utils/groupedStrengthsMapper.ts
@@ -1,7 +1,7 @@
 import type { AlnScreenerList, StrengthResponseDto, StrengthsList } from 'dto'
 import enumComparator from '../enumComparator'
 import { Result } from '../../utils/result/result'
-import { getActiveStrengthsFromAlnScreener, getLatestAlnScreener, getNonAlnActiveStrengths } from './index'
+import { getStrengthsFromAlnScreener, getLatestAlnScreener, getNonAlnStrengths } from './index'
 import dateComparator from '../dateComparator'
 
 type GroupedStrengths = Record<
@@ -22,11 +22,11 @@ const toGroupedStrengthsPromise = (
 ): Result<GroupedStrengths, Error> => {
   if (alnScreeners.isFulfilled() && strengths.isFulfilled()) {
     // Group and sort the data from the prisoner's non-ALN Strengths, and the Strengths from their latest ALN Screener
-    const nonAlnStrengths = getNonAlnActiveStrengths(strengths).sort((left, right) =>
+    const nonAlnStrengths = getNonAlnStrengths(strengths, true).sort((left, right) =>
       dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
     )
     const latestAlnScreener = getLatestAlnScreener(alnScreeners)
-    const strengthsFromLatestAlnScreener = getActiveStrengthsFromAlnScreener(latestAlnScreener).sort((left, right) =>
+    const strengthsFromLatestAlnScreener = getStrengthsFromAlnScreener(latestAlnScreener, true).sort((left, right) =>
       enumComparator(left.strengthTypeCode, right.strengthTypeCode),
     )
     const screenerDate = latestAlnScreener?.screenerDate

--- a/server/routes/utils/index.ts
+++ b/server/routes/utils/index.ts
@@ -15,22 +15,47 @@ const getLatestAlnScreener = (screeners: Result<AlnScreenerList>): AlnScreenerRe
       dateComparator(left.screenerDate, right.screenerDate, 'DESC'),
     )[0]
 
-const getNonAlnActiveStrengths = (strengths: Result<StrengthsList>): Array<StrengthResponseDto> =>
-  strengths.getOrNull()?.strengths.filter(strength => strength.active && !strength.fromALNScreener) ?? []
+/**
+ * Returns an array of non-ALN Strength Response DTO from the specified list of Strengths, where the strength's active
+ * flag is set according to the method argument.
+ */
+const getNonAlnStrengths = (strengths: Result<StrengthsList>, active: boolean): Array<StrengthResponseDto> =>
+  strengths.getOrNull()?.strengths.filter(strength => strength.active === active && !strength.fromALNScreener) ?? []
 
-const getActiveStrengthsFromAlnScreener = (alnScreener: AlnScreenerResponseDto): Array<StrengthResponseDto> =>
-  alnScreener?.strengths.filter(strength => strength.active && strength.fromALNScreener) ?? []
+/**
+ * Returns an array of ALN Strength Response DTO from the specified ALN Screener Response DTO, where the strength's active
+ * flag is set according to the method argument.
+ */
+const getStrengthsFromAlnScreener = (
+  alnScreener: AlnScreenerResponseDto,
+  active: boolean,
+): Array<StrengthResponseDto> =>
+  alnScreener?.strengths.filter(strength => strength.active === active && strength.fromALNScreener) ?? []
 
-const getNonAlnActiveChallenges = (challenges: Result<Array<ChallengeResponseDto>>): Array<ChallengeResponseDto> =>
-  challenges.getOrNull()?.filter(challenge => challenge.active && !challenge.fromALNScreener) ?? []
+/**
+ * Returns an array of non-ALN Challenge Response DTO from the specified list of Challenges, where the challenge's active
+ * flag is set according to the method argument.
+ */
+const getNonAlnChallenges = (
+  challenges: Result<Array<ChallengeResponseDto>>,
+  active: boolean,
+): Array<ChallengeResponseDto> =>
+  challenges.getOrNull()?.filter(challenge => challenge.active === active && !challenge.fromALNScreener) ?? []
 
-const getActiveChallengesFromAlnScreener = (alnScreener: AlnScreenerResponseDto): Array<ChallengeResponseDto> =>
-  alnScreener?.challenges.filter(challenge => challenge.active && challenge.fromALNScreener) ?? []
+/**
+ * Returns an array of ALN Challenge Response DTO from the specified ALN Screener Response DTO, where the challenge's active
+ * flag is set according to the method argument.
+ */
+const getChallengesFromAlnScreener = (
+  alnScreener: AlnScreenerResponseDto,
+  active: boolean,
+): Array<ChallengeResponseDto> =>
+  alnScreener?.challenges.filter(challenge => challenge.active === active && challenge.fromALNScreener) ?? []
 
 export {
   getLatestAlnScreener,
-  getNonAlnActiveStrengths,
-  getActiveStrengthsFromAlnScreener,
-  getNonAlnActiveChallenges,
-  getActiveChallengesFromAlnScreener,
+  getNonAlnStrengths,
+  getStrengthsFromAlnScreener,
+  getNonAlnChallenges,
+  getChallengesFromAlnScreener,
 }

--- a/server/views/pages/profile/overview/_challengesSummaryCard.njk
+++ b/server/views/pages/profile/overview/_challengesSummaryCard.njk
@@ -1,12 +1,15 @@
-{% if challengeCategories.isFulfilled() %}
-  {% set categories = challengeCategories.value %}
+{% set categories = [] %}
+{% if groupedChallenges.isFulfilled() %}
+  {% for category, challenges in groupedChallenges.value %}
+    {% set categories = (categories.push(category), categories) %}
+  {% endfor %}
 {% endif %}
 
 <div class="govuk-summary-card" data-qa="challenges-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Challenges</h2>
     <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-      {% if categories %}
+      {% if groupedChallenges.isFulfilled() %}
         {% if categories.length === 0 %}
           {% if userHasPermissionTo('RECORD_CHALLENGES') %}
             <li class="govuk-summary-card__action">
@@ -22,7 +25,7 @@
     </ul>
   </div>
   <div class="govuk-summary-card__content">
-    {% if challengeCategories.isFulfilled() %}
+    {% if groupedChallenges.isFulfilled() %}
 
       {% if categories | length %}
         <ul class="govuk-list">

--- a/server/views/pages/profile/overview/_challengesSummaryCard.test.ts
+++ b/server/views/pages/profile/overview/_challengesSummaryCard.test.ts
@@ -1,9 +1,12 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
+import { startOfToday } from 'date-fns'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import { Result } from '../../../../utils/result/result'
 import formatChallengeCategoryScreenValueFilter from '../../../../filters/formatChallengeCategoryFilter'
 import ChallengeCategory from '../../../../enums/challengeCategory'
+import aValidChallengeResponseDto from '../../../../testsupport/challengeResponseDtoTestDataBuilder'
+import ChallengeType from '../../../../enums/challengeType'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -26,6 +29,7 @@ const template = '_challengesSummaryCard.njk'
 const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary,
+  groupedChallenges: Result.fulfilled({}),
   challengeCategories: Result.fulfilled([ChallengeCategory.LITERACY_SKILLS, ChallengeCategory.NUMERACY_SKILLS]),
   userHasPermissionTo,
 }
@@ -40,13 +44,69 @@ describe('_challengesSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      challengeCategories: Result.fulfilled([
-        ChallengeCategory.ATTENTION_ORGANISING_TIME,
-        ChallengeCategory.LITERACY_SKILLS,
-        ChallengeCategory.MEMORY,
-        ChallengeCategory.NUMERACY_SKILLS,
-        ChallengeCategory.SENSORY,
-      ]),
+      groupedChallenges: Result.fulfilled({
+        ATTENTION_ORGANISING_TIME: {
+          nonAlnChallenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.ATTENTION_ORGANISING_TIME_DEFAULT,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            challenges: [],
+          },
+        },
+        LITERACY_SKILLS: {
+          nonAlnChallenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.LITERACY_SKILLS_DEFAULT,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            challenges: [],
+          },
+        },
+        MEMORY: {
+          nonAlnChallenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.MEMORY,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            challenges: [],
+          },
+        },
+        NUMERACY_SKILLS: {
+          nonAlnChallenges: [],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            challenges: [
+              aValidChallengeResponseDto({
+                challengeTypeCode: ChallengeType.ARITHMETIC,
+                challengeCategory: ChallengeCategory.NUMERACY_SKILLS,
+              }),
+            ],
+          },
+        },
+        SENSORY: {
+          nonAlnChallenges: [],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            challenges: [
+              aValidChallengeResponseDto({
+                challengeTypeCode: ChallengeType.CREATIVITY,
+              }),
+            ],
+          },
+        },
+      }),
     }
 
     // When
@@ -75,7 +135,7 @@ describe('_challengesSummaryCard', () => {
 
     const params = {
       ...templateParams,
-      challengeCategories: Result.fulfilled([]),
+      groupedChallenges: Result.fulfilled({}),
     }
 
     // When
@@ -96,7 +156,7 @@ describe('_challengesSummaryCard', () => {
 
     const params = {
       ...templateParams,
-      challengeCategories: Result.fulfilled([]),
+      groupedChallenges: Result.fulfilled({}),
     }
 
     // When
@@ -114,7 +174,7 @@ describe('_challengesSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      challengeCategories: Result.rejected(new Error('Failed to get challenges')),
+      groupedChallenges: Result.rejected(new Error('Failed to get challenges')),
     }
 
     // When

--- a/server/views/pages/profile/overview/_strengthsSummaryCard.njk
+++ b/server/views/pages/profile/overview/_strengthsSummaryCard.njk
@@ -1,12 +1,15 @@
-{% if strengthCategories.isFulfilled() %}
-  {% set categories = strengthCategories.value %}
+{% set categories = [] %}
+{% if groupedStrengths.isFulfilled() %}
+  {% for category, strengths in groupedStrengths.value %}
+    {% set categories = (categories.push(category), categories) %}
+  {% endfor %}
 {% endif %}
 
 <div class="govuk-summary-card" data-qa="strengths-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Strengths</h2>
     <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-      {% if strengthCategories.isFulfilled() %}
+      {% if groupedStrengths.isFulfilled() %}
         {% if categories.length === 0 %}
           {% if userHasPermissionTo('RECORD_STRENGTHS') %}
             <li class="govuk-summary-card__action">
@@ -23,7 +26,7 @@
   </div>
 
   <div class="govuk-summary-card__content">
-    {% if strengthCategories.isFulfilled() %}
+    {% if groupedStrengths.isFulfilled() %}
 
       {% if categories | length %}
         <ul class="govuk-list">

--- a/server/views/pages/profile/overview/_strengthsSummaryCard.test.ts
+++ b/server/views/pages/profile/overview/_strengthsSummaryCard.test.ts
@@ -1,9 +1,12 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
+import { startOfToday } from 'date-fns'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import { Result } from '../../../../utils/result/result'
 import formatStrengthCategoryScreenValueFilter from '../../../../filters/formatStrengthCategoryFilter'
 import StrengthCategory from '../../../../enums/strengthCategory'
+import { aValidStrengthResponseDto } from '../../../../testsupport/strengthResponseDtoTestDataBuilder'
+import StrengthType from '../../../../enums/strengthType'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -26,7 +29,7 @@ const template = '_strengthsSummaryCard.njk'
 const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary,
-  strengthCategories: Result.fulfilled([StrengthCategory.LITERACY_SKILLS, StrengthCategory.NUMERACY_SKILLS]),
+  groupedStrengths: Result.fulfilled({}),
   userHasPermissionTo,
 }
 
@@ -40,13 +43,69 @@ describe('_strengthsSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      strengthCategories: Result.fulfilled([
-        StrengthCategory.ATTENTION_ORGANISING_TIME,
-        StrengthCategory.LITERACY_SKILLS,
-        StrengthCategory.MEMORY,
-        StrengthCategory.NUMERACY_SKILLS,
-        StrengthCategory.SENSORY,
-      ]),
+      groupedStrengths: Result.fulfilled({
+        ATTENTION_ORGANISING_TIME: {
+          nonAlnStrengths: [
+            aValidStrengthResponseDto({
+              strengthTypeCode: StrengthType.ATTENTION_ORGANISING_TIME_DEFAULT,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            strengths: [],
+          },
+        },
+        LITERACY_SKILLS: {
+          nonAlnStrengths: [
+            aValidStrengthResponseDto({
+              strengthTypeCode: StrengthType.LITERACY_SKILLS_DEFAULT,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            strengths: [],
+          },
+        },
+        MEMORY: {
+          nonAlnStrengths: [
+            aValidStrengthResponseDto({
+              strengthTypeCode: StrengthType.MEMORY,
+            }),
+          ],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            strengths: [],
+          },
+        },
+        NUMERACY_SKILLS: {
+          nonAlnStrengths: [],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            strengths: [
+              aValidStrengthResponseDto({
+                strengthTypeCode: StrengthType.ARITHMETIC,
+                strengthCategory: StrengthCategory.NUMERACY_SKILLS,
+              }),
+            ],
+          },
+        },
+        SENSORY: {
+          nonAlnStrengths: [],
+          latestAlnScreener: {
+            screenerDate: startOfToday(),
+            createdAtPrison: 'BXI',
+            strengths: [
+              aValidStrengthResponseDto({
+                strengthTypeCode: StrengthType.CREATIVITY,
+              }),
+            ],
+          },
+        },
+      }),
     }
 
     // When
@@ -75,7 +134,7 @@ describe('_strengthsSummaryCard', () => {
 
     const params = {
       ...templateParams,
-      strengthCategories: Result.fulfilled([]),
+      groupedStrengths: Result.fulfilled({}),
     }
 
     // When
@@ -96,7 +155,7 @@ describe('_strengthsSummaryCard', () => {
 
     const params = {
       ...templateParams,
-      strengthCategories: Result.fulfilled([]),
+      groupedStrengths: Result.fulfilled({}),
     }
 
     // When
@@ -114,7 +173,7 @@ describe('_strengthsSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      strengthCategories: Result.rejected(new Error('Failed to get strengths')),
+      groupedStrengths: Result.rejected(new Error('Failed to get strengths')),
     }
 
     // When

--- a/server/views/pages/profile/overview/index.test.ts
+++ b/server/views/pages/profile/overview/index.test.ts
@@ -1,6 +1,6 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
-import { parseISO } from 'date-fns'
+import { parseISO, startOfToday } from 'date-fns'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import formatDate from '../../../../filters/formatDateFilter'
 import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
@@ -8,9 +8,7 @@ import { Result } from '../../../../utils/result/result'
 import { aValidConditionsList } from '../../../../testsupport/conditionDtoTestDataBuilder'
 import filterArrayOnPropertyFilter from '../../../../filters/filterArrayOnPropertyFilter'
 import formatConditionTypeScreenValueFilter from '../../../../filters/formatConditionTypeFilter'
-import StrengthCategory from '../../../../enums/strengthCategory'
 import formatStrengthCategoryScreenValueFilter from '../../../../filters/formatStrengthCategoryFilter'
-import ChallengeCategory from '../../../../enums/challengeCategory'
 import formatChallengeCategoryScreenValueFilter from '../../../../filters/formatChallengeCategoryFilter'
 import { aCuriousAlnAndLddAssessmentsDto } from '../../../../testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder'
 import formatAlnAssessmentReferralScreenValueFilter from '../../../../filters/formatAlnAssessmentReferralFilter'
@@ -18,6 +16,8 @@ import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatus
 import { formatSupportStrategyTypeScreenValueFilter } from '../../../../filters/formatSupportStrategyTypeFilter'
 import aValidSupportStrategyResponseDto from '../../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
 import SupportStrategyType from '../../../../enums/supportStrategyType'
+import { aValidStrengthResponseDto } from '../../../../testsupport/strengthResponseDtoTestDataBuilder'
+import StrengthType from '../../../../enums/strengthType'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -60,6 +60,36 @@ const groupedSupportStrategies = Result.fulfilled([
   }),
 ])
 
+const groupedStrengths = Result.fulfilled({
+  ATTENTION_ORGANISING_TIME: {
+    nonAlnStrengths: [
+      aValidStrengthResponseDto({
+        strengthTypeCode: StrengthType.ATTENTION_ORGANISING_TIME_DEFAULT,
+      }),
+    ],
+    latestAlnScreener: {
+      screenerDate: startOfToday(),
+      createdAtPrison: 'BXI',
+      strengths: [],
+    },
+  },
+})
+
+const groupedChallenges = Result.fulfilled({
+  LITERACY_SKILLS: {
+    nonAlnChallenges: [
+      aValidStrengthResponseDto({
+        strengthTypeCode: StrengthType.LITERACY_SKILLS_DEFAULT,
+      }),
+    ],
+    latestAlnScreener: {
+      screenerDate: startOfToday(),
+      createdAtPrison: 'BXI',
+      challenges: [],
+    },
+  },
+})
+
 const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary,
@@ -67,8 +97,8 @@ const templateParams = {
   educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
   conditions: Result.fulfilled(aValidConditionsList()),
   groupedSupportStrategies,
-  strengthCategories: Result.fulfilled([StrengthCategory.LITERACY_SKILLS, StrengthCategory.NUMERACY_SKILLS]),
-  challengeCategories: Result.fulfilled([ChallengeCategory.LITERACY_SKILLS, ChallengeCategory.NUMERACY_SKILLS]),
+  groupedStrengths,
+  groupedChallenges,
   curiousAlnAndLddAssessments: Result.fulfilled(aCuriousAlnAndLddAssessmentsDto()),
   prisonNamesById: Result.fulfilled(prisonNamesById),
   pageHasApiErrors: false,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -10,6 +10,7 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "moj/components/banner/macro.njk" import mojBanner %}


### PR DESCRIPTION
Initial refactoring of grouped strength and challenge mappers to better support displaying active and archived

This PR refactors the grouped strength and challenge mappers so that they can be used to differentiate and group "active" and "archived" (non-active / in history) strengths and challenges - ie. for these designs where we have a tabbed interface for "active" and "history":
<img width="763" height="993" alt="image" src="https://github.com/user-attachments/assets/75917614-26fc-48d6-8dc2-60e293fdba30" />

This PR does not implement the tabbed interface yet, nor does it get the archived/history strengths/challenges yet - it is in the initial refactoring to support this.


