### PR TITLE
RR-2142 - Auth changes to support requests for content-fragments; started to flesh out the route and controller

### DIFF
--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -15,10 +15,14 @@ export default function setUpCurrentUser(services: Services): Router {
       const {
         name,
         user_id: userId,
+        user_name: username,
+        auth_source: authSource,
         authorities: roles = [],
       } = jwtDecode(res.locals.user.token) as {
         name?: string
         user_id?: string
+        user_name?: string
+        auth_source?: 'nomis' | 'delius' | 'external' | 'azuread'
         authorities?: string[]
       }
 
@@ -26,6 +30,8 @@ export default function setUpCurrentUser(services: Services): Router {
         ...res.locals.user,
         userId,
         name,
+        authSource: authSource as never,
+        username,
         displayName: convertToTitleCase(name),
         userRoles: roles.map(role => role.substring(role.indexOf('_') + 1)),
       }

--- a/server/routes/content-fragments/additional-needs/additionalNeedsContentFragmentController.ts
+++ b/server/routes/content-fragments/additional-needs/additionalNeedsContentFragmentController.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express'
+import toGroupedStrengthsPromise from '../../utils/groupedStrengthsMapper'
+import toGroupedChallengesPromise from '../../utils/groupedChallengesMapper'
+import toGroupedSupportStrategiesPromise from '../../utils/groupedSupportStrategiesMapper'
+
+export default class AdditionalNeedsContentFragmentController {
+  getAdditionalNeedsContentFragment = async (req: Request, res: Response, next: NextFunction) => {
+    const { alnScreeners, conditions, challenges, strengths, supportStrategies } = res.locals
+
+    const groupedStrengthsPromise = toGroupedStrengthsPromise({
+      strengths,
+      alnScreeners,
+      active: true,
+    })
+    const groupedChallengesPromise = toGroupedChallengesPromise({ challenges, alnScreeners, active: true })
+    const supportStrategiesPromise = toGroupedSupportStrategiesPromise({ supportStrategies, active: true })
+
+    const viewRenderArgs = {
+      conditions,
+      groupedStrengths: groupedStrengthsPromise,
+      groupedChallenges: groupedChallengesPromise,
+      groupedSupportStrategies: supportStrategiesPromise,
+    }
+    return res.render('content-fragments/additional-needs/index', viewRenderArgs)
+  }
+}

--- a/server/routes/content-fragments/additional-needs/index.ts
+++ b/server/routes/content-fragments/additional-needs/index.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express'
+import { Services } from '../../../services'
+import retrieveAlnScreeners from '../../middleware/retrieveAlnScreeners'
+import retrieveConditions from '../../middleware/retrieveConditions'
+import retrieveStrengths from '../../middleware/retrieveStrengths'
+import retrieveChallenges from '../../middleware/retrieveChallenges'
+import retrieveSupportStrategies from '../../middleware/retrieveSupportStrategies'
+import AdditionalNeedsContentFragmentController from './additionalNeedsContentFragmentController'
+import asyncMiddleware from '../../../middleware/asyncMiddleware'
+
+const additionalNeedsContentFragmentRoutes = (services: Services): Router => {
+  const {
+    additionalLearningNeedsService,
+    challengeService,
+    conditionService,
+    strengthService,
+    supportStrategyService,
+  } = services
+  const router = Router({ mergeParams: true })
+
+  const additionalNeedsContentFragmentController = new AdditionalNeedsContentFragmentController()
+
+  router.get('/', [
+    retrieveAlnScreeners(additionalLearningNeedsService),
+    retrieveConditions(conditionService),
+    retrieveStrengths(strengthService),
+    retrieveChallenges(challengeService),
+    retrieveSupportStrategies(supportStrategyService),
+    asyncMiddleware(additionalNeedsContentFragmentController.getAdditionalNeedsContentFragment),
+  ])
+
+  return router
+}
+
+export default additionalNeedsContentFragmentRoutes

--- a/server/views/content-fragments/additional-needs/index.njk
+++ b/server/views/content-fragments/additional-needs/index.njk
@@ -1,0 +1,3 @@
+<section id="san-additional-needs-content-fragment">
+  <p class="govuk-body>">Additional needs overview</p>
+</section>


### PR DESCRIPTION
This PR updates how the auth token is handled and processed for the content-fragment routes

The auth token is on the `x-user-token` header, and as well as verifying it (as previously committed), we also need to setup `req.user` and `res.locals.user`; and also call the middleware to setup the current user inc getting roles and caseloads etc. This is already handled for us by passport and similar for "normal" use cases where the auth token is a bearer token on the `authorisation` header, but because we are using a different header we need to re-implement and setup calls to middleware for some of this.

The reason we need to do this is because once authenticated and the route & controller method are invoked, we will need to do things such as calling APIs to get the prisoner, the prisoner's conditions, the prisoner's strengths etc etc.
All calls to APIs use the authenticated username (`req.user.username`) - so this needs to be populated.
And any request for prisoner data needs to run through the middleware to check they are in one of the user's caseloads; therefore we need the caseloads and the activecaseloadId etc.

As this ticket progresses we are likely to apply some RBAC style checks over some of it, so with that in mind we also need the user's roles.

---

The other thing this PR does is start to flesh out the route, controller and initial nunjucks template
