### PR TITLE
RR-2081 - Parse and render multiple stakeholder referrals

### DIFF
--- a/integration_tests/mockApis/curiousApi.ts
+++ b/integration_tests/mockApis/curiousApi.ts
@@ -83,7 +83,7 @@ const stubGetCuriousV2Assessments = (
                 assessmentDate: '2025-10-01',
                 assessmentOutcome: 'Yes',
                 hasPrisonerConsent: 'Yes',
-                stakeholderReferral: 'Education Specialist',
+                stakeholderReferral: 'Education Specialist, Other',
               },
             ],
             esol: null,

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -252,7 +252,7 @@ declare module 'dto' {
   export interface CuriousAlnAssessmentDto {
     prisonId: string
     assessmentDate: Date
-    referral: AlnAssessmentReferral
+    referral: Array<AlnAssessmentReferral>
     supportPlanRequired: boolean // TODO - come up with a better name. This is Curious' view on whether a support plan is required, not ours. It does not account for whether the prisoner is in education and/or has other needs
   }
 

--- a/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.test.ts
+++ b/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.test.ts
@@ -70,7 +70,7 @@ describe('curiousAlnAndLddAssessmentsDtoMapper', () => {
           aCuriousAlnAssessmentDto({
             prisonId: 'MDI',
             assessmentDate: startOfDay('2025-10-01'),
-            referral: AlnAssessmentReferral.EDUCATION_SPECIALIST,
+            referral: [AlnAssessmentReferral.EDUCATION_SPECIALIST],
             supportPlanRequired: true,
           }),
         ],
@@ -265,14 +265,18 @@ describe('curiousAlnAndLddAssessmentsDtoMapper', () => {
 
   describe('Curious V2 ALN assessment mappings', () => {
     it.each([
-      { curiousValue: 'Healthcare', expected: AlnAssessmentReferral.HEALTHCARE },
-      { curiousValue: 'Psychology', expected: AlnAssessmentReferral.PSYCHOLOGY },
-      { curiousValue: 'Education Specialist', expected: AlnAssessmentReferral.EDUCATION_SPECIALIST },
-      { curiousValue: 'NSM', expected: AlnAssessmentReferral.NSM },
-      { curiousValue: 'Substance Misuse Team', expected: AlnAssessmentReferral.SUBSTANCE_MISUSE_TEAM },
-      { curiousValue: 'Safer Custody', expected: AlnAssessmentReferral.SAFER_CUSTODY },
-      { curiousValue: 'Other', expected: AlnAssessmentReferral.OTHER },
-      { curiousValue: null, expected: undefined },
+      { curiousValue: 'Healthcare', expected: [AlnAssessmentReferral.HEALTHCARE] },
+      { curiousValue: 'Psychology', expected: [AlnAssessmentReferral.PSYCHOLOGY] },
+      { curiousValue: 'Education Specialist', expected: [AlnAssessmentReferral.EDUCATION_SPECIALIST] },
+      { curiousValue: 'NSM', expected: [AlnAssessmentReferral.NSM] },
+      { curiousValue: 'Substance Misuse Team', expected: [AlnAssessmentReferral.SUBSTANCE_MISUSE_TEAM] },
+      { curiousValue: 'Safer Custody', expected: [AlnAssessmentReferral.SAFER_CUSTODY] },
+      { curiousValue: 'Other', expected: [AlnAssessmentReferral.OTHER] },
+      {
+        curiousValue: 'NSM, Other, Healthcare',
+        expected: [AlnAssessmentReferral.NSM, AlnAssessmentReferral.OTHER, AlnAssessmentReferral.HEALTHCARE],
+      },
+      { curiousValue: null, expected: [] },
     ] as Array<{
       curiousValue:
         | 'Healthcare'
@@ -282,7 +286,7 @@ describe('curiousAlnAndLddAssessmentsDtoMapper', () => {
         | 'Substance Misuse Team'
         | 'Safer Custody'
         | 'Other'
-      expected: AlnAssessmentReferral
+      expected: Array<AlnAssessmentReferral>
     }>)(
       'should correctly map Curious stakeholder referral value "$curiousValue" to "$expected"',
       ({ curiousValue, expected }) => {

--- a/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.ts
+++ b/server/data/mappers/curiousAlnAndLddAssessmentsDtoMapper.ts
@@ -36,7 +36,9 @@ const toCuriousLddAssessmentDtos = (apiResponse: LearnerLatestAssessmentV1DTO): 
 const toCuriousAlnAssessmentDto = (curiousV2AlnAssessment: LearnerAssessmentsAlnDTO): CuriousAlnAssessmentDto => ({
   prisonId: curiousV2AlnAssessment.establishmentId,
   assessmentDate: parseISO(curiousV2AlnAssessment.assessmentDate),
-  referral: toAlnAssessmentReferral(curiousV2AlnAssessment.stakeholderReferral),
+  referral: curiousV2AlnAssessment.stakeholderReferral
+    ? curiousV2AlnAssessment.stakeholderReferral.split(',').map(toAlnAssessmentReferral)
+    : [],
   supportPlanRequired: curiousV2AlnAssessment.assessmentOutcome?.toLowerCase().trim() === 'yes',
 })
 

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -83,7 +83,7 @@ describe('curiousService', () => {
           aCuriousAlnAssessmentDto({
             prisonId: 'MDI',
             assessmentDate: startOfDay('2025-10-01'),
-            referral: AlnAssessmentReferral.EDUCATION_SPECIALIST,
+            referral: [AlnAssessmentReferral.EDUCATION_SPECIALIST],
             supportPlanRequired: true,
           }),
         ],

--- a/server/testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder.ts
+++ b/server/testsupport/curiousAlnAndLddAssessmentsDtoTestDataBuilder.ts
@@ -33,12 +33,12 @@ const aCuriousLddAssessmentDto = (options?: {
 const aCuriousAlnAssessmentDto = (options?: {
   prisonId?: string
   assessmentDate?: Date
-  referral?: AlnAssessmentReferral
+  referral?: Array<AlnAssessmentReferral>
   supportPlanRequired?: boolean
 }): CuriousAlnAssessmentDto => ({
   prisonId: options?.prisonId || 'BXI',
   assessmentDate: options?.assessmentDate || startOfDay('2025-10-02'),
-  referral: options?.referral || AlnAssessmentReferral.PSYCHOLOGY,
+  referral: options?.referral === null ? null : options?.referral || [AlnAssessmentReferral.PSYCHOLOGY],
   supportPlanRequired: options?.supportPlanRequired === false ? false : options?.supportPlanRequired || true,
 })
 

--- a/server/views/pages/profile/overview/components/aln-assessments-details/alnAssessmentsDetails.test.ts
+++ b/server/views/pages/profile/overview/components/aln-assessments-details/alnAssessmentsDetails.test.ts
@@ -43,13 +43,13 @@ describe('Tests for the ALN Assessments Details component', () => {
         aCuriousAlnAssessmentDto({
           prisonId: 'LEI',
           assessmentDate: startOfDay('2024-10-13'),
-          referral: AlnAssessmentReferral.SAFER_CUSTODY,
+          referral: null,
           supportPlanRequired: true,
         }),
         aCuriousAlnAssessmentDto({
           prisonId: 'BXI',
           assessmentDate: startOfDay('2023-01-06'),
-          referral: AlnAssessmentReferral.EDUCATION_SPECIALIST,
+          referral: [AlnAssessmentReferral.SAFER_CUSTODY, AlnAssessmentReferral.EDUCATION_SPECIALIST],
           supportPlanRequired: false,
         }),
       ],
@@ -67,7 +67,7 @@ describe('Tests for the ALN Assessments Details component', () => {
     )
     expect(assessmentAtLeeds.find('[data-qa=assessment-date]').text().trim()).toEqual('13 October 2024')
     expect(assessmentAtLeeds.find('[data-qa=assessment-outcome]').text().trim()).toEqual('Additional needs identified')
-    expect(assessmentAtLeeds.find('[data-qa=assessment-referral]').text().trim()).toEqual('Safer Custody')
+    expect(assessmentAtLeeds.find('[data-qa=assessment-referral]').text().trim()).toEqual('Not recorded in Curious')
 
     const assessmentAtBrixton = $('[data-qa=aln-assessment-from-BXI]')
     expect(assessmentAtBrixton.length).toEqual(1)
@@ -78,7 +78,11 @@ describe('Tests for the ALN Assessments Details component', () => {
     expect(assessmentAtBrixton.find('[data-qa=assessment-outcome]').text().trim()).toEqual(
       'No Additional needs identified',
     )
-    expect(assessmentAtBrixton.find('[data-qa=assessment-referral]').text().trim()).toEqual('Education Specialist')
+    expect(assessmentAtBrixton.find('[data-qa=assessment-referral] li').length).toEqual(2)
+    expect(assessmentAtBrixton.find('[data-qa=assessment-referral] li').eq(0).text().trim()).toEqual('Safer Custody')
+    expect(assessmentAtBrixton.find('[data-qa=assessment-referral] li').eq(1).text().trim()).toEqual(
+      'Education Specialist',
+    )
   })
 
   it('should render the component given prison name lookup does not resolve prisons', () => {
@@ -90,13 +94,13 @@ describe('Tests for the ALN Assessments Details component', () => {
         aCuriousAlnAssessmentDto({
           prisonId: 'LEI',
           assessmentDate: startOfDay('2024-10-13'),
-          referral: AlnAssessmentReferral.SAFER_CUSTODY,
+          referral: [AlnAssessmentReferral.SAFER_CUSTODY],
           supportPlanRequired: true,
         }),
         aCuriousAlnAssessmentDto({
           prisonId: 'BXI',
           assessmentDate: startOfDay('2023-01-06'),
-          referral: AlnAssessmentReferral.EDUCATION_SPECIALIST,
+          referral: [AlnAssessmentReferral.EDUCATION_SPECIALIST],
           supportPlanRequired: false,
         }),
       ],

--- a/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
+++ b/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
@@ -43,7 +43,15 @@
               Referred to
             </dt>
             <dd class="govuk-summary-list__value" data-qa="assessment-referral">
-              {{ alnAssessment.referral | formatAlnAssessmentReferralScreenValue | default('Not recorded in Curious') }}
+              {% if alnAssessment.referral | length %}
+                <ul class="govuk-list">
+                  {% for referral in alnAssessment.referral %}
+                    <li>{{ referral | formatAlnAssessmentReferralScreenValue }}</li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                Not recorded in Curious
+              {% endif %}
             </dd>
           </div>
         </dl>


### PR DESCRIPTION
PR to parse and process the `stakeholderReferral` field from Curious as multiple values.

MN have made a change where they now use this field to communicate multiple values as a comma delimited string. This PR parses that list into an array and renders the array as a list on screen.

<img width="799" height="1259" alt="Screenshot 2025-11-27 at 15 37 44" src="https://github.com/user-attachments/assets/12b60606-1522-489e-a896-de77e17b4a82" />


## Supporting info from email conversation with MN
> The field type is remaining to be '**string**', and the API response will be **comma-space-delimited**
> <img width="781" height="448" alt="image" src="https://github.com/user-attachments/assets/d64db903-04e7-40e7-ac0d-ae8472dcd53e" />
