### PR TITLE
RR-2500 - Display learner's initial view on support in ESP reviews

### DIFF
--- a/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.njk
+++ b/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.njk
@@ -2,6 +2,7 @@
 
 {% set educationSupportPlanReviews = params.educationSupportPlanReviews %}
 {% set prisonerSummary = params.prisonerSummary %}
+{% set educationSupportPlan = params.educationSupportPlan %}
 
 {% if educationSupportPlanReviews.length > 0 %}
   {% set reviewsSortedByDate = educationSupportPlanReviews | sort(attribute = 'createdAt', reverse = true) %}
@@ -28,6 +29,18 @@
           html: previousPrisonerViewsOnProgress
         }) }}
       {% endif %}
+      {% set learnersInitialViewOnSupportNeeded %}
+        <ul class="govuk-list">
+          <li>
+            <p class="govuk-body app-u-multiline-text govuk-!-margin-bottom-2">{{ educationSupportPlan.individualSupport | default('None', true) }}</p>
+            <p class="govuk-hint">Added {{ educationSupportPlan.createdAt | formatDate('d MMM yyyy') }}</p>
+          </li>
+        </ul>
+      {% endset %}
+      {{ govukDetails({
+        summaryText: "Learner's initial view on support needed",
+        html: learnersInitialViewOnSupportNeeded
+      }) }}
     </div>
   </div>
 

--- a/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.test.njk
+++ b/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.test.njk
@@ -2,5 +2,6 @@
 
 {{ renderEducationSupportPlanReviews({
   prisonerSummary: prisonerSummary,
-  educationSupportPlanReviews: educationSupportPlanReviews
+  educationSupportPlanReviews: educationSupportPlanReviews,
+  educationSupportPlan: educationSupportPlan
 }) }}

--- a/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.test.ts
+++ b/server/views/pages/profile/education-support-plan/components/renderEducationSupportPlanReviews.test.ts
@@ -4,6 +4,7 @@ import { startOfDay } from 'date-fns'
 import type { ReviewEducationSupportPlanDto } from 'dto'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidReviewEducationSupportPlanDto from '../../../../../testsupport/reviewEducationSupportPlanDtoTestDataBuilder'
+import aValidEducationSupportPlanDto from '../../../../../testsupport/educationSupportPlanDtoTestDataBuilder'
 import formatDate from '../../../../../filters/formatDateFilter'
 import formatPrisonerNameFilter, { NameFormat } from '../../../../../filters/formatPrisonerNameFilter'
 
@@ -27,6 +28,10 @@ const template = 'renderEducationSupportPlanReviews.test.njk'
 const templateParams = {
   prisonerSummary,
   educationSupportPlanReviews: [aValidReviewEducationSupportPlanDto()],
+  educationSupportPlan: aValidEducationSupportPlanDto({
+    individualSupport: 'Headphones to help him with noise.',
+    createdAt: startOfDay('2025-04-10'),
+  }),
 }
 
 describe('Education Support Plan Reviews component', () => {
@@ -52,7 +57,8 @@ describe('Education Support Plan Reviews component', () => {
       expect(summaryCard.find('p').eq(0).text().trim()).toEqual(
         'Chris is pleased with his progress and is enthusiastic about his future',
       )
-      expect(summaryCard.find('li').length).toEqual(0)
+      // 1 li for the learner's initial view on support needed (no previous review li items as there is only one review)
+      expect(summaryCard.find('li').length).toEqual(1)
     })
 
     it('should render the Education Support Plan Reviews component given several reviews', () => {
@@ -88,7 +94,8 @@ describe('Education Support Plan Reviews component', () => {
       expect(summaryCard.find('p').eq(0).text().trim()).toEqual(
         'Chris is pleased with his progress and is enthusiastic about his future',
       )
-      expect(summaryCard.find('li').length).toEqual(3)
+      // 3 previous review li items + 1 learner's initial view li item
+      expect(summaryCard.find('li').length).toEqual(4)
       expect(summaryCard.find('li').eq(0).find('p').eq(0).text().trim()).toEqual('He feels he is making basic progress')
       expect(summaryCard.find('li').eq(0).find('p').eq(1).text().trim()).toEqual('Added 3 Oct 2025')
       expect(summaryCard.find('li').eq(1).find('p').eq(0).text().trim()).toEqual('Prisoner refused review')
@@ -97,6 +104,68 @@ describe('Education Support Plan Reviews component', () => {
         'Chris feels that he is not sure if he is making progress',
       )
       expect(summaryCard.find('li').eq(2).find('p').eq(1).text().trim()).toEqual('Added 3 Aug 2025')
+    })
+
+    it("should render the Learner's initial view on support needed collapsible given one review", () => {
+      // Given
+      const params = {
+        ...templateParams,
+        educationSupportPlanReviews: [
+          aValidReviewEducationSupportPlanDto({
+            prisonerViewOnProgress: 'Chris is pleased with his progress',
+            createdAt: startOfDay('2025-11-03'),
+          }),
+        ],
+        educationSupportPlan: aValidEducationSupportPlanDto({
+          individualSupport: 'Headphones to help him with noise.',
+          createdAt: startOfDay('2025-04-10'),
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      const summaryCard = $('[data-qa=education-support-plan-review-individuals-view-on-progress-summary-card]')
+      const detailsSummaries = summaryCard.find('.govuk-details__summary-text')
+      expect(detailsSummaries.length).toEqual(1)
+      expect(detailsSummaries.eq(0).text().trim()).toEqual("Learner's initial view on support needed")
+      const detailsContent = summaryCard.find('.govuk-details__text').eq(0)
+      expect(detailsContent.find('p').eq(0).text().trim()).toEqual('Headphones to help him with noise.')
+      expect(detailsContent.find('p').eq(1).text().trim()).toEqual('Added 10 Apr 2025')
+    })
+
+    it("should render the Learner's initial view on support needed collapsible alongside previous views given several reviews", () => {
+      // Given
+      const params = {
+        ...templateParams,
+        educationSupportPlanReviews: [
+          aValidReviewEducationSupportPlanDto({
+            prisonerViewOnProgress: 'First review progress',
+            createdAt: startOfDay('2025-08-03'),
+          }),
+          aValidReviewEducationSupportPlanDto({
+            prisonerViewOnProgress: 'Second review progress',
+            createdAt: startOfDay('2025-11-03'),
+          }),
+        ],
+        educationSupportPlan: aValidEducationSupportPlanDto({
+          individualSupport: 'Headphones to help him with noise.',
+          createdAt: startOfDay('2025-04-10'),
+        }),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      const summaryCard = $('[data-qa=education-support-plan-review-individuals-view-on-progress-summary-card]')
+      const detailsSummaries = summaryCard.find('.govuk-details__summary-text')
+      expect(detailsSummaries.length).toEqual(2)
+      expect(detailsSummaries.eq(0).text().trim()).toEqual('Previous views on progress')
+      expect(detailsSummaries.eq(1).text().trim()).toEqual("Learner's initial view on support needed")
     })
   })
 

--- a/server/views/pages/profile/education-support-plan/index.njk
+++ b/server/views/pages/profile/education-support-plan/index.njk
@@ -52,7 +52,8 @@
 
             {{ renderEducationSupportPlanReviews({
               prisonerSummary: prisonerSummary,
-              educationSupportPlanReviews: educationSupportPlanReviews
+              educationSupportPlanReviews: educationSupportPlanReviews,
+              educationSupportPlan: educationSupportPlan
             }) }}
 
           {% else %}

--- a/server/views/pages/profile/education-support-plan/index.test.ts
+++ b/server/views/pages/profile/education-support-plan/index.test.ts
@@ -193,6 +193,38 @@ describe('Profile education support plan page', () => {
       expect($('[data-qa=elsp-unavailable-message]').length).toEqual(0)
       expect($('[data-qa=api-error-banner]').length).toEqual(0)
     })
+
+    it("should render the Learner's initial view on support needed collapsible within the prisoner's view on progress card", () => {
+      // Given
+      const params = {
+        ...templateParams,
+        educationSupportPlan: Result.fulfilled(
+          aValidEducationSupportPlanDto({
+            individualSupport: 'Headphones to help him with noise.',
+            createdAt: startOfDay('2025-04-10'),
+          }),
+        ),
+        educationSupportPlanReviews: Result.fulfilled([
+          aValidReviewEducationSupportPlanDto({
+            prisonerViewOnProgress: 'Chris is pleased with his progress',
+            createdAt: startOfDay('2025-11-03'),
+          }),
+        ]),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      const summaryCard = $('[data-qa=education-support-plan-review-individuals-view-on-progress-summary-card]')
+      expect(summaryCard.length).toEqual(1)
+      const detailsSummaries = summaryCard.find('.govuk-details__summary-text')
+      expect(detailsSummaries.last().text().trim()).toEqual("Learner's initial view on support needed")
+      const detailsContent = summaryCard.find('.govuk-details__text').last()
+      expect(detailsContent.find('p').eq(0).text().trim()).toEqual('Headphones to help him with noise.')
+      expect(detailsContent.find('p').eq(1).text().trim()).toEqual('Added 10 Apr 2025')
+    })
   })
 
   it('should render the profile education support plan page given the prisoner has an ELSP but the lifecycle status is INACTIVE_PLAN', () => {


### PR DESCRIPTION
Adds a collapsible section to the Education Support Plan reviews component to display the prisoner's initial support requirements and the date they were recorded. This provides context for the initial plan alongside subsequent progress reviews.
