### PR TITLE
RR-2576 - Add feature toggle for SAN data deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ A changelog for the service is available [here](./CHANGELOG.md)
 ## Feature Toggles
 Features can be toggled by setting the relevant environment variable.
 
-| Name                    | Default Value | Type     | Description                                             |
-|-------------------------|---------------|----------|---------------------------------------------------------|
-| SOME_TOGGLE_ENABLED     | false         | Boolean  | Example feature toggle, for demonstration purposes.     |
-| DPR_REPORT_ENABLED      | false         | Boolean  | Set to true to enable the link to the DPR reporting UI. |
+| Name                              | Default Value | Type     | Description                                                                                                                                                                                |
+|-----------------------------------|---------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SOME_TOGGLE_ENABLED               | false         | Boolean  | Example feature toggle, for demonstration purposes.                                                                                                                                        |
+| DPR_REPORT_ENABLED                | false         | Boolean  | Set to true to enable the link to the DPR reporting UI.                                                                                                                                    |
+| SAN_DATA_DELETION_FEATURE_ENABLED | false         | Boolean  | Set to true to enable the SAN data-deletion journeys (delete challenges/strengths/conditions/support strategies/screener results). Must remain false in prod until stakeholder comms ready. |
 

--- a/feature.env
+++ b/feature.env
@@ -25,3 +25,4 @@ DPR_UI_REPORT_URL=https://digital-prison-reporting-mi-ui-dev.hmpps.service.justi
 ACTIVE_AGENCIES=***
 
 DPR_REPORT_ENABLED=true
+SAN_DATA_DELETION_FEATURE_ENABLED=true

--- a/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-ui/values.yaml
@@ -52,6 +52,7 @@ generic-service:
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
     SEARCH_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
     DPR_REPORT_ENABLED: true
+    SAN_DATA_DELETION_FEATURE_ENABLED: false
 
     # Comma delimited list of prison IDs that our service is rolled out into (active agencies)
     # Use spaces to aid readability if necessary; these are trimmed when the environment variable is read and processed.

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,6 +28,7 @@ generic-service:
     NEW_DPS_URL: 'https://dps-dev.prison.service.justice.gov.uk'
     COMPONENT_API_URL: 'https://frontend-components-dev.hmpps.service.justice.gov.uk'
     DPR_UI_REPORT_URL: 'https://digital-prison-reporting-mi-ui-dev.hmpps.service.justice.gov.uk/dpr/request-report/report/san001/san-additional-needs-report/filters'
+    SAN_DATA_DELETION_FEATURE_ENABLED: true
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32

--- a/server/config.ts
+++ b/server/config.ts
@@ -150,5 +150,6 @@ export default {
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
     dprReportEnabled: toBoolean(get('DPR_REPORT_ENABLED', false, requiredInProduction)),
+    sanDataDeletionEnabled: toBoolean(get('SAN_DATA_DELETION_FEATURE_ENABLED', false, requiredInProduction)),
   },
 }


### PR DESCRIPTION
Introduces the `SAN_DATA_DELETION_FEATURE_ENABLED` environment variable and configuration to control the rollout of additional needs data deletion functionality.

This toggle will remain disabled in production until stakeholder communications are complete.