### PR TITLE
RR-2128 / RR-2136 - Update journeys for both Create and Review ESP

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Features can be toggled by setting the relevant environment variable.
 | SOME_TOGGLE_ENABLED      | false         | Boolean  | Example feature toggle, for demonstration purposes.                                                             |
 | EDIT_AND_ARCHIVE_ENABLED | false         | Boolean  | Set to true to enable the edit & archive journeys for conditions, strengths, challenges and support strategies. |
 | EDIT_EHCP_ENABLED        | false         | Boolean  | Set to true to enable the edit EHCP functionality.                                                              |
-| NEW_EHCP_JOURNEY_ENABLED | false         | Boolean  | Set to true to enable the new EHCP journey.                                                                     |
+| NEW_ESP_JOURNEY_ENABLED  | false         | Boolean  | Set to true to enable the new ESP journey.                                                                      |
 

--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -53,7 +53,7 @@ generic-service:
     SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
     EDIT_AND_ARCHIVE_ENABLED: true
     EDIT_EHCP_ENABLED: false
-    NEW_EHCP_JOURNEY_ENABLED: false
+    NEW_ESP_JOURNEY_ENABLED: false
 
     # Comma delimited list of prison IDs that our service is rolled out into (active agencies)
     # Use spaces to aid readability if necessary; these are trimmed when the environment variable is read and processed.

--- a/server/config.ts
+++ b/server/config.ts
@@ -150,6 +150,6 @@ export default {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
     editAndArchiveEnabled: toBoolean(get('EDIT_AND_ARCHIVE_ENABLED', false, requiredInProduction)),
     editEhcpEnabled: toBoolean(get('EDIT_EHCP_ENABLED', false, requiredInProduction)),
-    newEhcpJourneyEnabled: toBoolean(get('NEW_EHCP_JOURNEY_ENABLED', false, requiredInProduction)),
+    newEspJourneyEnabled: toBoolean(get('NEW_ESP_JOURNEY_ENABLED', false, requiredInProduction)),
   },
 }

--- a/server/routes/education-support-plan/create/index.ts
+++ b/server/routes/education-support-plan/create/index.ts
@@ -44,6 +44,7 @@ import retrieveConditions from '../../middleware/retrieveConditions'
 import retrieveChallenges from '../../middleware/retrieveChallenges'
 import retrieveSupportStrategies from '../../middleware/retrieveSupportStrategies'
 import reviewExistingNeedsSchema from '../validationSchemas/reviewExistingNeedsSchema'
+import config from '../../../config'
 
 const createEducationSupportPlanRoutes = (services: Services): Router => {
   const {
@@ -86,8 +87,8 @@ const createEducationSupportPlanRoutes = (services: Services): Router => {
 
   router.get('/:journeyId/start', [
     createEmptyEducationSupportPlanDtoIfNotInJourneyData,
-    async (_req: Request, res: Response) => {
-      return res.redirect('who-created-the-plan')
+    async (req: Request, res: Response) => {
+      return res.redirect(config.featureToggles.newEspJourneyEnabled ? 'review-existing-needs' : 'who-created-the-plan')
     },
   ])
 

--- a/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedController.ts
+++ b/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { EducationSupportPlanDto } from 'dto'
 import YesNoValue from '../../../../enums/yesNoValue'
+import config from '../../../../config'
 
 export default class OtherPeopleConsultedController {
   getOtherPeopleConsultedView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -27,6 +28,14 @@ export default class OtherPeopleConsultedController {
       }
       // The answer has been changed to Yes/true, so we need to redirect the user to the screens allowing them to add people
       return res.redirect('other-people-consulted/add-person?submitToCheckAnswers=true')
+    }
+
+    if (config.featureToggles.newEspJourneyEnabled) {
+      return res.redirect(
+        wereOtherPeopleConsultedForm.wereOtherPeopleConsulted === YesNoValue.NO
+          ? 'individual-support-requirements'
+          : 'other-people-consulted/add-person',
+      )
     }
 
     return res.redirect(

--- a/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.ts
+++ b/server/routes/education-support-plan/create/other-people-consulted/otherPeopleConsultedListController.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import config from '../../../../config'
 
 export default class OtherPeopleConsultedListController {
   getOtherPeopleConsultedListView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -24,6 +25,12 @@ export default class OtherPeopleConsultedListController {
         numberOfPeopleOnDto >= 1
           ? `list${submitToCheckYourAnswersQueryString}`
           : `../other-people-consulted${submitToCheckYourAnswersQueryString}`,
+      )
+    }
+
+    if (config.featureToggles.newEspJourneyEnabled) {
+      return res.redirect(
+        req.query?.submitToCheckAnswers !== 'true' ? '../individual-support-requirements' : '../check-your-answers',
       )
     }
 

--- a/server/routes/education-support-plan/create/review-existing-needs/reviewExistingNeedsController.ts
+++ b/server/routes/education-support-plan/create/review-existing-needs/reviewExistingNeedsController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { EducationSupportPlanDto } from 'dto'
 import YesNoValue from '../../../../enums/yesNoValue'
+import config from '../../../../config'
 
 export default class ReviewExistingNeedsController {
   getReviewExistingNeedsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -16,6 +17,10 @@ export default class ReviewExistingNeedsController {
   submitReviewExistingNeedsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
     const reviewExistingNeedsForm = { ...req.body }
     this.updateDtoFromForm(req, reviewExistingNeedsForm)
+
+    if (config.featureToggles.newEspJourneyEnabled) {
+      return res.redirect('who-created-the-plan')
+    }
 
     return res.redirect(
       reviewExistingNeedsForm.reviewExistingNeeds === YesNoValue.NO

--- a/server/routes/education-support-plan/review/index.ts
+++ b/server/routes/education-support-plan/review/index.ts
@@ -46,6 +46,7 @@ import LearningNeedsSupportPractitionerSupportController from './learning-needs-
 import AdditionalInformationController from './additional-information/additionalInformationController'
 import ReviewSupportPlanController from './review-support-plan/reviewSupportPlanController'
 import CheckYourAnswersController from './check-your-answers/checkYourAnswersController'
+import config from '../../../config'
 
 const reviewEducationSupportPlanRoutes = (services: Services): Router => {
   const {
@@ -83,15 +84,17 @@ const reviewEducationSupportPlanRoutes = (services: Services): Router => {
 
   router.use('/', [
     checkUserHasPermissionTo(ApplicationAction.REVIEW_EDUCATION_LEARNER_SUPPORT_PLAN),
-    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/education-support-plan/:prisonNumber/review' - eg: '/education-support-plan/A1234BC/review/473e9ee4-37d6-4afb-92a2-5729b10cc60f/who-created-the-plan'
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/education-support-plan/:prisonNumber/review' - eg: '/education-support-plan/A1234BC/review/473e9ee4-37d6-4afb-92a2-5729b10cc60f/who-reviewed-the-plan'
   ])
   router.use('/:journeyId', [setupJourneyData(journeyDataService)])
 
   router.get('/:journeyId/start', [
     retrieveEducationSupportPlan(educationSupportPlanService),
     createEmptyReviewEducationSupportPlanDtoIfNotInJourneyData,
-    async (_req: Request, res: Response) => {
-      return res.redirect('who-reviewed-the-plan')
+    async (req: Request, res: Response) => {
+      return res.redirect(
+        config.featureToggles.newEspJourneyEnabled ? 'review-existing-needs' : 'who-reviewed-the-plan',
+      )
     },
   ])
 

--- a/server/routes/education-support-plan/review/review-existing-needs/reviewExistingNeedsController.ts
+++ b/server/routes/education-support-plan/review/review-existing-needs/reviewExistingNeedsController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { ReviewEducationSupportPlanDto } from 'dto'
 import YesNoValue from '../../../../enums/yesNoValue'
+import config from '../../../../config'
 
 export default class ReviewExistingNeedsController {
   getReviewExistingNeedsView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -16,6 +17,10 @@ export default class ReviewExistingNeedsController {
   submitReviewExistingNeedsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
     const reviewExistingNeedsForm = { ...req.body }
     this.updateDtoFromForm(req, reviewExistingNeedsForm)
+
+    if (config.featureToggles.newEspJourneyEnabled) {
+      return res.redirect('who-reviewed-the-plan')
+    }
 
     return res.redirect(
       reviewExistingNeedsForm.reviewExistingNeeds === YesNoValue.NO

--- a/server/routes/education-support-plan/review/reviewers-view-on-progress/reviewersViewOnProgressController.ts
+++ b/server/routes/education-support-plan/review/reviewers-view-on-progress/reviewersViewOnProgressController.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { ReviewEducationSupportPlanDto } from 'dto'
+import config from '../../../../config'
 
 export default class ReviewersViewOnProgressController {
   getReviewersViewOnProgressView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -21,6 +22,10 @@ export default class ReviewersViewOnProgressController {
   submitReviewersViewOnProgressForm: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
     const reviewersViewOnProgressForm = { ...req.body }
     this.updateDtoFromForm(req, reviewersViewOnProgressForm)
+
+    if (config.featureToggles.newEspJourneyEnabled) {
+      return res.redirect(req.query?.submitToCheckAnswers !== 'true' ? 'teaching-adjustments' : 'check-your-answers')
+    }
 
     return res.redirect(req.query?.submitToCheckAnswers !== 'true' ? 'review-existing-needs' : 'check-your-answers')
   }

--- a/server/routes/education-support-plan/validationSchemas/reviewExistingNeedsSchema.ts
+++ b/server/routes/education-support-plan/validationSchemas/reviewExistingNeedsSchema.ts
@@ -1,18 +1,17 @@
 import { z } from 'zod'
 import { createSchema } from '../../../middleware/validationMiddleware'
 import YesNoValue from '../../../enums/yesNoValue'
+import config from '../../../config'
 
 const reviewExistingNeedsSchema =
   (options: { journey: 'create' | 'review' } = { journey: 'create' }) =>
   async () => {
     const messages = {
       create: {
-        reviewExistingNeedsMandatoryMessage:
-          'Select whether you would like to review strengths, challenges and support needs before creating the plan',
+        reviewExistingNeedsMandatoryMessage: `${config.featureToggles.newEspJourneyEnabled ? 'You must review' : 'Select whether you would like to review'} strengths, challenges and support needs before creating the plan`,
       },
       review: {
-        reviewExistingNeedsMandatoryMessage:
-          'Select if you want to review challenges, strengths, conditions and support strategies before reviewing the education support plan',
+        reviewExistingNeedsMandatoryMessage: `${config.featureToggles.newEspJourneyEnabled ? 'You must review' : 'Select if you want to review'} challenges, strengths, conditions and support strategies before reviewing the education support plan`,
       },
     }
 

--- a/server/views/pages/education-support-plan/review-existing-needs/index.njk
+++ b/server/views/pages/education-support-plan/review-existing-needs/index.njk
@@ -11,29 +11,56 @@
         <div class="govuk-form-group">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-          {{ govukRadios({
-            name: "reviewExistingNeeds",
-            fieldset: {
-              legend: {
-                text: "Do you want to review " + prisonerSummary | formatFirst_name_Last_name + "'s challenges, strengths and support strategies before " + ("reviewing the" if mode == 'review' else "creating an") + " education support plan?",
-                isPageHeading: true,
-                classes: "govuk-fieldset__legend--l"
-              }
-            },
-            items: [
-              {
-                value: "YES",
-                text: "Yes",
-                checked: form.reviewExistingNeeds === "YES"
+          {% if featureToggles.newEspJourneyEnabled %}
+            {{ govukCheckboxes({
+              name: "reviewExistingNeeds",
+              fieldset: {
+                legend: {
+                  text: "You must review " + prisonerSummary | formatFirst_name_Last_name + "'s support strategies, challenges, strengths and conditions",
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l"
+                }
               },
-              {
-                value: "NO",
-                text: "No, we have already reviewed them",
-                checked: form.reviewExistingNeeds === "NO"
-              }
-            ],
-            errorMessage: errors | findError('reviewExistingNeeds')
-          }) }}
+              hint: {
+                html: '<a href="/profile/' + prisonerSummary.prisonNumber + '/overview" target="_blank" class="govuk-link">Review and update their support strategies, challenges, strengths and conditions (opens in a new tab).</a>',
+                classes: 'govuk-!-margin-top-3 govuk-!-margin-bottom-6'
+              },
+              items: [
+                {
+                  value: "YES",
+                  text: "I have reviewed these",
+                  checked: form.reviewExistingNeeds === "YES"
+                }
+              ],
+              errorMessage: errors | findError('reviewExistingNeeds')
+            }) }}
+          {% else %}
+
+
+            {{ govukRadios({
+              name: "reviewExistingNeeds",
+              fieldset: {
+                legend: {
+                  text: "Do you want to review " + prisonerSummary | formatFirst_name_Last_name + "'s challenges, strengths and support strategies before " + ("reviewing the" if mode == 'review' else "creating an") + " education support plan?",
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l"
+                }
+              },
+              items: [
+                {
+                  value: "YES",
+                  text: "Yes",
+                  checked: form.reviewExistingNeeds === "YES"
+                },
+                {
+                  value: "NO",
+                  text: "No, we have already reviewed them",
+                  checked: form.reviewExistingNeeds === "NO"
+                }
+              ],
+              errorMessage: errors | findError('reviewExistingNeeds')
+            }) }}
+          {% endif %}
         </div>
 
         {{ govukButton({


### PR DESCRIPTION
PR to update the journeys for both Create and Review ESP so that they start with the "have you reviewed all the stuff" page

The eature toggle is still disabled in all envs, and I've not done the cypress test changes yet. I'll enable in dev and do the cypress tests in my next PR 👍 
The video below is on my local dev environment where I have manually set the feature toggle to on 👍 


https://github.com/user-attachments/assets/56533608-d62b-46ad-a6fc-e7a2e994898d

