### PR TITLE
RR-2234 - correct typo

### DIFF
--- a/server/views/pages/profile/overview/components/aln-assessments-details/alnAssessmentsDetails.test.ts
+++ b/server/views/pages/profile/overview/components/aln-assessments-details/alnAssessmentsDetails.test.ts
@@ -76,7 +76,7 @@ describe('Tests for the ALN Assessments Details component', () => {
     )
     expect(assessmentAtBrixton.find('[data-qa=assessment-date]').text().trim()).toEqual('6 January 2023')
     expect(assessmentAtBrixton.find('[data-qa=assessment-outcome]').text().trim()).toEqual(
-      'No Additional needs identified',
+      'No additional needs identified',
     )
     expect(assessmentAtBrixton.find('[data-qa=assessment-referral] li').length).toEqual(2)
     expect(assessmentAtBrixton.find('[data-qa=assessment-referral] li').eq(0).text().trim()).toEqual('Safer Custody')

--- a/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
+++ b/server/views/pages/profile/overview/components/aln-assessments-details/template.njk
@@ -35,7 +35,7 @@
               Assessment outcome
             </dt>
             <dd class="govuk-summary-list__value" data-qa="assessment-outcome">
-              {{ 'Additional needs identified' if alnAssessment.supportPlanRequired else ' No Additional needs identified' }}
+              {{ 'Additional needs identified' if alnAssessment.supportPlanRequired else 'No additional needs identified' }}
             </dd>
           </div>
           <div class="govuk-summary-list__row">


### PR DESCRIPTION
PR to correct small typo (‘No Additional needs identified’ to ‘No additional needs identified’)