### PR TITLE
RR-2047 - Add feature toggle; basic changes to layout to add Edit button

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ Features can be toggled by setting the relevant environment variable.
 |--------------------------|---------------|----------|-----------------------------------------------------------------------------------------------------------------|
 | SOME_TOGGLE_ENABLED      | false         | Boolean  | Example feature toggle, for demonstration purposes.                                                             |
 | EDIT_AND_ARCHIVE_ENABLED | false         | Boolean  | Set to true to enable the edit & archive journeys for conditions, strengths, challenges and support strategies. |
+| EDIT_EHCP_ENABLED        | false         | Boolean  | Set to true to enable the edit EHCP functionality.                                                              |

--- a/assets/scss/components/_profile-education-support-plan.scss
+++ b/assets/scss/components/_profile-education-support-plan.scss
@@ -2,6 +2,7 @@
 
   [data-qa="education-support-plan-summary-card"],
   [data-qa="education-support-plan-persons-view-summary-card"],
+  [data-qa="education-support-plan-ehcp-summary-card"],
   [data-qa="declined-education-support-plan-summary-card"] {
     dt, dd {
       display: block;
@@ -11,6 +12,12 @@
       margin: 0;
       padding: 0;
       @include govuk-responsive-padding(2, 'top');
+    }
+  }
+
+  [data-qa="education-support-plan-ehcp-summary-card"] {
+    dd:last-of-type {
+      display: table-cell;
     }
   }
 

--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -52,6 +52,7 @@ generic-service:
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
     SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
     EDIT_AND_ARCHIVE_ENABLED: true
+    EDIT_EHCP_ENABLED: false
 
     # Comma delimited list of prison IDs that our service is rolled out into (active agencies)
     # Use spaces to aid readability if necessary; these are trimmed when the environment variable is read and processed.

--- a/server/config.ts
+++ b/server/config.ts
@@ -149,5 +149,6 @@ export default {
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
     editAndArchiveEnabled: toBoolean(get('EDIT_AND_ARCHIVE_ENABLED', false, requiredInProduction)),
+    editEhcpEnabled: toBoolean(get('EDIT_EHCP_ENABLED', false, requiredInProduction)),
   },
 }

--- a/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlan.njk
+++ b/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlan.njk
@@ -58,6 +58,24 @@
         </dd>
       </div>
 
+      {% if not featureToggles.editEhcpEnabled %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Current EHCP
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="education-health-care-plan">
+            {{ educationSupportPlan.hasCurrentEhcp | formatYesNo }}
+          </dd>
+        </div>
+      {% endif %}
+    </dl>
+  </div>
+</div>
+
+{% if featureToggles.editEhcpEnabled %}
+<div class="govuk-summary-card" data-qa="education-support-plan-ehcp-summary-card">
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Current EHCP
@@ -65,10 +83,18 @@
         <dd class="govuk-summary-list__value" data-qa="education-health-care-plan">
           {{ educationSupportPlan.hasCurrentEhcp | formatYesNo }}
         </dd>
+
+        <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+          <a class="govuk-link" href="" data-qa="ehcp-change-link">
+            Edit<span class="govuk-visually-hidden"> whdther the prisoner has an EHCP or not</span>
+          </a>
+        </dd>
+
       </div>
     </dl>
   </div>
 </div>
+{% endif %}
 
 {% if planHasNotBeenReviewed %}
   {# Only display the Prisoner's view on support needed, and ELSP Creation Audit fields if the ELSP has not been reviewed #}


### PR DESCRIPTION
Addition of feature toggle for the "edit EHCP feature" (disabled in all envs), and the basic layout change to display the Edit link (non functional at the moment) if the feature toggle is enabled.

### With toggle disabled (current layout)
<img width="1220" height="1120" alt="Screenshot 2025-12-05 at 09 32 12" src="https://github.com/user-attachments/assets/8e0bc723-212a-4c9e-a1cb-b2775f57aa28" />

### With toggle enabled (new layout with Edit button)
<img width="1195" height="1190" alt="Screenshot 2025-12-05 at 09 31 38" src="https://github.com/user-attachments/assets/27902fb9-369a-449f-b046-6ddf90e6a579" />
