### PR TITLE
RR-2142 - Flesh out nunjucks template

### DIFF
--- a/server/filters/dedupeArrayFilter.test.ts
+++ b/server/filters/dedupeArrayFilter.test.ts
@@ -1,0 +1,16 @@
+import dedupeArrayFilter from './dedupeArrayFilter'
+
+describe('dedupeArrayFilter', () => {
+  it('should dedupe the specified array', () => {
+    // Given
+    const arrayOfThings = ['thing4', 'thing1', 'thing2', 'thing3', 'thing1', 'thing2', 'thing3']
+
+    const expected = ['thing4', 'thing1', 'thing2', 'thing3']
+
+    // When
+    const actual = dedupeArrayFilter(arrayOfThings)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/filters/dedupeArrayFilter.ts
+++ b/server/filters/dedupeArrayFilter.ts
@@ -1,0 +1,6 @@
+/**
+ * Simple nunjucks filter to dedupe the specified array.
+ */
+export default function dedupeArrayFilter(array: unknown[]) {
+  return [...new Set(array)]
+}

--- a/server/filters/mapPropertyFromArrayFilter.test.ts
+++ b/server/filters/mapPropertyFromArrayFilter.test.ts
@@ -1,0 +1,20 @@
+import mapPropertyFromArrayFilter from './mapPropertyFromArrayFilter'
+
+describe('mapPropertyFromArrayFilter', () => {
+  it('should map an array returning the specified property', () => {
+    // Given
+    const arrayOfThings = [
+      { name: 'thing1', value: 'value1', active: true },
+      { name: 'thing2', value: 'value2', active: false },
+      { name: 'thing3', value: 'value3', active: true },
+    ]
+
+    const expected = ['thing1', 'thing2', 'thing3']
+
+    // When
+    const actual = mapPropertyFromArrayFilter(arrayOfThings, 'name')
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/filters/mapPropertyFromArrayFilter.ts
+++ b/server/filters/mapPropertyFromArrayFilter.ts
@@ -1,0 +1,7 @@
+/**
+ * Simple nunjucks filter to map an array by returning the specified property. It returns the value of the specified
+ * property name; it does not support passing a mapping function to be evaluated on each iteration.
+ */
+export default function mapPropertyFromArrayFilter(array: unknown[], property: string) {
+  return (array as never[]).map(item => item[property])
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,6 +32,8 @@ import {
 import challengeStaffSupportTextLookupFilter from '../filters/challengeStaffSupportTextLookupFilter'
 import formatAlnAssessmentReferralScreenValueFilter from '../filters/formatAlnAssessmentReferralFilter'
 import formatChallengeIdentificationSourceScreenValueFilter from '../filters/formatChallengeIdentificationSourceFilter'
+import dedupeArrayFilter from '../filters/dedupeArrayFilter'
+import mapPropertyFromArrayFilter from '../filters/mapPropertyFromArrayFilter'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -87,6 +89,8 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('formatSupportStrategyTypeScreenValue', formatSupportStrategyTypeScreenValueFilter)
   njkEnv.addFilter('formatSupportStrategyTypeHintText', formatSupportStrategyTypeHintTextFilter)
   njkEnv.addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
+  njkEnv.addFilter('dedupeArray', dedupeArrayFilter)
+  njkEnv.addFilter('mapPropertyFromArray', mapPropertyFromArrayFilter)
   njkEnv.addFilter('challengeSupportTextLookup', challengeStaffSupportTextLookupFilter)
   njkEnv.addFilter('formatAlnAssessmentReferralScreenValue', formatAlnAssessmentReferralScreenValueFilter)
 

--- a/server/views/content-fragments/additional-needs/index.njk
+++ b/server/views/content-fragments/additional-needs/index.njk
@@ -1,3 +1,62 @@
 <section id="san-additional-needs-content-fragment">
-  <p class="govuk-body>">Additional needs overview</p>
+
+  {% if additionalNeedsFactors.isFulfilled() %}
+
+    {% set conditions = additionalNeedsFactors.value.conditions | filterArrayOnProperty('active', true) %}
+    {% set challenges = additionalNeedsFactors.value.challenges | filterArrayOnProperty('active', true) | filterArrayOnProperty('fromALNScreener', false) %}
+    {% set supportStrategies = additionalNeedsFactors.value.supportStrategies | filterArrayOnProperty('active', true) %}
+
+    {% if conditions.length or challenges.length or supportStrategies.length %}
+      <section data-qa="additional-needs-factors">
+        {# List all Condition types, deduped and sorted alphabetically #}
+        <h2 class="govuk-heading-s>">Conditions</h2>
+        {% if conditions.length %}
+          {% set conditionTypes = conditions | mapPropertyFromArray('conditionTypeCode') | dedupeArray | sort %}
+          <ul class="govuk-list govuk-list--bullet" data-qa="conditions-list">
+            {% for conditionType in conditionTypes %}
+              <li>{{ conditionType | formatConditionTypeScreenValue }}</li>
+            {% endfor %}
+          </ul>
+
+        {% else %}
+          <p class="govuk-body" data-qa="no-conditions-message">No conditions recorded yet.</p>
+        {% endif %}
+
+
+        {# List support needs (challenge and support strategy categories combined) #}
+        <h2 class="govuk-heading-s>">Needs support with</h2>
+        {% if challenges.length or supportStrategies.length %}
+          {% set challegeCategories = challenges | mapPropertyFromArray('challengeCategory') %}
+          {% set supportStrategyCategories = supportStrategies | mapPropertyFromArray('supportStrategyCategory') %}
+          {% set supportNeedCategories = challegeCategories.concat(supportStrategyCategories) | dedupeArray | sort %}
+          <ul class="govuk-list" data-qa="support-needs-list">
+            {% for supportNeedCategory in supportNeedCategories %}
+              <li>{{ supportNeedCategory | formatChallengeCategoryScreenValue }}</li>
+            {% endfor %}
+          </ul>
+
+        {% else %}
+          <p class="govuk-body" data-qa="no-support-needs-message">No support strategies or challenges recorded yet.</p>
+        {% endif %}
+
+        <a href="{{ serviceUrl }}/profile/{{ prisonerSummary.prisonNumber }}/overview" class="govuk-link" target="_blank">
+          View details in the Support for additional needs service.
+        </a>
+      </section>
+
+    {% else %}
+      <p class="govuk-body" data-qa="no-additional-needs-factors-message">
+        No support strategies, challenges or conditions recorded yet.<br/>
+        You can add them and
+        <a href="{{ serviceUrl }}/profile/{{ prisonerSummary.prisonNumber }}/overview" class="govuk-link" target="_blank">
+          view additional learning needs screener results in the Support for additional needs service.
+        </a>
+      </p>
+    {% endif %}
+
+  {% else %}
+    <h2 class="govuk-heading-s" data-qa="additional-needs-factors-unavailable-message">We cannot show these details right now</h2>
+    <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+  {% endif %}
+
 </section>

--- a/server/views/content-fragments/additional-needs/index.test.ts
+++ b/server/views/content-fragments/additional-needs/index.test.ts
@@ -1,0 +1,281 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../utils/result/result'
+import anAdditionalNeedsFactorsDto from '../../../testsupport/additionalNeedsFactorsDtoTestDataBuilder'
+import filterArrayOnPropertyFilter from '../../../filters/filterArrayOnPropertyFilter'
+import dedupeArrayFilter from '../../../filters/dedupeArrayFilter'
+import mapPropertyFromArrayFilter from '../../../filters/mapPropertyFromArrayFilter'
+import { aValidConditionDto } from '../../../testsupport/conditionDtoTestDataBuilder'
+import ConditionType from '../../../enums/conditionType'
+import formatConditionTypeScreenValueFilter from '../../../filters/formatConditionTypeFilter'
+import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
+import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+import ChallengeCategory from '../../../enums/challengeCategory'
+import SupportStrategyCategory from '../../../enums/supportStrategyCategory'
+import formatChallengeCategoryScreenValueFilter from '../../../filters/formatChallengeCategoryFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
+  .addFilter('dedupeArray', dedupeArrayFilter)
+  .addFilter('mapPropertyFromArray', mapPropertyFromArrayFilter)
+  .addFilter('formatConditionTypeScreenValue', formatConditionTypeScreenValueFilter)
+  .addFilter('formatChallengeCategoryScreenValue', formatChallengeCategoryScreenValueFilter)
+
+const prisonerSummary = aValidPrisonerSummary({ prisonNumber: 'A1234BC' })
+const template = 'index.njk'
+
+const templateParams = {
+  prisonerSummary,
+  additionalNeedsFactors: Result.fulfilled(anAdditionalNeedsFactorsDto()),
+  serviceUrl: 'http://localhost:3000',
+}
+
+describe('Additional Needs content fragment tests', () => {
+  describe('render conditions', () => {
+    it('should render conditions message given Additional Needs Factors has active conditions', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({
+          ...anAdditionalNeedsFactorsDto(),
+          conditions: [
+            aValidConditionDto({ active: false, conditionTypeCode: ConditionType.ABI }), // Not active so not expected to be rendered
+            aValidConditionDto({ active: true, conditionTypeCode: ConditionType.DYSLEXIA }),
+            aValidConditionDto({ active: true, conditionTypeCode: ConditionType.ADHD }),
+            aValidConditionDto({ active: false, conditionTypeCode: ConditionType.DYSLEXIA }), // Not active so not expected to be rendered
+            aValidConditionDto({ active: false, conditionTypeCode: ConditionType.FASD }), // Not active so not expected to be rendered
+            aValidConditionDto({ active: true, conditionTypeCode: ConditionType.LD_OTHER }),
+            aValidConditionDto({ active: true, conditionTypeCode: ConditionType.DYSLEXIA }),
+          ],
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-conditions-message]').length).toEqual(0)
+      expect($('[data-qa=conditions-list] li').length).toEqual(3)
+      expect($('[data-qa=conditions-list] li').eq(0).text().trim()).toEqual(
+        'Attention deficit hyperactivity disorder (ADHD or ADD)',
+      )
+      expect($('[data-qa=conditions-list] li').eq(1).text().trim()).toEqual('Dyslexia')
+      expect($('[data-qa=conditions-list] li').eq(2).text().trim()).toEqual('Learning disabilities')
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+
+    it('should render no conditions message given Additional Needs Factors has no conditions at all', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({ ...anAdditionalNeedsFactorsDto(), conditions: [] }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-conditions-message]').length).toEqual(1)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+
+    it('should render no conditions message given Additional Needs Factors has no active conditions', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({
+          ...anAdditionalNeedsFactorsDto(),
+          conditions: [aValidConditionDto({ active: false })],
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-conditions-message]').length).toEqual(1)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+  })
+
+  describe('render support needs', () => {
+    it('should render conditions message given Additional Needs Factors has active challenges and active support strategies', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({
+          ...anAdditionalNeedsFactorsDto(),
+          challenges: [
+            aValidChallengeResponseDto({
+              active: false, // Not active so not expected to be rendered
+              challengeCategory: ChallengeCategory.MEMORY,
+              fromALNScreener: false,
+            }),
+            aValidChallengeResponseDto({
+              active: true,
+              challengeCategory: ChallengeCategory.SENSORY,
+              fromALNScreener: false,
+            }),
+            aValidChallengeResponseDto({
+              active: true,
+              challengeCategory: ChallengeCategory.EMOTIONS_FEELINGS,
+              fromALNScreener: false,
+            }),
+            aValidChallengeResponseDto({
+              active: true,
+              challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+              fromALNScreener: false,
+            }),
+            aValidChallengeResponseDto({
+              active: true,
+              challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+              fromALNScreener: false,
+            }),
+            aValidChallengeResponseDto({
+              active: true,
+              challengeCategory: ChallengeCategory.ATTENTION_ORGANISING_TIME,
+              fromALNScreener: true, // From the ALN screener so not expected to be rendered
+            }),
+          ],
+          supportStrategies: [
+            aValidSupportStrategyResponseDto({
+              active: false, // Not active so not expected to be rendered
+              supportStrategyCategory: SupportStrategyCategory.SENSORY,
+            }),
+            aValidSupportStrategyResponseDto({
+              active: true,
+              supportStrategyCategory: SupportStrategyCategory.EMOTIONS_FEELINGS,
+            }),
+            aValidSupportStrategyResponseDto({
+              active: true,
+              supportStrategyCategory: SupportStrategyCategory.NUMERACY_SKILLS,
+            }),
+            aValidSupportStrategyResponseDto({
+              active: true,
+              supportStrategyCategory: SupportStrategyCategory.MEMORY,
+            }),
+          ],
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-conditions-message]').length).toEqual(0)
+      expect($('[data-qa=support-needs-list] li').length).toEqual(5)
+      expect($('[data-qa=support-needs-list] li').eq(0).text().trim()).toEqual('Emotions and feelings')
+      expect($('[data-qa=support-needs-list] li').eq(1).text().trim()).toEqual('Literacy skills')
+      expect($('[data-qa=support-needs-list] li').eq(2).text().trim()).toEqual('Memory')
+      expect($('[data-qa=support-needs-list] li').eq(3).text().trim()).toEqual('Numeracy skills')
+      expect($('[data-qa=support-needs-list] li').eq(4).text().trim()).toEqual('Sensory')
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+
+    it('should render no support needs message given Additional Needs Factors has no challenges and no support strategies at all', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({
+          ...anAdditionalNeedsFactorsDto(),
+          challenges: [],
+          supportStrategies: [],
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-support-needs-message]').length).toEqual(1)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+
+    it('should render no support needs message given Additional Needs Factors has no active challenges and no active support strategies', () => {
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled({
+          ...anAdditionalNeedsFactorsDto(),
+          challenges: [aValidChallengeResponseDto({ active: false })],
+          supportStrategies: [aValidSupportStrategyResponseDto({ active: false })],
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(1)
+      expect($('[data-qa=no-support-needs-message]').length).toEqual(1)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+  })
+
+  describe('empty/error states', () => {
+    it('should render the content fragment given the prisoner has no Additional Needs Factors', () => {
+      // Given
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.fulfilled(
+          anAdditionalNeedsFactorsDto({
+            conditions: [],
+            challenges: [],
+            supportStrategies: [],
+          }),
+        ),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(0)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(1)
+      expect($('[data-qa=no-additional-needs-factors-message] a').attr('href')).toEqual(
+        'http://localhost:3000/profile/A1234BC/overview',
+      )
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(0)
+    })
+
+    it('should render the content fragment given the Additional Needs service API promise is not resolved', () => {
+      // Given
+      const params = {
+        ...templateParams,
+        additionalNeedsFactors: Result.rejected(new Error('Failed to get challenges')),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('[data-qa=additional-needs-factors]').length).toEqual(0)
+      expect($('[data-qa=no-additional-needs-factors-message]').length).toEqual(0)
+      expect($('[data-qa=additional-needs-factors-unavailable-message]').length).toEqual(1)
+    })
+  })
+})


### PR DESCRIPTION
PR to flesh out the nunjucks for the Additional Needs content fragment.

It's difficult to visualise because it is meant to return a raw HTML markup fragment that is meant to be injected into other content (ie. the modal in Prisoner Profile), but this is what the raw response in postman looks like:
<img width="1137" height="1279" alt="Screenshot 2025-12-18 at 11 35 20" src="https://github.com/user-attachments/assets/fb51b1f3-a2fc-4802-827c-61e0d30af13c" />

and if that content were to be rendered in a browser (albeit without the surrounding modal and css that the page page would bring in) it looks like this:
<img width="1150" height="578" alt="Screenshot 2025-12-18 at 11 35 31" src="https://github.com/user-attachments/assets/ec0c0d5c-0172-4de1-96ed-6c7b91e84c98" />

