### PR TITLE
RR-2042 - Re-import curious swagger spec to get new field name for levelBanding

### DIFF
--- a/server/@types/curiousApi/index.d.ts
+++ b/server/@types/curiousApi/index.d.ts
@@ -31,7 +31,7 @@ export interface paths {
     get?: never
     put?: never
     post?: never
-    /** Returns deleted employer data for the given employer Id  */
+    /** Returns deleted employer data for the given employer Id */
     delete: operations['deleteEmployerUsingDELETE']
     options?: never
     head?: never
@@ -566,6 +566,8 @@ export interface components {
       assessmentDate?: string
       /** @description Assessment Outcome Value */
       assessmentOutcome?: string
+      /** @description Assessment Reason Value */
+      assessmentReason?: string
       /** @description Establishment (prison) identifier */
       establishmentId?: string
       /** @description Establishment (prison) name */
@@ -586,6 +588,8 @@ export interface components {
       assessmentNextStep?: string
       /** @description Assessment Outcome Value */
       assessmentOutcome?: string
+      /** @description Assessment Reason Value */
+      assessmentReason?: string
       /** @description Establishment (prison) identifier */
       establishmentId?: string
       /** @description Establishment (prison) name */
@@ -604,14 +608,16 @@ export interface components {
       assessmentDate?: string
       /** @description Assessment Next Step Value */
       assessmentNextStep?: string
+      /** @description Assessment Reason Value */
+      assessmentReason?: string
       /** @description Establishment (prison) identifier */
       establishmentId?: string
       /** @description Establishment (prison) name */
       establishmentName?: string
       /** @description Has Prisoner Consent Value */
       hasPrisonerConsent?: string
-      /** @description Assessment Level Branding Value */
-      levelBranding?: string
+      /** @description Assessment Level Banding Value */
+      levelBanding?: string
       /** @description Stakeholder Referral Value */
       stakeholderReferral?: string
       /** @description Assessment Working Towards Level Value */

--- a/server/testsupport/curiousAssessmentsTestDataBuilder.ts
+++ b/server/testsupport/curiousAssessmentsTestDataBuilder.ts
@@ -173,7 +173,7 @@ const anEnglishFunctionalSkillsLearnerAssessmentsDTO = (options?: {
     | 'Level 1'
     | 'Level 2'
     | 'Level 3'
-  levelBranding?:
+  levelBanding?:
     | '0.0'
     | '0.1'
     | '0.2'
@@ -222,7 +222,7 @@ const anEnglishFunctionalSkillsLearnerAssessmentsDTO = (options?: {
   assessmentDate: options?.assessmentDate || '2025-10-01',
   assessmentNextStep: options?.assessmentNextStep || 'Progress to course at level consistent with assessment result',
   workingTowardsLevel: options?.workingTowardsLevel || 'Entry Level 2',
-  levelBranding: options?.levelBranding || '2.1',
+  levelBanding: options?.levelBanding || '2.1',
   hasPrisonerConsent: options?.hasPrisonerConsent || 'Yes',
   stakeholderReferral: options?.stakeholderReferral || 'Education Specialist',
 })
@@ -243,7 +243,7 @@ const aMathsFunctionalSkillsLearnerAssessmentsDTO = (options?: {
     | 'Level 1'
     | 'Level 2'
     | 'Level 3'
-  levelBranding?:
+  levelBanding?:
     | '0.0'
     | '0.1'
     | '0.2'
@@ -292,7 +292,7 @@ const aMathsFunctionalSkillsLearnerAssessmentsDTO = (options?: {
   assessmentDate: options?.assessmentDate || '2025-10-01',
   assessmentNextStep: options?.assessmentNextStep || 'Progress to course at level consistent with assessment result',
   workingTowardsLevel: options?.workingTowardsLevel || 'Entry Level 2',
-  levelBranding: options?.levelBranding || '2.1',
+  levelBanding: options?.levelBanding || '2.1',
   hasPrisonerConsent: options?.hasPrisonerConsent || 'Yes',
   stakeholderReferral: options?.stakeholderReferral || 'Education Specialist',
 })
@@ -302,7 +302,7 @@ const aDigitalFunctionalSkillsLearnerAssessmentsDTO = (options?: {
   prisonName?: string
   assessmentDate?: string
   workingTowardsLevel?: 'Pre-Entry' | 'Entry Level' | 'Level 1'
-  levelBranding?:
+  levelBanding?:
     | '0.0'
     | '0.1'
     | '0.2'
@@ -328,7 +328,7 @@ const aDigitalFunctionalSkillsLearnerAssessmentsDTO = (options?: {
   establishmentName: options?.prisonName || 'MOORLAND (HMP & YOI)',
   assessmentDate: options?.assessmentDate || '2025-10-01',
   workingTowardsLevel: options?.workingTowardsLevel || 'Level 1',
-  levelBranding: options?.levelBranding || '1.2',
+  levelBanding: options?.levelBanding || '1.2',
   assessmentNextStep: null,
   hasPrisonerConsent: null,
   stakeholderReferral: null,


### PR DESCRIPTION
Re-import curious swagger spec to get new field name for levelBanding
(SAN does not make use of this field, but it is the right thing to do to import the spec given that MN have specifically told us about this field name change)