### PR TITLE
RR-2009 - Set up tabbed interface on Support Strategies page

### DIFF
--- a/integration_tests/e2e/profile/supportStrategies.cy.ts
+++ b/integration_tests/e2e/profile/supportStrategies.cy.ts
@@ -40,8 +40,8 @@ context('Profile Support Strategies Page', () => {
 
     // Then
     Page.verifyOnPage(SupportStrategiesPage) //
-      .hasSupportStrategySummaryCard(SupportStrategyType.MEMORY)
-      .hasSupportStrategySummaryCard(SupportStrategyType.SENSORY)
+      .hasActiveSupportStrategySummaryCard(SupportStrategyType.MEMORY)
+      .hasActiveSupportStrategySummaryCard(SupportStrategyType.SENSORY)
       .apiErrorBannerIsNotDisplayed()
   })
 

--- a/integration_tests/pages/profile/supportStrategiesPage.ts
+++ b/integration_tests/pages/profile/supportStrategiesPage.ts
@@ -15,20 +15,24 @@ export default class SupportStrategiesPage extends ProfilePage {
     return Page.verifyOnPage(SupportStrategyDetailPage)
   }
 
-  hasSupportStrategySummaryCard(category: SupportStrategyType): SupportStrategiesPage {
-    this.supportStrategyCategorySummaryCard(category).should('be.visible')
+  hasActiveSupportStrategySummaryCard(category: SupportStrategyType): SupportStrategiesPage {
+    this.supportStrategyCategorySummaryCard({ category, active: true }).should('be.visible')
     return this
   }
 
   hasNoActiveSupportStrategies(): SupportStrategiesPage {
-    this.noSupportStrategiesSummaryCard().should('be.visible')
+    this.noSupportStrategiesMessage({ active: true }).should('be.visible')
     return this
   }
 
-  private noSupportStrategiesSummaryCard = (): PageElement => cy.get('[data-qa=no-support-strategies-summary-card]')
+  private noSupportStrategiesMessage = (options: { active: boolean }): PageElement =>
+    cy.get(`[data-qa=no-${options.active ? 'active' : 'archived'}-support-strategies-message]`)
 
-  private supportStrategyCategorySummaryCard = (category: SupportStrategyType): PageElement =>
-    cy.get(`[data-qa=support-strategy-summary-card-${category}]`)
+  private supportStrategyCategorySummaryCard = (options: {
+    category: SupportStrategyType
+    active: boolean
+  }): PageElement =>
+    cy.get(`[data-qa=${options.active ? 'active' : 'archived'}-support-strategy-summary-card_${options.category}]`)
 
-  private supportStrategies = (): PageElement => cy.get('[data-qa=support-strategy-summary-list-row]')
+  private supportStrategies = (): PageElement => cy.get('.govuk-summary-list__row.support-strategy')
 }

--- a/server/views/components/support-strategies-summary-card/macro.njk
+++ b/server/views/components/support-strategies-summary-card/macro.njk
@@ -1,0 +1,17 @@
+{# Support Strategies Summary Card macro
+
+Data supplied to this macro:
+  params: {
+    supportStrategies: Array<SupportStrategyResponseDto> - Array of Support Strategies
+    prisonNamesById: Object of key value pairs, where the key is the prison ID, and the value is the prison name
+    showActions: boolean to determine whether Actions links are rendered
+    userHasPermissionTo: function that determines user permissions
+    title: string - Summary Card title
+    id: string
+    classes: string
+    attributes: Object of key value pairs of additonal attributes to add the to the component
+  }
+#}
+{% macro supportStrategiesSummaryCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.njk
+++ b/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.njk
@@ -1,0 +1,12 @@
+{% from "./macro.njk" import supportStrategiesSummaryCard %}
+
+{{ supportStrategiesSummaryCard({
+  supportStrategies: supportStrategies,
+  prisonNamesById: prisonNamesById,
+  showActions: showActions,
+  userHasPermissionTo: userHasPermissionTo,
+  title: title,
+  id: id,
+  classes: classes,
+  attributes: attributes
+}) }}

--- a/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.ts
+++ b/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.ts
@@ -1,0 +1,239 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { parseISO } from 'date-fns'
+import type { SupportStrategyResponseDto } from 'dto'
+import formatDateFilter from '../../../filters/formatDateFilter'
+import { formatStrengthTypeScreenValueFilter } from '../../../filters/formatStrengthTypeFilter'
+import formatStrengthIdentificationSourceScreenValueFilter from '../../../filters/formatStrengthIdentificationSourceFilter'
+import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('formatDate', formatDateFilter)
+  .addFilter('formatStrengthTypeScreenValue', formatStrengthTypeScreenValueFilter)
+  .addFilter('formatStrengthIdentificationSourceScreenValue', formatStrengthIdentificationSourceScreenValueFilter)
+  .addGlobal('featureToggles', { editAndArchiveEnabled: true })
+
+const prisonNamesById = {
+  BXI: 'Brixton (HMP)',
+  LEI: 'Leeds (HMP)',
+}
+const userHasPermissionTo = jest.fn()
+const templateParams = {
+  title: 'Attention, organising and time management',
+  supportStrategies: [aValidSupportStrategyResponseDto()],
+  prisonNamesById,
+  userHasPermissionTo,
+  showActions: true,
+}
+
+const template = 'supportStrategiesSummaryCard.test.njk'
+
+describe('Tests for Support Strategies Summary Card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the component given support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      supportStrategies: [
+        aValidSupportStrategyResponseDto({
+          details:
+            'Needs instructions broken down into short manageable steps, and presented both verbally and in writing',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:01:00'),
+        }),
+        aValidSupportStrategyResponseDto({
+          details: 'He can be more attentive when the context of conversation does not change frequently.',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:00:00'),
+        }),
+      ],
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Attention, organising and time management')
+
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(2)
+
+    const firstSupportStrategy = supportStrategies.eq(0)
+    expect(firstSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'Needs instructions broken down into short manageable steps, and presented both verbally and in writing',
+    )
+    expect(firstSupportStrategy.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
+      'Last updated 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+
+    const secondSupportStrategy = supportStrategies.eq(1)
+    expect(secondSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'He can be more attentive when the context of conversation does not change frequently.',
+    )
+    expect(secondSupportStrategy.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
+      'Last updated 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+  })
+
+  it('should render the component given prisonNamesById does not contain the prison', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      supportStrategies: [
+        aValidSupportStrategyResponseDto({
+          details:
+            'Needs instructions broken down into short manageable steps, and presented both verbally and in writing',
+          updatedByDisplayName: 'Person 3',
+          updatedAtPrison: 'BXI',
+          updatedAt: parseISO('2025-06-13'),
+        }),
+      ],
+      prisonNamesById: {},
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Attention, organising and time management')
+
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect($('[data-qa=support-strategy-audit]').text().trim()).toEqual('Last updated 13 Jun 2025 by Person 3, BXI')
+  })
+
+  it('should not render the component given no support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      supportStrategies: [] as Array<SupportStrategyResponseDto>,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+
+    // Then
+    expect(content.trim()).toEqual('')
+  })
+
+  it('should not render any actions given the showActions flag is false', () => {
+    const params = {
+      ...templateParams,
+      showActions: false,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(0)
+    expect(userHasPermissionTo).not.toHaveBeenCalled()
+  })
+
+  it('should not render any actions given the showActions flag is true but the user does not have any permissions', () => {
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = {
+      ...templateParams,
+      showActions: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render edit strength action given the showActions flag is true and the user only has permission to edit support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+      showActions: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render archive strength action given the showActions flag is true and the user only has permission to archive support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+
+    const params = {
+      ...templateParams,
+      showActions: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render both strength actions given the showActions flag is true and the user has permissions to edit and archive support strategies', () => {
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = {
+      ...templateParams,
+      showActions: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+})

--- a/server/views/components/support-strategies-summary-card/template.njk
+++ b/server/views/components/support-strategies-summary-card/template.njk
@@ -1,0 +1,59 @@
+{% from "govuk/macros/attributes.njk" import govukAttributes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{#- Set classes for this component #}
+{%- set classNames = "govuk-summary-card" -%}
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{#- Define component attributes #}
+{%- set componentAttributes %} class="{{ classNames }}" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
+
+{% set supportStrategies = params.supportStrategies %}
+{% set showActions = params.showActions %}
+{% set userHasPermissionTo = params.userHasPermissionTo %}
+
+{% if supportStrategies | length %}
+  <div {{ componentAttributes | safe }}>
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">{{ params.title }}</h2>
+    </div>
+
+    <div class="govuk-summary-card__content govuk-!-padding-top-0">
+      <div class="govuk-summary-list">
+
+        {% for supportStrategy in supportStrategies %}
+          <div class="govuk-summary-list__row support-strategy">
+            <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}</p>
+
+            <div class="actions-wrapper">
+              <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
+                {% set prisonName = params.prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
+                Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}</span>
+              </p>
+
+              {% if featureToggles.editAndArchiveEnabled %}
+                {% if showActions %}
+                  <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                    {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
+                      </li>
+                    {% endif %}
+                    {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive/reason" data-qa="archive-support-strategy-button">Move to history</a>
+                      </li>
+                    {% endif %}
+                  </ul>
+                {% endif %}
+              {% endif %}
+            </div>
+          </div>
+        {% endfor %}
+
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/server/views/pages/education-support-plan/review-existing-needs/support-strategies/index.njk
+++ b/server/views/pages/education-support-plan/review-existing-needs/support-strategies/index.njk
@@ -1,5 +1,5 @@
 {% extends "../../layout.njk" %}
-{% from "../../../../components/strengths-summary-card/macro.njk" import strengthsSummaryCard %}
+{% from "../../../../components/support-strategies-summary-card/macro.njk" import supportStrategiesSummaryCard %}
 
 {% set pageId = 'education-support-plan-review-existing-support-strategies' %}
 {% set pageTitle = ('Review' if mode == 'review' else 'Create') + ' an education support plan - Review support strategies' %}
@@ -16,27 +16,17 @@
       {% if supportStrategies | length %}
 
         {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-        {% for groupName, supportStrategyData in supportStrategies %}
-          <div class="govuk-summary-card" data-qa="support-strategy-summary-card-{{ groupName }}">
-            <div class="govuk-summary-card__title-wrapper">
-              <h2 class="govuk-summary-card__title">{{ groupName | formatSupportStrategyTypeScreenValue }}</h2>
-            </div>
-            <div class="govuk-summary-card__content govuk-!-padding-top-0">
-              <div class="govuk-summary-list">
-                {% for supportStrategy in supportStrategyData %}
-                  <div class="govuk-summary-list__row" data-qa="support-strategy-summary-list-row">
-                    <p class="govuk-body govuk-!-margin-top-3"
-                       data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
-                    </p>
-                    {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
-                    <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
-                      Added on {{ supportStrategy.updatedAt | formatDate('d MMMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
-                    </p>
-                  </div>
-                {% endfor %}
-              </div>
-            </div>
-          </div>
+        {% for supportStragegyCategory, supportStrategies in supportStrategies %}
+
+          {{ supportStrategiesSummaryCard({
+            title: supportStragegyCategory | formatSupportStrategyTypeScreenValue | default(supportStragegyCategory, true),
+            supportStrategies: supportStrategies,
+            prisonNamesById: prisonNamesById,
+            showActions: false,
+            attributes: {
+              'data-qa': 'support-strategy-summary-card_' + supportStragegyCategory
+            }
+          }) }}
         {% endfor %}
 
 

--- a/server/views/pages/education-support-plan/review-existing-needs/support-strategies/index.test.ts
+++ b/server/views/pages/education-support-plan/review-existing-needs/support-strategies/index.test.ts
@@ -104,7 +104,7 @@ describe('Create ELSP - review existing support strategies page', () => {
     // Then
     expect($('.govuk-summary-card').length).toEqual(3) // expect summary cards for Sensory, Memory and Numeracy Skills
 
-    const sensoryCard = $('[data-qa=support-strategy-summary-card-SENSORY]')
+    const sensoryCard = $('[data-qa=support-strategy-summary-card_SENSORY]')
     expect(sensoryCard.length).toEqual(1)
     expect(sensoryCard.find('h2').text().trim()).toEqual('Sensory')
     expect(
@@ -112,15 +112,15 @@ describe('Create ELSP - review existing support strategies page', () => {
     ).toEqual('Have patience with him and speak softly and clearly.')
     expect(
       sensoryCard.find('.govuk-summary-list__row').eq(0).find('[data-qa=support-strategy-audit]').text().trim(),
-    ).toEqual('Added on 2 May 2024 by Alex Smith, Brixton (HMP)')
+    ).toEqual('Last updated 2 May 2024 by Alex Smith, Brixton (HMP)')
     expect(
       sensoryCard.find('.govuk-summary-list__row').eq(1).find('[data-qa=support-strategy-details]').text().trim(),
     ).toEqual('Use of noise cancelling headphones will help Chris concentrate better.')
     expect(
       sensoryCard.find('.govuk-summary-list__row').eq(1).find('[data-qa=support-strategy-audit]').text().trim(),
-    ).toEqual('Added on 1 January 2024 by A.Smith, Brixton (HMP)')
+    ).toEqual('Last updated 1 Jan 2024 by A.Smith, Brixton (HMP)')
 
-    const memoryCard = $('[data-qa=support-strategy-summary-card-MEMORY]')
+    const memoryCard = $('[data-qa=support-strategy-summary-card_MEMORY]')
     expect(memoryCard.length).toEqual(1)
     expect(memoryCard.find('h2').text().trim()).toEqual('Memory')
     expect(
@@ -128,9 +128,9 @@ describe('Create ELSP - review existing support strategies page', () => {
     ).toEqual('Use of flash cards will help Chris remember more easily.')
     expect(
       memoryCard.find('.govuk-summary-list__row').eq(0).find('[data-qa=support-strategy-audit]').text().trim(),
-    ).toEqual('Added on 20 August 2023 by Brian Jones, Leeds (HMP)')
+    ).toEqual('Last updated 20 Aug 2023 by Brian Jones, Leeds (HMP)')
 
-    const numeracySkillsCard = $('[data-qa=support-strategy-summary-card-NUMERACY_SKILLS_DEFAULT]')
+    const numeracySkillsCard = $('[data-qa=support-strategy-summary-card_NUMERACY_SKILLS_DEFAULT]')
     expect(numeracySkillsCard.length).toEqual(1)
     expect(numeracySkillsCard.find('h2').text().trim()).toEqual('Numeracy skills')
     expect(
@@ -143,7 +143,7 @@ describe('Create ELSP - review existing support strategies page', () => {
     ).toEqual('Chris uses his fingers to count and it works well for him.')
     expect(
       numeracySkillsCard.find('.govuk-summary-list__row').eq(0).find('[data-qa=support-strategy-audit]').text().trim(),
-    ).toEqual('Added on 20 August 2023 by Brian Jones, Leeds (HMP)')
+    ).toEqual('Last updated 20 Aug 2023 by Brian Jones, Leeds (HMP)')
 
     expect($('[data-qa=no-support-strategies-summary-card]').length).toEqual(0)
     expect($('[data-qa=support-strategies-unavailable-message]').length).toEqual(0)

--- a/server/views/pages/profile/support-strategies/index.njk
+++ b/server/views/pages/profile/support-strategies/index.njk
@@ -1,5 +1,6 @@
 {% extends "../layout.njk" %}
 {% from "../components/actions-card/macro.njk" import actionsCard %}
+{% from "../../../components/support-strategies-summary-card/macro.njk" import supportStrategiesSummaryCard %}
 
 {% set pageId = 'profile-support-strategies' %}
 {% set pageTitle = "Support for additional needs - Support strategies" %}
@@ -18,79 +19,86 @@
 
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
-      <section>
-        {% if activeSupportStrategies.isFulfilled() %}
-          {% set activeSupportStrategies = activeSupportStrategies.value %}
+      {% if activeSupportStrategies.isFulfilled() and archivedSupportStrategies.isFulfilled() %}
+        {% set activeSupportStrategies = activeSupportStrategies.value %}
+        {% set activeSupportStrategiesCount = activeSupportStrategies | length %}
+        {% set archivedSupportStrategies = archivedSupportStrategies.value %}
+        {% set archivedSupportStrategiesCount = archivedSupportStrategies | length %}
+        {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
 
+        {% set activeSupportStrategiesContent %}
           {% if activeSupportStrategies | length %}
-            {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
-            {% for groupName, supportStrategyData in activeSupportStrategies %}
-              <div class="govuk-summary-card" data-qa="support-strategy-summary-card-{{ groupName }}">
-                <div class="govuk-summary-card__title-wrapper">
-                  <h2 class="govuk-summary-card__title">{{ groupName | formatSupportStrategyTypeScreenValue }}</h2>
-                </div>
-                <div class="govuk-summary-card__content govuk-!-padding-top-0">
-                  <div class="govuk-summary-list">
-                    {% for supportStrategy in supportStrategyData %}
-                      <div class="govuk-summary-list__row" data-qa="support-strategy-summary-list-row">
-                        <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text"
-                          data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}
-                        </p>
+            {% for supportStragegyCategory, supportStrategies in activeSupportStrategies %}
 
-                        <div class="actions-wrapper">
-                          <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
-                            {% set prisonName = prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
-                            Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }} by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}
-                          </p>
-
-                          {% if featureToggles.editAndArchiveEnabled %}
-                            <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-                              {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
-                                <li class="govuk-summary-card__action">
-                                  <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
-                                </li>
-                              {% endif %}
-                              {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
-                                <li class="govuk-summary-card__action">
-                                  <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive/reason" data-qa="archive-support-strategy-button">Move to history</a>
-                                </li>
-                              {% endif %}
-                            </ul>
-                          {% endif %}
-                        </div>
-
-                      </div>
-                    {% endfor %}
-                  </div>
-                </div>
-              </div>
+              {{ supportStrategiesSummaryCard({
+                title: supportStragegyCategory | formatSupportStrategyTypeScreenValue | default(supportStragegyCategory, true),
+                supportStrategies: supportStrategies,
+                prisonNamesById: prisonNamesById,
+                showActions: true,
+                userHasPermissionTo: userHasPermissionTo,
+                attributes: {
+                  'data-qa': 'active-support-strategy-summary-card_' + supportStragegyCategory
+                }
+              }) }}
             {% endfor %}
 
           {% else %}
-            <div class="govuk-summary-card" data-qa="no-support-strategies-summary-card">
-              <div class="govuk-summary-card__content">
-                <p class="govuk-body">
-                  No support strategies recorded
-                </p>
+            {% if featureToggles.editAndArchiveEnabled %}
+              <p class="govuk-body" data-qa="no-active-support-strategies-message">
+                {{ prisonerSummary | formatFirst_name_Last_name }} has no current support strategies.
+              </p>
+            {% else %}
+              <div class="govuk-summary-card">
+                <div class="govuk-summary-card__content">
+                  <p class="govuk-body" data-qa="no-active-support-strategies-message">
+                    No support strategies recorded
+                  </p>
+                </div>
               </div>
-            </div>
+
+            {% endif %}
+
           {% endif %}
 
-        {% else %}
-            <h3 class="govuk-heading-s" data-qa="support-strategies-unavailable-message">We cannot show these details
-              right now</h3>
-            <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be
-              available.</p>
-        {% endif %}
-      </section>
+          <p class="govuk-body">
+            {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
+              <a class="govuk-link govuk-!-display-none-print" href="/support-strategies/{{ prisonerSummary.prisonNumber }}/create/select-category">
+                Add a support strategy
+              </a>
+            {% endif %}
+          </p>
+        {% endset %}
 
-      <p class="govuk-body">
-        {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
-          <a class="govuk-link govuk-!-display-none-print" href="/support-strategies/{{ prisonerSummary.prisonNumber }}/create/select-category">
-            Add a support strategy
-          </a>
+        {% if featureToggles.editAndArchiveEnabled %}
+          {{ govukTabs({
+            items: [
+              {
+                label: 'Current (' + activeSupportStrategiesCount + ')',
+                id: 'current-support-strategies',
+                panel: {
+                  html: activeSupportStrategiesContent
+                }
+              },
+              {
+                label: 'History (' + archivedSupportStrategiesCount + ')',
+                id: 'archived-support-strategies',
+                panel: {
+                  html: ''
+                }
+              }
+            ]
+          }) }}
+        {% else %}
+          {{ activeSupportStrategiesContent | safe }}
         {% endif %}
-      </p>
+
+      {% else %}
+          <h3 class="govuk-heading-s" data-qa="support-strategies-unavailable-message">We cannot show these details
+            right now</h3>
+          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be
+            available.</p>
+      {% endif %}
+
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">

--- a/server/views/pages/profile/support-strategies/index.test.ts
+++ b/server/views/pages/profile/support-strategies/index.test.ts
@@ -83,8 +83,8 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=support-strategy-summary-card-LITERACY_SKILLS]').length).toEqual(1)
-    const literacySkillsEntry = $('[data-qa=support-strategy-summary-card-LITERACY_SKILLS]').eq(0)
+    expect($('[data-qa=active-support-strategy-summary-card_LITERACY_SKILLS]').length).toEqual(1)
+    const literacySkillsEntry = $('[data-qa=active-support-strategy-summary-card_LITERACY_SKILLS]').eq(0)
 
     expect(literacySkillsEntry.find('[data-qa=support-strategy-details]').text().trim()).toEqual(
       'Uses audio books and text-to-speech software',
@@ -92,9 +92,9 @@ describe('Profile support strategies page', () => {
     expect(literacySkillsEntry.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
       'Last updated 1 Jan 2024 by John Smith, Brixton (HMP)',
     )
-    expect($('[data-qa=support-strategy-summary-card-NUMERACY_SKILLS]').length).toEqual(1)
+    expect($('[data-qa=active-support-strategy-summary-card_NUMERACY_SKILLS]').length).toEqual(1)
 
-    const numeracySkillsEntry = $('[data-qa=support-strategy-summary-card-NUMERACY_SKILLS]').eq(0)
+    const numeracySkillsEntry = $('[data-qa=active-support-strategy-summary-card_NUMERACY_SKILLS]').eq(0)
 
     expect(numeracySkillsEntry.find('[data-qa=support-strategy-details]').text().trim()).toEqual(
       'Requires additional time for mathematical tasks',
@@ -102,7 +102,7 @@ describe('Profile support strategies page', () => {
     expect(numeracySkillsEntry.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
       'Last updated 2 Jan 2024 by Jane Doe, Leeds (HMP)',
     )
-    expect($('[data-qa=no-support-strategies-summary-card]').length).toEqual(0)
+    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
@@ -118,7 +118,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=no-support-strategies-summary-card]').length).toEqual(1)
+    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(1)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
@@ -135,7 +135,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=no-support-strategies-summary-card]').length).toEqual(0)
+    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(1)
   })
 
@@ -154,7 +154,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const supportStrategies = $('[data-qa=support-strategy-summary-list-row]')
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
     expect(supportStrategies.length).toEqual(1)
     expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
     expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
@@ -179,7 +179,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const supportStrategies = $('[data-qa=support-strategy-summary-list-row]')
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
     expect(supportStrategies.length).toEqual(1)
     expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
     expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)
@@ -204,7 +204,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const supportStrategies = $('[data-qa=support-strategy-summary-list-row]')
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
     expect(supportStrategies.length).toEqual(1)
     expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
     expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
@@ -228,7 +228,7 @@ describe('Profile support strategies page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const supportStrategies = $('[data-qa=support-strategy-summary-list-row]')
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
     expect(supportStrategies.length).toEqual(1)
     expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
     expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)


### PR DESCRIPTION
Set up the tabbed interface on the Support Strategies page:

<img width="1094" height="1274" alt="Screenshot 2025-11-14 at 14 08 46" src="https://github.com/user-attachments/assets/d7c30ba5-b8e6-4353-9e0d-dab3d61d9077" />
