### PR TITLE
RR-2011 - Screen, validator and service call for archiving a strength

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -147,6 +147,7 @@ declare module 'dto' {
     symptoms?: string
     howIdentified?: Array<StrengthIdentificationSource>
     howIdentifiedOther?: string
+    archiveReason?: string
   }
 
   export interface StrengthsList {
@@ -167,6 +168,7 @@ declare module 'dto' {
     active: boolean
     fromALNScreener: boolean
     alnScreenerDate?: Date
+    archiveReason?: string
   }
 
   /**

--- a/server/data/mappers/archiveStrengthRequestMapper.test.ts
+++ b/server/data/mappers/archiveStrengthRequestMapper.test.ts
@@ -1,0 +1,33 @@
+import aValidStrengthDto from '../../testsupport/strengthDtoTestDataBuilder'
+import StrengthType from '../../enums/strengthType'
+import StrengthIdentificationSource from '../../enums/strengthIdentificationSource'
+import anArchiveStrengthRequest from '../../testsupport/archiveStrengthRequestTestDataBuilder'
+import toArchiveStrengthRequest from './archiveStrengthRequestMapper'
+
+describe('archiveStrengthRequestMapper', () => {
+  describe('toArchiveStrengthRequest', () => {
+    it('should map a StrengthDto to an ArchiveStrengthRequest', () => {
+      // Given
+      const strengthDto = aValidStrengthDto({
+        prisonNumber: 'A1234BC',
+        prisonId: 'BXI',
+        strengthTypeCode: StrengthType.READING_COMPREHENSION,
+        symptoms: 'John can read and understand written language very well',
+        howIdentified: [StrengthIdentificationSource.WIDER_PRISON, StrengthIdentificationSource.OTHER],
+        howIdentifiedOther: `John's reading strength was discovered during a poetry recital evening`,
+        archiveReason: 'The strength was created in error',
+      })
+
+      const expectedArchiveStrengthRequest = anArchiveStrengthRequest({
+        prisonId: 'BXI',
+        reason: 'The strength was created in error',
+      })
+
+      // When
+      const actual = toArchiveStrengthRequest(strengthDto)
+
+      // Then
+      expect(actual).toEqual(expectedArchiveStrengthRequest)
+    })
+  })
+})

--- a/server/data/mappers/archiveStrengthRequestMapper.ts
+++ b/server/data/mappers/archiveStrengthRequestMapper.ts
@@ -1,0 +1,9 @@
+import type { ArchiveStrengthRequest } from 'supportAdditionalNeedsApiClient'
+import type { StrengthDto } from 'dto'
+
+const toArchiveStrengthRequest = (strength: StrengthDto): ArchiveStrengthRequest => ({
+  prisonId: strength.prisonId,
+  archiveReason: strength.archiveReason,
+})
+
+export default toArchiveStrengthRequest

--- a/server/data/mappers/strengthDtoMapper.test.ts
+++ b/server/data/mappers/strengthDtoMapper.test.ts
@@ -99,13 +99,14 @@ describe('toStrengthDto', () => {
           updatedAt: '2025-07-26T12:00:00.000Z',
           updatedBy: 'user2',
           updatedByDisplayName: 'Dave Davidson 2',
-          active: true,
+          active: false,
           fromALNScreener: true,
           howIdentified: ['WIDER_PRISON'],
           howIdentifiedOther: '',
           symptoms: 'Some varying symptoms',
           updatedAtPrison: 'BXI',
           alnScreenerDate: '2025-07-23T12:00:00.000Z',
+          archiveReason: 'Created in error',
         },
       ],
     }
@@ -144,7 +145,7 @@ describe('toStrengthDto', () => {
       updatedAtPrison: 'BXI',
       reference: testRef2,
       fromALNScreener: true,
-      active: true,
+      active: false,
       createdByDisplayName: 'Bob Martin 2',
       updatedByDisplayName: 'Dave Davidson 2',
       howIdentified: ['WIDER_PRISON'],
@@ -152,6 +153,7 @@ describe('toStrengthDto', () => {
       symptoms: 'Some varying symptoms',
       alnScreenerDate: parseISO('2025-07-23T12:00:00.000Z'),
       strengthTypeCode: 'TYPE001',
+      archiveReason: 'Created in error',
     })
   })
 

--- a/server/data/mappers/strengthDtoMapper.ts
+++ b/server/data/mappers/strengthDtoMapper.ts
@@ -22,6 +22,7 @@ const toStrengthResponseDto = (prisonNumber: string, strength: StrengthResponse)
         active: strength.active,
         howIdentifiedOther: strength.howIdentifiedOther,
         alnScreenerDate: strength.alnScreenerDate ? parseISO(strength.alnScreenerDate) : null,
+        archiveReason: strength.archiveReason,
       }
     : null
 }

--- a/server/routes/strengths/archive/reason/reasonController.test.ts
+++ b/server/routes/strengths/archive/reason/reasonController.test.ts
@@ -1,0 +1,154 @@
+import { Request, Response } from 'express'
+import ReasonController from './reasonController'
+import StrengthService from '../../../../services/strengthService'
+import AuditService from '../../../../services/auditService'
+import { aValidStrengthResponseDto } from '../../../../testsupport/strengthResponseDtoTestDataBuilder'
+
+jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/strengthService')
+
+describe('reasonController', () => {
+  const strengthService = new StrengthService(null) as jest.Mocked<StrengthService>
+  const auditService = new AuditService(null) as jest.Mocked<AuditService>
+  const controller = new ReasonController(strengthService, auditService)
+
+  const username = 'A_DPS_USER'
+  const prisonNumber = 'A1234BC'
+  const strengthReference = '518d65dc-2866-46a7-94c0-ffb331e66061'
+  const strengthDto = aValidStrengthResponseDto({
+    reference: strengthReference,
+    archiveReason: null,
+  })
+
+  const flash = jest.fn()
+  const req = {
+    session: {},
+    user: { username },
+    journeyData: {},
+    body: {},
+    params: { prisonNumber },
+    flash,
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+    redirectWithSuccess: jest.fn(),
+    render: jest.fn(),
+    locals: { user: { username, activeCaseLoadId: 'BXI' } },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.body = {}
+    req.journeyData = { strengthDto }
+  })
+
+  it('should render the view when there is no previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    res.locals.invalidForm = undefined
+
+    const expectedViewTemplate = 'pages/strengths/reason/archive-journey/index'
+    const expectedViewModel = {
+      dto: strengthDto,
+      errorRecordingStrength: false,
+      form: { archiveReason: '' },
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should render view given previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    const invalidForm = {
+      archiveReason: ['not-a-valid-value'],
+    }
+    res.locals.invalidForm = invalidForm
+
+    const expectedViewTemplate = 'pages/strengths/reason/archive-journey/index'
+    const expectedViewModel = {
+      dto: strengthDto,
+      errorRecordingStrength: false,
+      form: invalidForm,
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should submit form and redirect to next route given calling API is successful', async () => {
+    // Given
+    const strengthResponseDto = aValidStrengthResponseDto({ prisonNumber, reference: strengthReference })
+    req.journeyData = { strengthDto: strengthResponseDto }
+    req.body = {
+      archiveReason: 'Strength is not relevant and was recorded in error',
+    }
+    strengthService.archiveStrength.mockResolvedValue(null)
+
+    const expectedStrengthDto = {
+      ...strengthResponseDto,
+      prisonId: 'BXI',
+      archiveReason: 'Strength is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = `/profile/${prisonNumber}/strengths#archived-strengths`
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength moved to History')
+    expect(req.journeyData.strengthDto).toBeUndefined()
+    expect(flash).not.toHaveBeenCalled()
+    expect(strengthService.archiveStrength).toHaveBeenCalledWith(username, strengthReference, expectedStrengthDto)
+    expect(auditService.logArchiveStrength).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: {
+          strengthReference,
+        },
+        subjectId: prisonNumber,
+        subjectType: 'PRISONER_ID',
+        who: username,
+      }),
+    )
+  })
+
+  it('should submit form and redirect to next route given calling API is not successful', async () => {
+    // Given
+    const strengthResponseDto = aValidStrengthResponseDto({ prisonNumber, reference: strengthReference })
+    req.journeyData = { strengthDto: strengthResponseDto }
+    req.body = {
+      archiveReason: 'Strength is not relevant and was recorded in error',
+    }
+
+    strengthService.archiveStrength.mockRejectedValue(new Error('Internal Server Error'))
+
+    const expectedStrengthDto = {
+      ...strengthResponseDto,
+      prisonId: 'BXI',
+      archiveReason: 'Strength is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = 'reason'
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
+    expect(req.journeyData.strengthDto).toEqual(strengthResponseDto)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
+    expect(strengthService.archiveStrength).toHaveBeenCalledWith(username, strengthReference, expectedStrengthDto)
+    expect(auditService.logArchiveStrength).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/strengths/archive/reason/reasonController.ts
+++ b/server/routes/strengths/archive/reason/reasonController.ts
@@ -1,0 +1,73 @@
+import { NextFunction, Request, Response } from 'express'
+import type { StrengthResponseDto } from 'dto'
+import { AuditService, StrengthService } from '../../../../services'
+import { BaseAuditData } from '../../../../services/auditService'
+import { Result } from '../../../../utils/result/result'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+export default class ReasonController {
+  constructor(
+    private readonly strengthService: StrengthService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  getReasonView = async (req: Request, res: Response, next: NextFunction) => {
+    const { invalidForm } = res.locals
+    const strengthResponseDto = req.journeyData.strengthDto as StrengthResponseDto
+
+    const reasonForm = invalidForm ?? { archiveReason: '' }
+
+    const viewRenderArgs = {
+      mode: 'archive',
+      dto: strengthResponseDto,
+      form: reasonForm,
+      errorRecordingStrength: req.flash('pageHasApiErrors')[0] != null,
+    }
+
+    return res.render('pages/strengths/reason/archive-journey/index', viewRenderArgs)
+  }
+
+  submitReasonForm = async (req: Request, res: Response, next: NextFunction) => {
+    const reasonForm = { ...req.body }
+    this.updateDtoFromForm(req, reasonForm)
+
+    const { activeCaseLoadId, username } = res.locals.user as PrisonUser
+
+    const strengthResponseDto = req.journeyData.strengthDto as StrengthResponseDto
+    const { reference } = strengthResponseDto
+    const strengthDto = { ...strengthResponseDto, prisonId: activeCaseLoadId }
+
+    const { apiErrorCallback } = res.locals
+    const apiResult = await Result.wrap(
+      this.strengthService.archiveStrength(username, reference, strengthDto),
+      apiErrorCallback,
+    )
+    if (!apiResult.isFulfilled()) {
+      req.flash('pageHasApiErrors', 'true')
+      return res.redirect('reason')
+    }
+
+    const { prisonNumber } = strengthResponseDto
+    req.journeyData.strengthDto = undefined
+    this.auditService.logArchiveStrength(this.archiveStrengthAuditData(req, strengthResponseDto)) // no need to wait for response
+    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths#archived-strengths`, 'Strength moved to History')
+  }
+
+  private updateDtoFromForm = (req: Request, form: { archiveReason: string }) => {
+    const { strengthDto } = req.journeyData
+    strengthDto.archiveReason = form.archiveReason
+    req.journeyData.strengthDto = strengthDto
+  }
+
+  private archiveStrengthAuditData = (req: Request, strengthDto: StrengthResponseDto): BaseAuditData => {
+    return {
+      details: {
+        strengthReference: strengthDto.reference,
+      },
+      subjectType: 'PRISONER_ID',
+      subjectId: req.params.prisonNumber,
+      who: req.user?.username ?? 'UNKNOWN',
+      correlationId: req.id,
+    }
+  }
+}

--- a/server/routes/strengths/validationSchemas/archiveReasonSchema.test.ts
+++ b/server/routes/strengths/validationSchemas/archiveReasonSchema.test.ts
@@ -1,0 +1,98 @@
+import { Request, Response } from 'express'
+import type { Error } from '../../../filters/findErrorFilter'
+import { validate } from '../../../middleware/validationMiddleware'
+import archiveReasonSchema from './archiveReasonSchema'
+
+describe('archiveReasonSchema', () => {
+  const req = {
+    originalUrl: '',
+    body: {},
+    flash: jest.fn(),
+  } as unknown as Request
+  const res = {
+    redirectWithErrors: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.originalUrl =
+      '/strengths/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason'
+  })
+
+  it('happy path - validation passes', async () => {
+    // Given
+    const requestBody = { archiveReason: 'This strength was incorrectly added by mistake' }
+    req.body = requestBody
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).toHaveBeenCalled()
+    expect(req.flash).not.toHaveBeenCalled()
+    expect(res.redirectWithErrors).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    //
+    null,
+    undefined,
+    '',
+    ' ',
+    `
+
+    `,
+  ])('sad path - archiveReason field validation fails - %s', async archiveReason => {
+    // Given
+    const requestBody = { archiveReason }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Add reason for moving this strength to the History',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/strengths/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+
+  it('sad path - archiveReason field length validation fails', async () => {
+    // Given
+    const requestBody = { archiveReason: 'a'.repeat(4001) }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Reason for moving this strength to the History must be 4000 characters or less',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/strengths/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+})

--- a/server/routes/strengths/validationSchemas/archiveReasonSchema.ts
+++ b/server/routes/strengths/validationSchemas/archiveReasonSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+import { createSchema } from '../../../middleware/validationMiddleware'
+
+const archiveReasonSchema = async () => {
+  const ARCHIVE_REASON_MAX_LENGTH = 4000
+
+  const archiveReasonMandatoryMessage = 'Add reason for moving this strength to the History'
+  const archiveReasonMaxLengthMessage = `Reason for moving this strength to the History must be ${ARCHIVE_REASON_MAX_LENGTH} characters or less`
+
+  return createSchema({
+    archiveReason: z //
+      .string({ message: archiveReasonMandatoryMessage })
+      .trim()
+      .min(1, archiveReasonMandatoryMessage)
+      .max(ARCHIVE_REASON_MAX_LENGTH, archiveReasonMaxLengthMessage),
+  })
+}
+
+export default archiveReasonSchema

--- a/server/services/strengthService.test.ts
+++ b/server/services/strengthService.test.ts
@@ -10,6 +10,7 @@ import aValidStrengthDto from '../testsupport/strengthDtoTestDataBuilder'
 import StrengthType from '../enums/strengthType'
 import StrengthIdentificationSource from '../enums/strengthIdentificationSource'
 import anUpdateStrengthRequest from '../testsupport/updateStrengthRequestTestDataBuilder'
+import anArchiveStrengthRequest from '../testsupport/archiveStrengthRequestTestDataBuilder'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
 
@@ -269,6 +270,64 @@ describe('strengthService', () => {
         strengthReference,
         username,
         expectedUpdateStrengthRequest,
+      )
+    })
+  })
+
+  describe('archiveStrength', () => {
+    it('should archive strength', async () => {
+      // Given
+      supportAdditionalNeedsApiClient.archiveStrength.mockResolvedValue(null)
+
+      const strengthDto = aValidStrengthDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Strength created in error',
+      })
+
+      const expectedArchiveStrengthRequest = anArchiveStrengthRequest({
+        prisonId: 'BXI',
+        reason: 'Strength created in error',
+      })
+
+      // When
+      await service.archiveStrength(username, strengthReference, strengthDto)
+
+      // Then
+      expect(supportAdditionalNeedsApiClient.archiveStrength).toHaveBeenCalledWith(
+        prisonNumber,
+        strengthReference,
+        username,
+        expectedArchiveStrengthRequest,
+      )
+    })
+
+    it('should rethrow error given API client throws error', async () => {
+      // Given
+      const expectedError = new Error('Internal Server Error')
+      supportAdditionalNeedsApiClient.archiveStrength.mockRejectedValue(expectedError)
+
+      const strengthDto = aValidStrengthDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Strength created in error',
+      })
+
+      const expectedArchiveStrengthRequest = anArchiveStrengthRequest({
+        prisonId: 'BXI',
+        reason: 'Strength created in error',
+      })
+
+      // When
+      const actual = await service.archiveStrength(username, strengthReference, strengthDto).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(supportAdditionalNeedsApiClient.archiveStrength).toHaveBeenCalledWith(
+        prisonNumber,
+        strengthReference,
+        username,
+        expectedArchiveStrengthRequest,
       )
     })
   })

--- a/server/services/strengthService.ts
+++ b/server/services/strengthService.ts
@@ -5,6 +5,7 @@ import logger from '../../logger'
 import { toStrengthsList } from '../data/mappers/strengthResponseDtoMapper'
 import { toStrengthResponseDto } from '../data/mappers/strengthDtoMapper'
 import toUpdateStrengthRequest from '../data/mappers/updateStrengthRequestMapper'
+import toArchiveStrengthRequest from '../data/mappers/archiveStrengthRequestMapper'
 
 export default class StrengthService {
   constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
@@ -57,6 +58,22 @@ export default class StrengthService {
       )
     } catch (e) {
       logger.error(`Error updating Strength for [${prisonNumber}]`, e)
+      throw e
+    }
+  }
+
+  async archiveStrength(username: string, strengthReference: string, strength: StrengthDto): Promise<void> {
+    const { prisonNumber } = strength
+    try {
+      const archiveStrengthRequest = toArchiveStrengthRequest(strength)
+      await this.supportAdditionalNeedsApiClient.archiveStrength(
+        prisonNumber,
+        strengthReference,
+        username,
+        archiveStrengthRequest,
+      )
+    } catch (e) {
+      logger.error(`Error archiving Strength for [${prisonNumber}]`, e)
       throw e
     }
   }

--- a/server/testsupport/strengthDtoTestDataBuilder.ts
+++ b/server/testsupport/strengthDtoTestDataBuilder.ts
@@ -9,6 +9,7 @@ const aValidStrengthDto = (options?: {
   symptoms?: string
   howIdentified?: Array<StrengthIdentificationSource>
   howIdentifiedOther?: string
+  archiveReason?: string
 }): StrengthDto => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
   prisonId: options?.prisonId || 'BXI',
@@ -20,6 +21,7 @@ const aValidStrengthDto = (options?: {
     options?.howIdentifiedOther === null
       ? null
       : options?.howIdentifiedOther || `John's reading strength was discovered during a poetry recital evening`,
+  archiveReason: options?.archiveReason,
 })
 
 export default aValidStrengthDto

--- a/server/testsupport/strengthResponseDtoTestDataBuilder.ts
+++ b/server/testsupport/strengthResponseDtoTestDataBuilder.ts
@@ -23,6 +23,7 @@ const aValidStrengthResponseDto = (
     active?: boolean
     fromALNScreener?: boolean
     alnScreenerDate?: Date
+    archiveReason?: string
   },
 ): StrengthResponseDto => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
@@ -38,6 +39,7 @@ const aValidStrengthResponseDto = (
   active: options?.active == null ? true : options?.active,
   fromALNScreener: options?.fromALNScreener == null ? true : options?.fromALNScreener,
   alnScreenerDate: options?.alnScreenerDate === null ? null : options?.alnScreenerDate,
+  archiveReason: options?.archiveReason,
   ...validDtoAuditFields(options),
 })
 

--- a/server/views/pages/profile/overview/_supportStrategiesSummaryCard.njk
+++ b/server/views/pages/profile/overview/_supportStrategiesSummaryCard.njk
@@ -30,9 +30,7 @@
           <div class="govuk-summary-list__row" data-qa="support-strategy-summary-list-row">
             <h3 class="govuk-heading-s govuk-!-margin-top-3"> {{ groupName | formatSupportStrategyTypeScreenValue }} </h3>
             {% for supportStrategy in supportStrategyData %}
-              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text"
-                 data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
-              </p>
+              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}</p>
             {% endfor %}
           </div>
         {% endfor %}

--- a/server/views/pages/strengths/layout.njk
+++ b/server/views/pages/strengths/layout.njk
@@ -14,5 +14,7 @@
     </div>
   {% endif %}
 
-  <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} strength</p>
+  {% if not mode == 'archive' %}
+    <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} strength</p>
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/strengths/reason/archive-journey/index.njk
+++ b/server/views/pages/strengths/reason/archive-journey/index.njk
@@ -1,0 +1,64 @@
+{% extends "../../layout.njk" %}
+
+{% set pageId = 'archive-strength-reason' %}
+{% set pageTitle = "Move strength to history - Move strength to history reason" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Move {{ prisonerSummary | formatFirst_name_Last_name }}'s strength to the History</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-hint">Strengths in the History tab are view only and cannot be reactivated.</p>
+
+      {% set insetContent %}
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">{{ dto.strengthCategory | formatStrengthCategoryScreenValue | default(dto.strengthCategory, true) }}</h3>
+        <p class="govuk-body app-u-multiline-text">{{ dto.symptoms }}</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">How was this strength identified?</h2>
+        <ul class="govuk-list">
+          {% for strengthIdentificationSource in dto.howIdentified %}
+            <li>{{ strengthIdentificationSource | formatStrengthIdentificationSourceScreenValue if strengthIdentificationSource != 'OTHER' else dto.howIdentifiedOther }}</li>
+          {% endfor %}
+        </ul>
+      {% endset %}
+      {{ govukInsetText({
+        html: insetContent
+      }) }}
+
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ govukTextarea({
+            id: "archiveReason",
+            name: "archiveReason",
+            rows: "4",
+            value: form.archiveReason,
+            type: "text",
+            label: {
+              text: "Add a reason for moving this strength to the History",
+              classes: "govuk-label--s",
+              attributes: { "aria-live": "polite" }
+            },
+            attributes: { "aria-label" : "Give details of the archive reason" },
+            errorMessage: errors | findError("archiveReason")
+          }) }}
+
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Move strength",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
PR to add the screen journey, validator, and service call to archive a strength.

As shown in the screen capture, this PR **does not** include rendering the archived strengths on the History tab, but it does update the count. Rendering the archived strengths on the history tab will come in one of my next PRs, as will cypress tests (also missing from this PR)

https://github.com/user-attachments/assets/3a51d86e-6dbe-4076-9e12-f845f03ef746



