### PR TITLE
RR-2010 - Screen, validator and service call for archiving a challenge

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -105,6 +105,7 @@ declare module 'dto' {
     symptoms?: string
     howIdentified?: Array<ChallengeIdentificationSource>
     howIdentifiedOther?: string
+    archiveReason?: string
   }
 
   /**
@@ -120,6 +121,7 @@ declare module 'dto' {
     howIdentified?: Array<ChallengeIdentificationSource>
     howIdentifiedOther?: string
     alnScreenerDate?: Date
+    archiveReason?: string
   }
 
   export interface ConditionsList {

--- a/server/data/mappers/archiveChallengeRequestMapper.test.ts
+++ b/server/data/mappers/archiveChallengeRequestMapper.test.ts
@@ -1,0 +1,33 @@
+import aValidChallengeDto from '../../testsupport/challengeDtoTestDataBuilder'
+import ChallengeType from '../../enums/challengeType'
+import ChallengeIdentificationSource from '../../enums/challengeIdentificationSource'
+import anArchiveChallengeRequest from '../../testsupport/archiveChallengeRequestTestDataBuilder'
+import toArchiveChallengeRequest from './archiveChallengeRequestMapper'
+
+describe('archiveChallengeRequestMapper', () => {
+  describe('toArchiveChallengeRequest', () => {
+    it('should map a ChallengeDto to an ArchiveChallengeRequest', () => {
+      // Given
+      const challengeDto = aValidChallengeDto({
+        prisonNumber: 'A1234BC',
+        prisonId: 'BXI',
+        challengeTypeCode: ChallengeType.READING_COMPREHENSION,
+        symptoms: 'John can not read and understand written language very well',
+        howIdentified: [ChallengeIdentificationSource.WIDER_PRISON, ChallengeIdentificationSource.OTHER],
+        howIdentifiedOther: `John's reading challenge was discovered during a poetry recital evening`,
+        archiveReason: 'The challenge was created in error',
+      })
+
+      const expectedArchiveChallengeRequest = anArchiveChallengeRequest({
+        prisonId: 'BXI',
+        reason: 'The challenge was created in error',
+      })
+
+      // When
+      const actual = toArchiveChallengeRequest(challengeDto)
+
+      // Then
+      expect(actual).toEqual(expectedArchiveChallengeRequest)
+    })
+  })
+})

--- a/server/data/mappers/archiveChallengeRequestMapper.ts
+++ b/server/data/mappers/archiveChallengeRequestMapper.ts
@@ -1,0 +1,9 @@
+import type { ArchiveChallengeRequest } from 'supportAdditionalNeedsApiClient'
+import type { ChallengeDto } from 'dto'
+
+const toArchiveChallengeRequest = (challenge: ChallengeDto): ArchiveChallengeRequest => ({
+  prisonId: challenge.prisonId,
+  archiveReason: challenge.archiveReason,
+})
+
+export default toArchiveChallengeRequest

--- a/server/data/mappers/challengeDtoMapper.test.ts
+++ b/server/data/mappers/challengeDtoMapper.test.ts
@@ -99,13 +99,14 @@ describe('toChallengeDto', () => {
           updatedAt: '2025-07-26T12:00:00.000Z',
           updatedBy: 'user2',
           updatedByDisplayName: 'Dave Davidson 2',
-          active: true,
+          active: false,
           fromALNScreener: true,
           howIdentified: ['WIDER_PRISON'],
           howIdentifiedOther: '',
           symptoms: 'Some varying symptoms',
           updatedAtPrison: 'BXI',
           alnScreenerDate: '2025-07-23T12:00:00.000Z',
+          archiveReason: 'Created in error',
         },
       ],
     }
@@ -144,7 +145,7 @@ describe('toChallengeDto', () => {
       updatedAtPrison: 'BXI',
       reference: testRef2,
       fromALNScreener: true,
-      active: true,
+      active: false,
       createdByDisplayName: 'Bob Martin 2',
       updatedByDisplayName: 'Dave Davidson 2',
       howIdentified: ['WIDER_PRISON'],
@@ -152,6 +153,7 @@ describe('toChallengeDto', () => {
       symptoms: 'Some varying symptoms',
       alnScreenerDate: parseISO('2025-07-23T12:00:00.000Z'),
       challengeTypeCode: 'TYPE001',
+      archiveReason: 'Created in error',
     })
   })
 

--- a/server/data/mappers/challengeDtoMapper.ts
+++ b/server/data/mappers/challengeDtoMapper.ts
@@ -22,6 +22,7 @@ const toChallengeResponseDto = (prisonNumber: string, challenge: ChallengeRespon
         active: challenge.active,
         howIdentifiedOther: challenge.howIdentifiedOther,
         alnScreenerDate: challenge.alnScreenerDate ? parseISO(challenge.alnScreenerDate) : null,
+        archiveReason: challenge.archiveReason,
       }
     : null
 }

--- a/server/routes/challenges/archive/reason/reasonController.test.ts
+++ b/server/routes/challenges/archive/reason/reasonController.test.ts
@@ -1,0 +1,167 @@
+import { Request, Response } from 'express'
+import ReasonController from './reasonController'
+import ChallengeService from '../../../../services/challengeService'
+import AuditService from '../../../../services/auditService'
+import aValidChallengeResponseDto from '../../../../testsupport/challengeResponseDtoTestDataBuilder'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../../utils/result/result'
+
+jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/challengeService')
+
+describe('reasonController', () => {
+  const challengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
+  const auditService = new AuditService(null) as jest.Mocked<AuditService>
+  const controller = new ReasonController(challengeService, auditService)
+
+  const username = 'A_DPS_USER'
+  const prisonNumber = 'A1234BC'
+  const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
+  const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
+
+  const challengeReference = '518d65dc-2866-46a7-94c0-ffb331e66061'
+  const challengeDto = aValidChallengeResponseDto({
+    reference: challengeReference,
+    archiveReason: null,
+  })
+
+  const flash = jest.fn()
+  const req = {
+    session: {},
+    user: { username },
+    journeyData: {},
+    body: {},
+    params: { prisonNumber },
+    flash,
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+    redirectWithSuccess: jest.fn(),
+    render: jest.fn(),
+    locals: {
+      prisonerSummary,
+      prisonNamesById,
+      user: { username, activeCaseLoadId: 'BXI' },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.body = {}
+    req.journeyData = { challengeDto }
+  })
+
+  it('should render the view when there is no previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    res.locals.invalidForm = undefined
+
+    const expectedViewTemplate = 'pages/challenges/reason/archive-journey/index'
+    const expectedViewModel = {
+      prisonerSummary,
+      prisonNamesById,
+      dto: challengeDto,
+      errorRecordingChallenge: false,
+      form: { archiveReason: '' },
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should render view given previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    const invalidForm = {
+      archiveReason: ['not-a-valid-value'],
+    }
+    res.locals.invalidForm = invalidForm
+
+    const expectedViewTemplate = 'pages/challenges/reason/archive-journey/index'
+    const expectedViewModel = {
+      prisonerSummary,
+      prisonNamesById,
+      dto: challengeDto,
+      errorRecordingChallenge: false,
+      form: invalidForm,
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should submit form and redirect to next route given calling API is successful', async () => {
+    // Given
+    const challengeResponseDto = aValidChallengeResponseDto({ prisonNumber, reference: challengeReference })
+    req.journeyData = { challengeDto: challengeResponseDto }
+    req.body = {
+      archiveReason: 'Challenge is not relevant and was recorded in error',
+    }
+    challengeService.archiveChallenge.mockResolvedValue(null)
+
+    const expectedChallengeDto = {
+      ...challengeResponseDto,
+      prisonId: 'BXI',
+      archiveReason: 'Challenge is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = `/profile/${prisonNumber}/challenges#archived-challenges`
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Challenge moved to History')
+    expect(req.journeyData.challengeDto).toBeUndefined()
+    expect(flash).not.toHaveBeenCalled()
+    expect(challengeService.archiveChallenge).toHaveBeenCalledWith(username, challengeReference, expectedChallengeDto)
+    expect(auditService.logArchiveChallenge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: {
+          challengeReference,
+        },
+        subjectId: prisonNumber,
+        subjectType: 'PRISONER_ID',
+        who: username,
+      }),
+    )
+  })
+
+  it('should submit form and redirect to next route given calling API is not successful', async () => {
+    // Given
+    const challengeResponseDto = aValidChallengeResponseDto({ prisonNumber, reference: challengeReference })
+    req.journeyData = { challengeDto: challengeResponseDto }
+    req.body = {
+      archiveReason: 'Challenge is not relevant and was recorded in error',
+    }
+
+    challengeService.archiveChallenge.mockRejectedValue(new Error('Internal Server Error'))
+
+    const expectedChallengeDto = {
+      ...challengeResponseDto,
+      prisonId: 'BXI',
+      archiveReason: 'Challenge is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = 'reason'
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
+    expect(req.journeyData.challengeDto).toEqual(challengeResponseDto)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
+    expect(challengeService.archiveChallenge).toHaveBeenCalledWith(username, challengeReference, expectedChallengeDto)
+    expect(auditService.logArchiveChallenge).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/challenges/archive/reason/reasonController.ts
+++ b/server/routes/challenges/archive/reason/reasonController.ts
@@ -1,0 +1,78 @@
+import { NextFunction, Request, Response } from 'express'
+import type { ChallengeResponseDto } from 'dto'
+import { AuditService, ChallengeService } from '../../../../services'
+import { BaseAuditData } from '../../../../services/auditService'
+import { Result } from '../../../../utils/result/result'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+export default class ReasonController {
+  constructor(
+    private readonly challengeService: ChallengeService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  getReasonView = async (req: Request, res: Response, next: NextFunction) => {
+    const { invalidForm, prisonerSummary, prisonNamesById } = res.locals
+    const challengeResponseDto = req.journeyData.challengeDto as ChallengeResponseDto
+
+    const reasonForm = invalidForm ?? { archiveReason: '' }
+
+    const viewRenderArgs = {
+      prisonerSummary,
+      prisonNamesById,
+      mode: 'archive',
+      dto: challengeResponseDto,
+      form: reasonForm,
+      errorRecordingChallenge: req.flash('pageHasApiErrors')[0] != null,
+    }
+
+    return res.render('pages/challenges/reason/archive-journey/index', viewRenderArgs)
+  }
+
+  submitReasonForm = async (req: Request, res: Response, next: NextFunction) => {
+    const reasonForm = { ...req.body }
+    this.updateDtoFromForm(req, reasonForm)
+
+    const { activeCaseLoadId, username } = res.locals.user as PrisonUser
+
+    const challengeResponseDto = req.journeyData.challengeDto as ChallengeResponseDto
+    const { reference } = challengeResponseDto
+    const challengeDto = { ...challengeResponseDto, prisonId: activeCaseLoadId }
+
+    const { apiErrorCallback } = res.locals
+    const apiResult = await Result.wrap(
+      this.challengeService.archiveChallenge(username, reference, challengeDto),
+      apiErrorCallback,
+    )
+    if (!apiResult.isFulfilled()) {
+      req.flash('pageHasApiErrors', 'true')
+      return res.redirect('reason')
+    }
+
+    const { prisonNumber } = challengeResponseDto
+    req.journeyData.challengeDto = undefined
+    this.auditService.logArchiveChallenge(this.archiveChallengeAuditData(req, challengeResponseDto)) // no need to wait for response
+    return res.redirectWithSuccess(
+      `/profile/${prisonNumber}/challenges#archived-challenges`,
+      'Challenge moved to History',
+    )
+  }
+
+  private updateDtoFromForm = (req: Request, form: { archiveReason: string }) => {
+    const { challengeDto } = req.journeyData
+    challengeDto.archiveReason = form.archiveReason
+    req.journeyData.challengeDto = challengeDto
+  }
+
+  private archiveChallengeAuditData = (req: Request, challengeDto: ChallengeResponseDto): BaseAuditData => {
+    return {
+      details: {
+        challengeReference: challengeDto.reference,
+      },
+      subjectType: 'PRISONER_ID',
+      subjectId: req.params.prisonNumber,
+      who: req.user?.username ?? 'UNKNOWN',
+      correlationId: req.id,
+    }
+  }
+}

--- a/server/routes/challenges/validationSchemas/archiveReasonSchema.test.ts
+++ b/server/routes/challenges/validationSchemas/archiveReasonSchema.test.ts
@@ -1,0 +1,98 @@
+import { Request, Response } from 'express'
+import type { Error } from '../../../filters/findErrorFilter'
+import { validate } from '../../../middleware/validationMiddleware'
+import archiveReasonSchema from './archiveReasonSchema'
+
+describe('archiveReasonSchema', () => {
+  const req = {
+    originalUrl: '',
+    body: {},
+    flash: jest.fn(),
+  } as unknown as Request
+  const res = {
+    redirectWithErrors: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.originalUrl =
+      '/challenges/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason'
+  })
+
+  it('happy path - validation passes', async () => {
+    // Given
+    const requestBody = { archiveReason: 'This challenge was incorrectly added by mistake' }
+    req.body = requestBody
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).toHaveBeenCalled()
+    expect(req.flash).not.toHaveBeenCalled()
+    expect(res.redirectWithErrors).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    //
+    null,
+    undefined,
+    '',
+    ' ',
+    `
+
+    `,
+  ])('sad path - archiveReason field validation fails - %s', async archiveReason => {
+    // Given
+    const requestBody = { archiveReason }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Add reason for moving this challenge to the History',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/challenges/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+
+  it('sad path - archiveReason field length validation fails', async () => {
+    // Given
+    const requestBody = { archiveReason: 'a'.repeat(4001) }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Reason for moving this challenge to the History must be 4000 characters or less',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/challenges/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+})

--- a/server/routes/challenges/validationSchemas/archiveReasonSchema.ts
+++ b/server/routes/challenges/validationSchemas/archiveReasonSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+import { createSchema } from '../../../middleware/validationMiddleware'
+
+const archiveReasonSchema = async () => {
+  const ARCHIVE_REASON_MAX_LENGTH = 4000
+
+  const archiveReasonMandatoryMessage = 'Add reason for moving this challenge to the History'
+  const archiveReasonMaxLengthMessage = `Reason for moving this challenge to the History must be ${ARCHIVE_REASON_MAX_LENGTH} characters or less`
+
+  return createSchema({
+    archiveReason: z //
+      .string({ message: archiveReasonMandatoryMessage })
+      .trim()
+      .min(1, archiveReasonMandatoryMessage)
+      .max(ARCHIVE_REASON_MAX_LENGTH, archiveReasonMaxLengthMessage),
+  })
+}
+
+export default archiveReasonSchema

--- a/server/services/challengeService.test.ts
+++ b/server/services/challengeService.test.ts
@@ -8,6 +8,7 @@ import aValidChallengeResponseDto from '../testsupport/challengeResponseDtoTestD
 import ChallengeType from '../enums/challengeType'
 import ChallengeIdentificationSource from '../enums/challengeIdentificationSource'
 import anUpdateChallengeRequest from '../testsupport/updateChallengeRequestTestDataBuilder'
+import anArchiveChallengeRequest from '../testsupport/archiveChallengeRequestTestDataBuilder'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
 
@@ -255,6 +256,64 @@ describe('challengeService', () => {
         challengeReference,
         username,
         expectedUpdateChallengeRequest,
+      )
+    })
+  })
+
+  describe('archiveChallenge', () => {
+    it('should archive challenge', async () => {
+      // Given
+      supportAdditionalNeedsApiClient.archiveChallenge.mockResolvedValue(null)
+
+      const challengeDto = aValidChallengeDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Challenge created in error',
+      })
+
+      const expectedArchiveChallengeRequest = anArchiveChallengeRequest({
+        prisonId: 'BXI',
+        reason: 'Challenge created in error',
+      })
+
+      // When
+      await service.archiveChallenge(username, challengeReference, challengeDto)
+
+      // Then
+      expect(supportAdditionalNeedsApiClient.archiveChallenge).toHaveBeenCalledWith(
+        prisonNumber,
+        challengeReference,
+        username,
+        expectedArchiveChallengeRequest,
+      )
+    })
+
+    it('should rethrow error given API client throws error', async () => {
+      // Given
+      const expectedError = new Error('Internal Server Error')
+      supportAdditionalNeedsApiClient.archiveChallenge.mockRejectedValue(expectedError)
+
+      const challengeDto = aValidChallengeDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Challenge created in error',
+      })
+
+      const expectedArchiveChallengeRequest = anArchiveChallengeRequest({
+        prisonId: 'BXI',
+        reason: 'Challenge created in error',
+      })
+
+      // When
+      const actual = await service.archiveChallenge(username, challengeReference, challengeDto).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(supportAdditionalNeedsApiClient.archiveChallenge).toHaveBeenCalledWith(
+        prisonNumber,
+        challengeReference,
+        username,
+        expectedArchiveChallengeRequest,
       )
     })
   })

--- a/server/services/challengeService.ts
+++ b/server/services/challengeService.ts
@@ -4,6 +4,7 @@ import { toCreateChallengesRequest } from '../data/mappers/createChallengesReque
 import logger from '../../logger'
 import { toChallengeDto, toChallengeResponseDto } from '../data/mappers/challengeDtoMapper'
 import toUpdateChallengeRequest from '../data/mappers/updateChallengeRequestMapper'
+import toArchiveChallengeRequest from '../data/mappers/archiveChallengeRequestMapper'
 
 export default class ChallengeService {
   constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
@@ -60,6 +61,22 @@ export default class ChallengeService {
       )
     } catch (e) {
       logger.error(`Error updating Challenge for [${prisonNumber}]`, e)
+      throw e
+    }
+  }
+
+  async archiveChallenge(username: string, challengeReference: string, challenge: ChallengeDto): Promise<void> {
+    const { prisonNumber } = challenge
+    try {
+      const archiveChallengeRequest = toArchiveChallengeRequest(challenge)
+      await this.supportAdditionalNeedsApiClient.archiveChallenge(
+        prisonNumber,
+        challengeReference,
+        username,
+        archiveChallengeRequest,
+      )
+    } catch (e) {
+      logger.error(`Error archiving Challenge for [${prisonNumber}]`, e)
       throw e
     }
   }

--- a/server/testsupport/challengeDtoTestDataBuilder.ts
+++ b/server/testsupport/challengeDtoTestDataBuilder.ts
@@ -9,6 +9,7 @@ const aValidChallengeDto = (options?: {
   symptoms?: string
   howIdentified?: Array<ChallengeIdentificationSource>
   howIdentifiedOther?: string
+  archiveReason?: string
 }): ChallengeDto => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
   prisonId: options?.prisonId || 'BXI',
@@ -19,6 +20,7 @@ const aValidChallengeDto = (options?: {
     options?.howIdentifiedOther === null
       ? null
       : options?.howIdentifiedOther || 'The trainer noticed that John could read better on a cream background',
+  archiveReason: options?.archiveReason,
 })
 
 export default aValidChallengeDto

--- a/server/testsupport/challengeResponseDtoTestDataBuilder.ts
+++ b/server/testsupport/challengeResponseDtoTestDataBuilder.ts
@@ -15,6 +15,7 @@ const aValidChallengeResponseDto = (
     active?: boolean
     fromALNScreener?: boolean
     alnScreenerDate?: Date
+    archiveReason?: string
   },
 ): ChallengeResponseDto => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
@@ -30,6 +31,7 @@ const aValidChallengeResponseDto = (
   active: options?.active == null ? true : options?.active,
   fromALNScreener: options?.fromALNScreener == null ? true : options?.fromALNScreener,
   alnScreenerDate: options?.alnScreenerDate === null ? null : options?.alnScreenerDate,
+  archiveReason: options?.archiveReason,
   ...validDtoAuditFields(options),
 })
 

--- a/server/testsupport/challengeResponseTestDataBuilder.ts
+++ b/server/testsupport/challengeResponseTestDataBuilder.ts
@@ -20,6 +20,7 @@ const aValidChallengeResponse = (
     howIdentifiedOther?: string
     alnScreenerDate?: string
     challengeCategory?: string
+    archiveReason?: string
   },
 ): ChallengeResponse => ({
   active: options?.active == null ? true : options?.active,
@@ -40,6 +41,7 @@ const aValidChallengeResponse = (
     categoryCode: options?.challengeCategory || 'LITERACY_SKILLS',
   },
   alnScreenerDate: options?.alnScreenerDate === null ? null : options?.alnScreenerDate || '2025-06-18',
+  archiveReason: options?.archiveReason,
   ...validAuditFields(options),
 })
 

--- a/server/testsupport/strengthResponseTestDataBuilder.ts
+++ b/server/testsupport/strengthResponseTestDataBuilder.ts
@@ -15,6 +15,7 @@ const aValidStrengthResponse = (
     howIdentified?: Array<string>
     howIdentifiedOther?: string
     alnScreenerDate?: string
+    archiveReason?: string
   },
 ): StrengthResponse => ({
   active: options?.active == null ? true : options?.active,
@@ -31,6 +32,7 @@ const aValidStrengthResponse = (
     categoryCode: options?.strengthCategory || 'LITERACY_SKILLS',
   },
   alnScreenerDate: options?.alnScreenerDate === null ? null : options?.alnScreenerDate || '2025-06-18',
+  archiveReason: options?.archiveReason,
   ...validAuditFields(options),
 })
 

--- a/server/views/pages/challenges/layout.njk
+++ b/server/views/pages/challenges/layout.njk
@@ -14,5 +14,7 @@
     </div>
   {% endif %}
 
-  <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} challenge</p>
+  {% if not mode == 'archive' %}
+    <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} challenge</p>
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/challenges/reason/archive-journey/index.njk
+++ b/server/views/pages/challenges/reason/archive-journey/index.njk
@@ -1,0 +1,70 @@
+{% extends "../../layout.njk" %}
+
+{% set pageId = 'archive-challenge-reason' %}
+{% set pageTitle = "Move challenge to history - Move challenge to history reason" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Move {{ prisonerSummary | formatFirst_name_Last_name }}'s challenge to the History</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-hint">Challenges in the History tab are view only and cannot be reactivated.</p>
+
+      {% set insetContent %}
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">{{ dto.challengeCategory | formatChallengeCategoryScreenValue | default(dto.challengeCategory, true) }}</h3>
+        <p class="govuk-body app-u-multiline-text">{{ dto.symptoms }}</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">How was this challenge identified?</h2>
+        <ul class="govuk-list">
+          {% for challengeIdentificationSource in dto.howIdentified %}
+            <li>{{ challengeIdentificationSource | formatChallengeIdentificationSourceScreenValue if challengeIdentificationSource != 'OTHER' else dto.howIdentifiedOther }}</li>
+          {% endfor %}
+        </ul>
+
+        <p class="govuk-hint govuk-body govuk-!-font-size-16">
+          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+          {% set prisonName = prisonNamesById[dto.updatedAtPrison] | default(dto.updatedAtPrison) %}
+          Last updated {{ dto.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ dto.updatedByDisplayName }}, {{ prisonName }}</span>
+        </p>
+      {% endset %}
+      {{ govukInsetText({
+        html: insetContent
+      }) }}
+
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ govukTextarea({
+            id: "archiveReason",
+            name: "archiveReason",
+            rows: "4",
+            value: form.archiveReason,
+            type: "text",
+            label: {
+              text: "Add a reason for moving this challenge to the History",
+              classes: "govuk-label--s",
+              attributes: { "aria-live": "polite" }
+            },
+            attributes: { "aria-label" : "Give details of the archive reason" },
+            errorMessage: errors | findError("archiveReason")
+          }) }}
+
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Move challenge",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
PR to add the screen journey, validator, and service call to archive a challenge.

As shown in the screen capture, this PR **does not** include rendering the archived challenges on the History tab, but it does update the count. Rendering the archived challenges on the history tab will come in one of my next PRs, as will cypress tests (also missing from this PR)

https://github.com/user-attachments/assets/ee65cd33-9482-4ef8-b7b3-1da0f2b0a5cb

