### PR TITLE
RR-2012 - Screen, validator and service call for archiving a condition

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -137,6 +137,7 @@ declare module 'dto' {
     conditionDetails: string
     source: ConditionSource
     active?: boolean
+    archiveReason?: string
   }
 
   /**

--- a/server/data/mappers/archiveConditionRequestMapper.test.ts
+++ b/server/data/mappers/archiveConditionRequestMapper.test.ts
@@ -1,0 +1,33 @@
+import { aValidConditionDto } from '../../testsupport/conditionDtoTestDataBuilder'
+import ConditionType from '../../enums/conditionType'
+import anArchiveConditionRequest from '../../testsupport/archiveConditionRequestTestDataBuilder'
+import toArchiveConditionRequest from './archiveConditionRequestMapper'
+import ConditionSource from '../../enums/conditionSource'
+
+describe('archiveConditionRequestMapper', () => {
+  describe('toArchiveConditionRequest', () => {
+    it('should map a ConditionDto to an ArchiveConditionRequest', () => {
+      // Given
+      const conditionDto = aValidConditionDto({
+        prisonNumber: 'A1234BC',
+        prisonId: 'BXI',
+        conditionTypeCode: ConditionType.DYSLEXIA,
+        conditionName: 'Dyslexia',
+        conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
+        source: ConditionSource.CONFIRMED_DIAGNOSIS,
+        archiveReason: 'The condition was created in error',
+      })
+
+      const expectedArchiveConditionRequest = anArchiveConditionRequest({
+        prisonId: 'BXI',
+        reason: 'The condition was created in error',
+      })
+
+      // When
+      const actual = toArchiveConditionRequest(conditionDto)
+
+      // Then
+      expect(actual).toEqual(expectedArchiveConditionRequest)
+    })
+  })
+})

--- a/server/data/mappers/archiveConditionRequestMapper.ts
+++ b/server/data/mappers/archiveConditionRequestMapper.ts
@@ -1,0 +1,9 @@
+import type { ArchiveConditionRequest } from 'supportAdditionalNeedsApiClient'
+import type { ConditionDto } from 'dto'
+
+const toArchiveConditionRequest = (condition: ConditionDto): ArchiveConditionRequest => ({
+  prisonId: condition.prisonId,
+  archiveReason: condition.archiveReason,
+})
+
+export default toArchiveConditionRequest

--- a/server/data/mappers/conditionDtoMapper.test.ts
+++ b/server/data/mappers/conditionDtoMapper.test.ts
@@ -12,7 +12,7 @@ describe('conditionDtoMapper', () => {
     const apiResponse = aValidConditionListResponse({
       conditionResponses: [
         {
-          active: true,
+          active: false,
           source: 'SELF_DECLARED',
           conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
           conditionType: { code: 'DYSLEXIA' },
@@ -26,6 +26,7 @@ describe('conditionDtoMapper', () => {
           updatedByDisplayName: 'Alex Smith',
           updatedAt: '2023-06-19T09:39:44Z',
           updatedAtPrison: 'MDI',
+          archiveReason: 'Created in error',
         },
       ],
     })
@@ -35,7 +36,7 @@ describe('conditionDtoMapper', () => {
       conditions: [
         {
           prisonId: null,
-          active: true,
+          active: false,
           prisonNumber,
           conditionDetails: 'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
           conditionName: 'Phonological dyslexia',
@@ -50,6 +51,7 @@ describe('conditionDtoMapper', () => {
           updatedAtPrison: 'MDI',
           updatedBy: 'asmith_gen',
           updatedByDisplayName: 'Alex Smith',
+          archiveReason: 'Created in error',
         },
       ],
     })

--- a/server/data/mappers/conditionDtoMapper.ts
+++ b/server/data/mappers/conditionDtoMapper.ts
@@ -21,6 +21,7 @@ const toConditionDto = (prisonNumber: string, conditionResponse: ConditionRespon
         conditionDetails: conditionResponse.conditionDetails,
         source: conditionResponse.source,
         active: conditionResponse.active,
+        archiveReason: conditionResponse.archiveReason,
       }
     : null
 

--- a/server/routes/conditions/archive/reason/reasonController.test.ts
+++ b/server/routes/conditions/archive/reason/reasonController.test.ts
@@ -1,0 +1,164 @@
+import { Request, Response } from 'express'
+import ReasonController from './reasonController'
+import ConditionService from '../../../../services/conditionService'
+import AuditService from '../../../../services/auditService'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../../utils/result/result'
+import { aValidConditionDto } from '../../../../testsupport/conditionDtoTestDataBuilder'
+
+jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/conditionService')
+
+describe('reasonController', () => {
+  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const auditService = new AuditService(null) as jest.Mocked<AuditService>
+  const controller = new ReasonController(conditionService, auditService)
+
+  const username = 'A_DPS_USER'
+  const prisonNumber = 'A1234BC'
+  const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
+  const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
+
+  const conditionReference = '518d65dc-2866-46a7-94c0-ffb331e66061'
+  const conditionDto = aValidConditionDto({
+    prisonNumber,
+    reference: conditionReference,
+    archiveReason: null,
+  })
+
+  const flash = jest.fn()
+  const req = {
+    session: {},
+    user: { username },
+    journeyData: {},
+    body: {},
+    params: { prisonNumber },
+    flash,
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+    redirectWithSuccess: jest.fn(),
+    render: jest.fn(),
+    locals: {
+      prisonerSummary,
+      prisonNamesById,
+      user: { username, activeCaseLoadId: 'BXI' },
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.body = {}
+    req.journeyData = { conditionDto }
+  })
+
+  it('should render the view when there is no previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    res.locals.invalidForm = undefined
+
+    const expectedViewTemplate = 'pages/conditions/reason/archive-journey/index'
+    const expectedViewModel = {
+      prisonerSummary,
+      prisonNamesById,
+      dto: conditionDto,
+      errorRecordingCondition: false,
+      form: { archiveReason: '' },
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should render view given previously submitted invalid form', async () => {
+    // Given
+    flash.mockReturnValue([])
+    const invalidForm = {
+      archiveReason: ['not-a-valid-value'],
+    }
+    res.locals.invalidForm = invalidForm
+
+    const expectedViewTemplate = 'pages/conditions/reason/archive-journey/index'
+    const expectedViewModel = {
+      prisonerSummary,
+      prisonNamesById,
+      dto: conditionDto,
+      errorRecordingCondition: false,
+      form: invalidForm,
+      mode: 'archive',
+    }
+
+    // When
+    await controller.getReasonView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors')
+  })
+
+  it('should submit form and redirect to next route given calling API is successful', async () => {
+    // Given
+    req.body = {
+      archiveReason: 'Condition is not relevant and was recorded in error',
+    }
+    conditionService.archiveCondition.mockResolvedValue(null)
+
+    const expectedConditionDto = {
+      ...conditionDto,
+      prisonId: 'BXI',
+      archiveReason: 'Condition is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = `/profile/${prisonNumber}/conditions#archived-conditions`
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Condition moved to History')
+    expect(req.journeyData.conditionDto).toBeUndefined()
+    expect(flash).not.toHaveBeenCalled()
+    expect(conditionService.archiveCondition).toHaveBeenCalledWith(username, conditionReference, expectedConditionDto)
+    expect(auditService.logArchiveCondition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: {
+          conditionReference,
+        },
+        subjectId: prisonNumber,
+        subjectType: 'PRISONER_ID',
+        who: username,
+      }),
+    )
+  })
+
+  it('should submit form and redirect to next route given calling API is not successful', async () => {
+    // Given
+    req.body = {
+      archiveReason: 'Condition is not relevant and was recorded in error',
+    }
+
+    conditionService.archiveCondition.mockRejectedValue(new Error('Internal Server Error'))
+
+    const expectedConditionDto = {
+      ...conditionDto,
+      prisonId: 'BXI',
+      archiveReason: 'Condition is not relevant and was recorded in error',
+    }
+    const expectedNextRoute = 'reason'
+
+    // When
+    await controller.submitReasonForm(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextRoute)
+    expect(req.journeyData.conditionDto).toEqual(conditionDto)
+    expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
+    expect(conditionService.archiveCondition).toHaveBeenCalledWith(username, conditionReference, expectedConditionDto)
+    expect(auditService.logArchiveCondition).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/conditions/archive/reason/reasonController.ts
+++ b/server/routes/conditions/archive/reason/reasonController.ts
@@ -1,0 +1,77 @@
+import { NextFunction, Request, Response } from 'express'
+import type { ConditionDto } from 'dto'
+import { AuditService, ConditionService } from '../../../../services'
+import { BaseAuditData } from '../../../../services/auditService'
+import { Result } from '../../../../utils/result/result'
+import { PrisonUser } from '../../../../interfaces/hmppsUser'
+
+export default class ReasonController {
+  constructor(
+    private readonly conditionService: ConditionService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  getReasonView = async (req: Request, res: Response, next: NextFunction) => {
+    const { invalidForm, prisonerSummary, prisonNamesById } = res.locals
+    const { conditionDto } = req.journeyData
+
+    const reasonForm = invalidForm ?? { archiveReason: '' }
+
+    const viewRenderArgs = {
+      prisonerSummary,
+      prisonNamesById,
+      mode: 'archive',
+      dto: conditionDto,
+      form: reasonForm,
+      errorRecordingCondition: req.flash('pageHasApiErrors')[0] != null,
+    }
+
+    return res.render('pages/conditions/reason/archive-journey/index', viewRenderArgs)
+  }
+
+  submitReasonForm = async (req: Request, res: Response, next: NextFunction) => {
+    const reasonForm = { ...req.body }
+    this.updateDtoFromForm(req, reasonForm)
+
+    const { activeCaseLoadId, username } = res.locals.user as PrisonUser
+
+    const conditionDto = { ...req.journeyData.conditionDto, prisonId: activeCaseLoadId }
+    const { reference } = conditionDto
+
+    const { apiErrorCallback } = res.locals
+    const apiResult = await Result.wrap(
+      this.conditionService.archiveCondition(username, reference, conditionDto),
+      apiErrorCallback,
+    )
+    if (!apiResult.isFulfilled()) {
+      req.flash('pageHasApiErrors', 'true')
+      return res.redirect('reason')
+    }
+
+    const { prisonNumber } = conditionDto
+    req.journeyData.conditionDto = undefined
+    this.auditService.logArchiveCondition(this.archiveConditionAuditData(req, conditionDto)) // no need to wait for response
+    return res.redirectWithSuccess(
+      `/profile/${prisonNumber}/conditions#archived-conditions`,
+      'Condition moved to History',
+    )
+  }
+
+  private updateDtoFromForm = (req: Request, form: { archiveReason: string }) => {
+    const { conditionDto } = req.journeyData
+    conditionDto.archiveReason = form.archiveReason
+    req.journeyData.conditionDto = conditionDto
+  }
+
+  private archiveConditionAuditData = (req: Request, conditionDto: ConditionDto): BaseAuditData => {
+    return {
+      details: {
+        conditionReference: conditionDto.reference,
+      },
+      subjectType: 'PRISONER_ID',
+      subjectId: req.params.prisonNumber,
+      who: req.user?.username ?? 'UNKNOWN',
+      correlationId: req.id,
+    }
+  }
+}

--- a/server/routes/conditions/validationSchemas/archiveReasonSchema.test.ts
+++ b/server/routes/conditions/validationSchemas/archiveReasonSchema.test.ts
@@ -1,0 +1,98 @@
+import { Request, Response } from 'express'
+import type { Error } from '../../../filters/findErrorFilter'
+import { validate } from '../../../middleware/validationMiddleware'
+import archiveReasonSchema from './archiveReasonSchema'
+
+describe('archiveReasonSchema', () => {
+  const req = {
+    originalUrl: '',
+    body: {},
+    flash: jest.fn(),
+  } as unknown as Request
+  const res = {
+    redirectWithErrors: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.originalUrl =
+      '/conditions/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason'
+  })
+
+  it('happy path - validation passes', async () => {
+    // Given
+    const requestBody = { archiveReason: 'This condition was incorrectly added by mistake' }
+    req.body = requestBody
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).toHaveBeenCalled()
+    expect(req.flash).not.toHaveBeenCalled()
+    expect(res.redirectWithErrors).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    //
+    null,
+    undefined,
+    '',
+    ' ',
+    `
+
+    `,
+  ])('sad path - archiveReason field validation fails - %s', async archiveReason => {
+    // Given
+    const requestBody = { archiveReason }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Add reason for moving this condition to the History',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/conditions/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+
+  it('sad path - archiveReason field length validation fails', async () => {
+    // Given
+    const requestBody = { archiveReason: 'a'.repeat(4001) }
+    req.body = requestBody
+
+    const expectedErrors: Array<Error> = [
+      {
+        href: '#archiveReason',
+        text: 'Reason for moving this condition to the History must be 4000 characters or less',
+      },
+    ]
+    const expectedInvalidForm = JSON.stringify(requestBody)
+
+    // When
+    await validate(archiveReasonSchema)(req, res, next)
+
+    // Then
+    expect(req.body).toEqual(requestBody)
+    expect(next).not.toHaveBeenCalled()
+    expect(req.flash).toHaveBeenCalledWith('invalidForm', expectedInvalidForm)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      '/conditions/A1234BC/187168d1-121c-42bf-b456-47711924ffa4/archive/473e9ee4-37d6-4afb-92a2-5729b10cc60f/reason',
+      expectedErrors,
+    )
+  })
+})

--- a/server/routes/conditions/validationSchemas/archiveReasonSchema.ts
+++ b/server/routes/conditions/validationSchemas/archiveReasonSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+import { createSchema } from '../../../middleware/validationMiddleware'
+
+const archiveReasonSchema = async () => {
+  const ARCHIVE_REASON_MAX_LENGTH = 4000
+
+  const archiveReasonMandatoryMessage = 'Add reason for moving this condition to the History'
+  const archiveReasonMaxLengthMessage = `Reason for moving this condition to the History must be ${ARCHIVE_REASON_MAX_LENGTH} characters or less`
+
+  return createSchema({
+    archiveReason: z //
+      .string({ message: archiveReasonMandatoryMessage })
+      .trim()
+      .min(1, archiveReasonMandatoryMessage)
+      .max(ARCHIVE_REASON_MAX_LENGTH, archiveReasonMaxLengthMessage),
+  })
+}
+
+export default archiveReasonSchema

--- a/server/services/conditionService.test.ts
+++ b/server/services/conditionService.test.ts
@@ -8,6 +8,7 @@ import { aValidConditionListResponse, aValidConditionResponse } from '../testsup
 import ConditionType from '../enums/conditionType'
 import ConditionSource from '../enums/conditionSource'
 import anUpdateConditionRequest from '../testsupport/updateConditionRequestTestDataBuilder'
+import anArchiveConditionRequest from '../testsupport/archiveConditionRequestTestDataBuilder'
 
 jest.mock('../data/supportAdditionalNeedsApiClient')
 
@@ -268,6 +269,64 @@ describe('conditionService', () => {
         conditionReference,
         username,
         expectedUpdateConditionRequest,
+      )
+    })
+  })
+
+  describe('archiveCondition', () => {
+    it('should archive condition', async () => {
+      // Given
+      supportAdditionalNeedsApiClient.archiveCondition.mockResolvedValue(null)
+
+      const conditionDto = aValidConditionDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Condition created in error',
+      })
+
+      const expectedArchiveConditionRequest = anArchiveConditionRequest({
+        prisonId: 'BXI',
+        reason: 'Condition created in error',
+      })
+
+      // When
+      await service.archiveCondition(username, conditionReference, conditionDto)
+
+      // Then
+      expect(supportAdditionalNeedsApiClient.archiveCondition).toHaveBeenCalledWith(
+        prisonNumber,
+        conditionReference,
+        username,
+        expectedArchiveConditionRequest,
+      )
+    })
+
+    it('should rethrow error given API client throws error', async () => {
+      // Given
+      const expectedError = new Error('Internal Server Error')
+      supportAdditionalNeedsApiClient.archiveCondition.mockRejectedValue(expectedError)
+
+      const conditionDto = aValidConditionDto({
+        prisonNumber,
+        prisonId: 'BXI',
+        archiveReason: 'Condition created in error',
+      })
+
+      const expectedArchiveConditionRequest = anArchiveConditionRequest({
+        prisonId: 'BXI',
+        reason: 'Condition created in error',
+      })
+
+      // When
+      const actual = await service.archiveCondition(username, conditionReference, conditionDto).catch(e => e)
+
+      // Then
+      expect(actual).toEqual(expectedError)
+      expect(supportAdditionalNeedsApiClient.archiveCondition).toHaveBeenCalledWith(
+        prisonNumber,
+        conditionReference,
+        username,
+        expectedArchiveConditionRequest,
       )
     })
   })

--- a/server/services/conditionService.ts
+++ b/server/services/conditionService.ts
@@ -4,6 +4,7 @@ import { toCreateConditionsRequest } from '../data/mappers/createConditionsReque
 import logger from '../../logger'
 import { toConditionDto, toConditionsList } from '../data/mappers/conditionDtoMapper'
 import toUpdateConditionRequest from '../data/mappers/updateConditionRequestMapper'
+import toArchiveConditionRequest from '../data/mappers/archiveConditionRequestMapper'
 
 export default class ConditionService {
   constructor(private readonly supportAdditionalNeedsApiClient: SupportAdditionalNeedsApiClient) {}
@@ -55,6 +56,22 @@ export default class ConditionService {
       )
     } catch (e) {
       logger.error(`Error updating Condition for [${prisonNumber}]`, e)
+      throw e
+    }
+  }
+
+  async archiveCondition(username: string, conditionReference: string, condition: ConditionDto): Promise<void> {
+    const { prisonNumber } = condition
+    try {
+      const archiveConditionRequest = toArchiveConditionRequest(condition)
+      await this.supportAdditionalNeedsApiClient.archiveCondition(
+        prisonNumber,
+        conditionReference,
+        username,
+        archiveConditionRequest,
+      )
+    } catch (e) {
+      logger.error(`Error archiving Condition for [${prisonNumber}]`, e)
       throw e
     }
   }

--- a/server/testsupport/conditionDtoTestDataBuilder.ts
+++ b/server/testsupport/conditionDtoTestDataBuilder.ts
@@ -20,6 +20,7 @@ const aValidConditionDto = (
     conditionDetails?: string
     source?: ConditionSource
     active?: boolean
+    archiveReason?: string
   },
 ): ConditionDto => ({
   prisonId: options?.prisonId == null ? null : options?.prisonId || 'BXI',
@@ -33,6 +34,7 @@ const aValidConditionDto = (
         'John says he was diagnosed with dyslexia as a child, but this has not yet been evidenced.',
   conditionName: options?.conditionName === null ? null : options?.conditionName || 'Phonological dyslexia',
   active: options?.active == null ? true : options?.active,
+  archiveReason: options?.archiveReason,
   ...validDtoAuditFields(options),
 })
 

--- a/server/testsupport/conditionResponseTestDataBuilder.ts
+++ b/server/testsupport/conditionResponseTestDataBuilder.ts
@@ -15,6 +15,7 @@ const aValidConditionResponse = (
     source?: ConditionSource
     conditionDetails?: string
     conditionName?: string
+    archiveReason?: string
   },
 ): ConditionResponse => ({
   active: options?.active == null ? true : options?.active,
@@ -28,6 +29,7 @@ const aValidConditionResponse = (
     code: options?.conditionTypeCode || 'DYSLEXIA',
   },
   conditionName: options?.conditionName === null ? null : options?.conditionName || 'Phonological dyslexia',
+  archiveReason: options?.archiveReason,
   ...validAuditFields(options),
 })
 

--- a/server/views/pages/conditions/layout.njk
+++ b/server/views/pages/conditions/layout.njk
@@ -14,5 +14,7 @@
     </div>
   {% endif %}
 
-  <p class="govuk-body">{{ 'Edit condition' if mode == 'edit' else 'Record conditions' }}</p>
+  {% if not mode == 'archive' %}
+    <p class="govuk-body">{{ 'Edit condition' if mode == 'edit' else 'Record conditions' }}</p>
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/conditions/reason/archive-journey/index.njk
+++ b/server/views/pages/conditions/reason/archive-journey/index.njk
@@ -1,0 +1,65 @@
+{% extends "../../layout.njk" %}
+
+{% set pageId = 'archive-condition-reason' %}
+{% set pageTitle = "Move condition to history - Move condition to history reason" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Move {{ prisonerSummary | formatFirst_name_Last_name }}'s condition to the History</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-hint">Conditions in the History tab are view only and cannot be reactivated.</p>
+
+      {% set insetContent %}
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">{{ dto.conditionTypeCode | formatConditionTypeScreenValue | default(dto.conditionTypeCode, true) }}</h3>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">{{ 'Self-declared condition' if dto.source == 'SELF_DECLARED' else 'Confirmed diagnosis' }}</h3>
+        <p class="govuk-body app-u-multiline-text">{{ dto.conditionDetails }}</p>
+
+        <p class="govuk-hint govuk-body govuk-!-font-size-16">
+          {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+          {% set prisonName = prisonNamesById[dto.updatedAtPrison] | default(dto.updatedAtPrison) %}
+          Last updated {{ dto.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ dto.updatedByDisplayName }}, {{ prisonName }}</span>
+        </p>
+      {% endset %}
+      {{ govukInsetText({
+        html: insetContent
+      }) }}
+
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ govukTextarea({
+            id: "archiveReason",
+            name: "archiveReason",
+            rows: "4",
+            value: form.archiveReason,
+            type: "text",
+            label: {
+              text: "Add a reason for moving this condition to the History",
+              classes: "govuk-label--s",
+              attributes: { "aria-live": "polite" }
+            },
+            attributes: { "aria-label" : "Give details of the archive reason" },
+            errorMessage: errors | findError("archiveReason")
+          }) }}
+
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Move condition",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
PR to add the screen journey, validator, and service call to archive a condition.

As shown in the screen capture, this PR does not include rendering the archived conditions on the History tab, but it does update the count. Rendering the archived conditons on the history tab will come in one of my next PRs, as will cypress tests (also missing from this PR)

https://github.com/user-attachments/assets/fa5395a8-a1df-413c-a99a-5527cd28674a

