### PR TITLE
Update all mentions of 'strengths' to include 'interests'

### DIFF
--- a/integration_tests/e2e/strengths/archive/archiveStrength.cy.ts
+++ b/integration_tests/e2e/strengths/archive/archiveStrength.cy.ts
@@ -44,7 +44,7 @@ context('Archive a Strength', () => {
 
     // Then
     Page.verifyOnPage(StrengthsPage) //
-      .hasSuccessMessage('Strength moved to History')
+      .hasSuccessMessage('Strength or interest moved to History')
 
     cy.wiremockVerify(
       putRequestedFor(

--- a/integration_tests/e2e/strengths/create/createStrength.cy.ts
+++ b/integration_tests/e2e/strengths/create/createStrength.cy.ts
@@ -50,7 +50,7 @@ context('Create a Strength', () => {
       .submitPageTo(StrengthDetailPage)
 
     Page.verifyOnPage(StrengthDetailPage)
-      .hasPageHeading('Add emotions and feelings strength')
+      .hasPageHeading('Add emotions and feelings strength or interest for Abby Kyriakopoulos')
       // submit the page without answering the question to trigger a validation error
       .submitPageTo(StrengthDetailPage)
       .hasErrorCount(2)
@@ -73,7 +73,7 @@ context('Create a Strength', () => {
 
     // Then
     Page.verifyOnPage(StrengthsPage) //
-      .hasSuccessMessage('Strength added')
+      .hasSuccessMessage('Strength or interest added')
 
     cy.wiremockVerify(
       postRequestedFor(urlEqualTo(`/support-additional-needs-api/profile/${prisonNumber}/strengths`)) //

--- a/integration_tests/e2e/strengths/delete/deleteStrength.cy.ts
+++ b/integration_tests/e2e/strengths/delete/deleteStrength.cy.ts
@@ -52,7 +52,7 @@ context('Delete a Strength (Current tab)', () => {
 
     // Then - verify success banner
     Page.verifyOnPage(StrengthsPage) //
-      .hasSuccessMessage('Strength deleted.')
+      .hasSuccessMessage('Strength or interest deleted')
 
     // And verify the DELETE request was made with the correct query params
     cy.wiremockVerify(

--- a/integration_tests/e2e/strengths/edit/editStrength.cy.ts
+++ b/integration_tests/e2e/strengths/edit/editStrength.cy.ts
@@ -64,7 +64,7 @@ context('Edit a Strength', () => {
 
     // Then
     Page.verifyOnPage(StrengthsPage) //
-      .hasSuccessMessage('Strength updated')
+      .hasSuccessMessage('Strength or interest updated')
 
     cy.wiremockVerify(
       putRequestedFor(

--- a/integration_tests/e2e/strengths/history-delete/deleteHistoryStrength.cy.ts
+++ b/integration_tests/e2e/strengths/history-delete/deleteHistoryStrength.cy.ts
@@ -81,7 +81,7 @@ context('Delete a Strength (History tab)', () => {
 
     // Then - verify success banner
     Page.verifyOnPage(StrengthsPage) //
-      .hasSuccessMessage('History strength deleted.')
+      .hasSuccessMessage('History strength or interest deleted')
 
     // And verify the DELETE request was made with the correct query params
     cy.wiremockVerify(

--- a/integration_tests/pages/profile/overviewPage.ts
+++ b/integration_tests/pages/profile/overviewPage.ts
@@ -40,7 +40,7 @@ export default class OverviewPage extends ProfilePage {
   }
 
   hasNoStrengthsRecorded(): OverviewPage {
-    this.strengthsSummaryCardContent().should('contain', 'No strengths recorded')
+    this.strengthsSummaryCardContent().should('contain', 'No strengths and interests recorded')
     this.strengthsUnavailableMessage().should('not.exist')
     return this
   }

--- a/server/routes/strengths/archive/reason/reasonController.test.ts
+++ b/server/routes/strengths/archive/reason/reasonController.test.ts
@@ -121,7 +121,7 @@ describe('reasonController', () => {
     await controller.submitReasonForm(req, res, next)
 
     // Then
-    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength moved to History')
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength or interest moved to History')
     expect(req.journeyData.strengthDto).toBeUndefined()
     expect(flash).not.toHaveBeenCalled()
     expect(strengthService.archiveStrength).toHaveBeenCalledWith(username, strengthReference, expectedStrengthDto)

--- a/server/routes/strengths/archive/reason/reasonController.ts
+++ b/server/routes/strengths/archive/reason/reasonController.ts
@@ -52,7 +52,10 @@ export default class ReasonController {
     const { prisonNumber } = strengthResponseDto
     req.journeyData.strengthDto = undefined
     this.auditService.logArchiveStrength(this.archiveStrengthAuditData(req, strengthResponseDto)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths#archived-strengths`, 'Strength moved to History')
+    return res.redirectWithSuccess(
+      `/profile/${prisonNumber}/strengths#archived-strengths`,
+      'Strength or interest moved to History',
+    )
   }
 
   private updateDtoFromForm = (req: Request, form: { archiveReason: string }) => {

--- a/server/routes/strengths/create/detail/detailController.test.ts
+++ b/server/routes/strengths/create/detail/detailController.test.ts
@@ -153,7 +153,7 @@ describe('detailController', () => {
     await controller.submitDetailForm(req, res, next)
 
     // Then
-    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength added')
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength or interest added')
     expect(req.journeyData.strengthDto).toBeUndefined()
     expect(flash).not.toHaveBeenCalled()
     expect(strengthService.createStrengths).toHaveBeenCalledWith(username, [expectedStrengthDto])

--- a/server/routes/strengths/create/detail/detailController.ts
+++ b/server/routes/strengths/create/detail/detailController.ts
@@ -49,7 +49,7 @@ export default class DetailController {
     const { prisonNumber } = strengthDto
     req.journeyData.strengthDto = undefined
     this.auditService.logCreateStrength(this.createStrengthAuditData(req)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths`, 'Strength added')
+    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths`, 'Strength or interest added')
   }
 
   private populateFormFromDto = (dto: StrengthDto) => {

--- a/server/routes/strengths/delete/confirm/confirmController.test.ts
+++ b/server/routes/strengths/delete/confirm/confirmController.test.ts
@@ -103,7 +103,7 @@ describe('delete/confirm/confirmController', () => {
           who: username,
         }),
       )
-      expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength deleted.')
+      expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength or interest deleted')
       expect(flash).not.toHaveBeenCalled()
     })
 

--- a/server/routes/strengths/delete/confirm/confirmController.ts
+++ b/server/routes/strengths/delete/confirm/confirmController.ts
@@ -41,7 +41,10 @@ export default class ConfirmController {
 
     req.journeyData.strengthDto = undefined
     this.auditService.logDeleteStrength(this.deleteStrengthAuditData(req, dto))
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths#current-strengths`, 'Strength deleted.')
+    return res.redirectWithSuccess(
+      `/profile/${prisonNumber}/strengths#current-strengths`,
+      'Strength or interest deleted',
+    )
   }
 
   private deleteStrengthAuditData = (req: Request, dto: StrengthResponseDto): BaseAuditData => {

--- a/server/routes/strengths/edit/detail/detailController.test.ts
+++ b/server/routes/strengths/edit/detail/detailController.test.ts
@@ -123,7 +123,7 @@ describe('detailController', () => {
     await controller.submitDetailForm(req, res, next)
 
     // Then
-    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength updated')
+    expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'Strength or interest updated')
     expect(req.journeyData.strengthDto).toBeUndefined()
     expect(flash).not.toHaveBeenCalled()
     expect(strengthService.updateStrength).toHaveBeenCalledWith(username, strengthReference, expectedStrengthDto)

--- a/server/routes/strengths/edit/detail/detailController.ts
+++ b/server/routes/strengths/edit/detail/detailController.ts
@@ -56,7 +56,7 @@ export default class DetailController {
     const { prisonNumber } = strengthResponseDto
     req.journeyData.strengthDto = undefined
     this.auditService.logEditStrength(this.editStrengthsAuditData(req, strengthResponseDto)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths`, 'Strength updated')
+    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths`, 'Strength or interest updated')
   }
 
   private updateDtoFromForm = (

--- a/server/routes/strengths/history-delete/confirm/historyConfirmController.test.ts
+++ b/server/routes/strengths/history-delete/confirm/historyConfirmController.test.ts
@@ -103,7 +103,7 @@ describe('history-delete/confirm/historyConfirmController', () => {
           who: username,
         }),
       )
-      expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'History strength deleted.')
+      expect(res.redirectWithSuccess).toHaveBeenCalledWith(expectedNextRoute, 'History strength or interest deleted')
       expect(flash).not.toHaveBeenCalled()
     })
 

--- a/server/routes/strengths/history-delete/confirm/historyConfirmController.ts
+++ b/server/routes/strengths/history-delete/confirm/historyConfirmController.ts
@@ -41,7 +41,10 @@ export default class HistoryConfirmController {
 
     req.journeyData.strengthDto = undefined
     this.auditService.logDeleteStrength(this.deleteStrengthAuditData(req, dto))
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/strengths#archived-strengths`, 'History strength deleted.')
+    return res.redirectWithSuccess(
+      `/profile/${prisonNumber}/strengths#archived-strengths`,
+      'History strength or interest deleted',
+    )
   }
 
   private deleteStrengthAuditData = (req: Request, dto: StrengthResponseDto): BaseAuditData => {

--- a/server/routes/strengths/validationSchemas/archiveReasonSchema.test.ts
+++ b/server/routes/strengths/validationSchemas/archiveReasonSchema.test.ts
@@ -52,7 +52,7 @@ describe('archiveReasonSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#archiveReason',
-        text: 'Add reason for moving this strength to the History',
+        text: 'Add reason for moving this strength or interest to the History',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)
@@ -78,7 +78,7 @@ describe('archiveReasonSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#archiveReason',
-        text: 'Reason for moving this strength to the History must be 4000 characters or less',
+        text: 'Reason for moving this strength or interest to the History must be 4000 characters or less',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)

--- a/server/routes/strengths/validationSchemas/archiveReasonSchema.ts
+++ b/server/routes/strengths/validationSchemas/archiveReasonSchema.ts
@@ -4,8 +4,8 @@ import { createSchema } from '../../../middleware/validationMiddleware'
 const archiveReasonSchema = async () => {
   const ARCHIVE_REASON_MAX_LENGTH = 4000
 
-  const archiveReasonMandatoryMessage = 'Add reason for moving this strength to the History'
-  const archiveReasonMaxLengthMessage = `Reason for moving this strength to the History must be ${ARCHIVE_REASON_MAX_LENGTH} characters or less`
+  const archiveReasonMandatoryMessage = 'Add reason for moving this strength or interest to the History'
+  const archiveReasonMaxLengthMessage = `Reason for moving this strength or interest to the History must be ${ARCHIVE_REASON_MAX_LENGTH} characters or less`
 
   return createSchema({
     archiveReason: z //

--- a/server/routes/strengths/validationSchemas/deleteReasonSchema.test.ts
+++ b/server/routes/strengths/validationSchemas/deleteReasonSchema.test.ts
@@ -61,7 +61,7 @@ describe('deleteReasonSchema', () => {
         const expectedErrors: Array<Error> = [
           {
             href: '#deleteReason',
-            text: 'Add reason for deleting strength',
+            text: 'Add reason for deleting strength or interest',
           },
         ]
         const expectedInvalidForm = JSON.stringify(requestBody)
@@ -88,7 +88,7 @@ describe('deleteReasonSchema', () => {
       const expectedErrors: Array<Error> = [
         {
           href: '#deleteReason',
-          text: 'Add reason for deleting strength',
+          text: 'Add reason for deleting strength or interest',
         },
       ]
 
@@ -113,7 +113,7 @@ describe('deleteReasonSchema', () => {
       const expectedErrors: Array<Error> = [
         {
           href: '#deleteReason',
-          text: 'Add reason for deleting history strength',
+          text: 'Add reason for deleting history strength or interest',
         },
       ]
 

--- a/server/routes/strengths/validationSchemas/deleteReasonSchema.ts
+++ b/server/routes/strengths/validationSchemas/deleteReasonSchema.ts
@@ -6,8 +6,8 @@ const deleteReasonSchema =
   (options: { mode: 'active' | 'history' } = { mode: 'active' }) =>
   async () => {
     const messages = {
-      active: { mandatoryMessage: 'Add reason for deleting strength' },
-      history: { mandatoryMessage: 'Add reason for deleting history strength' },
+      active: { mandatoryMessage: 'Add reason for deleting strength or interest' },
+      history: { mandatoryMessage: 'Add reason for deleting history strength or interest' },
     }
 
     return createSchema({

--- a/server/routes/strengths/validationSchemas/detailSchema.test.ts
+++ b/server/routes/strengths/validationSchemas/detailSchema.test.ts
@@ -81,7 +81,7 @@ describe('detailSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#description',
-        text: 'Enter a description of the strength',
+        text: 'Enter a description of the strength or interest',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)
@@ -111,7 +111,7 @@ describe('detailSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#description',
-        text: 'Description of the strength must be 4000 characters or less',
+        text: 'Description of the strength or interest must be 4000 characters or less',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)
@@ -150,7 +150,7 @@ describe('detailSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#howIdentified',
-        text: 'Select at least one option for how this strength was identified',
+        text: 'Select at least one option for how this strength or interest was identified',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)
@@ -191,7 +191,7 @@ describe('detailSchema', () => {
       const expectedErrors: Array<Error> = [
         {
           href: '#howIdentifiedOther',
-          text: 'Enter details of how this strength was identified',
+          text: 'Enter details of how this strength or interest was identified',
         },
       ]
       const expectedInvalidForm = JSON.stringify(requestBody)
@@ -222,7 +222,7 @@ describe('detailSchema', () => {
     const expectedErrors: Array<Error> = [
       {
         href: '#howIdentifiedOther',
-        text: 'How this strength was identified must be 200 characters or less',
+        text: 'How this strength or interest was identified must be 200 characters or less',
       },
     ]
     const expectedInvalidForm = JSON.stringify(requestBody)

--- a/server/routes/strengths/validationSchemas/detailSchema.ts
+++ b/server/routes/strengths/validationSchemas/detailSchema.ts
@@ -8,11 +8,11 @@ const detailSchema = async () => {
   const DETAIL_MAX_LENGTH = 4000
   const HOW_IDENTIFIED_OTHER_MAX_LENGTH = 200
 
-  const detailMandatoryMessage = 'Enter a description of the strength'
-  const detailMaxLengthMessage = `Description of the strength must be ${DETAIL_MAX_LENGTH} characters or less`
-  const howIdentifiedMandatoryMessage = 'Select at least one option for how this strength was identified'
-  const howIdentifiedOtherMandatoryMessage = 'Enter details of how this strength was identified'
-  const howIdentifiedOtherMaxLengthMessage = `How this strength was identified must be ${HOW_IDENTIFIED_OTHER_MAX_LENGTH} characters or less`
+  const detailMandatoryMessage = 'Enter a description of the strength or interest'
+  const detailMaxLengthMessage = `Description of the strength or interest must be ${DETAIL_MAX_LENGTH} characters or less`
+  const howIdentifiedMandatoryMessage = 'Select at least one option for how this strength or interest was identified'
+  const howIdentifiedOtherMandatoryMessage = 'Enter details of how this strength or interest was identified'
+  const howIdentifiedOtherMaxLengthMessage = `How this strength or interest was identified must be ${HOW_IDENTIFIED_OTHER_MAX_LENGTH} characters or less`
 
   return createSchema({
     description: z //

--- a/server/views/pages/profile/components/actions-card/template.njk
+++ b/server/views/pages/profile/components/actions-card/template.njk
@@ -147,7 +147,7 @@
         {% if userHasPermissionTo('RECORD_STRENGTHS') %}
           <li>
             <a class="govuk-link" data-qa="add-strength-button" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">
-              Add strengths
+              Add strengths and interests
             </a>
           </li>
         {% endif %}

--- a/server/views/pages/profile/layout.njk
+++ b/server/views/pages/profile/layout.njk
@@ -71,7 +71,7 @@
                {% if tab === 'strengths' -%} aria-current="page" {% endif %}
                href="strengths"
             >
-              Strengths
+              Strengths and interests
             </a>
           </li>
           <li class="moj-sub-navigation__item">

--- a/server/views/pages/profile/overview/_strengthsSummaryCard.njk
+++ b/server/views/pages/profile/overview/_strengthsSummaryCard.njk
@@ -7,18 +7,18 @@
 
 <div class="govuk-summary-card" data-qa="strengths-summary-card">
   <div class="govuk-summary-card__title-wrapper">
-    <h2 class="govuk-summary-card__title">Strengths</h2>
+    <h2 class="govuk-summary-card__title">Strengths and interests</h2>
     <ul class="govuk-summary-card__actions govuk-!-display-none-print">
       {% if groupedStrengths.isFulfilled() %}
         {% if categories.length === 0 %}
           {% if userHasPermissionTo('RECORD_STRENGTHS') %}
             <li class="govuk-summary-card__action">
-              <a class="govuk-link govuk-!-font-weight-regular" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category" data-qa="add-strength-button">Add strengths</a>
+              <a class="govuk-link govuk-!-font-weight-regular" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category" data-qa="add-strength-button">Add strengths and interests</a>
             </li>
           {% endif %}
         {% else %}
           <li class="govuk-summary-card__action">
-            <a class="govuk-link govuk-!-font-weight-regular" href="/profile/{{ prisonerSummary.prisonNumber }}/strengths" data-qa="view-strengths-button">View strengths</a>
+            <a class="govuk-link govuk-!-font-weight-regular" href="/profile/{{ prisonerSummary.prisonNumber }}/strengths" data-qa="view-strengths-button">View strengths and interests</a>
           </li>
         {% endif %}
       {% endif %}
@@ -36,7 +36,7 @@
         </ul>
       {% else %}
           <p class="govuk-body" data-qa="no-strengths-recorded-message">
-            No strengths recorded
+            No strengths and interests recorded
           </p>
       {% endif %}
 

--- a/server/views/pages/profile/strengths/index.njk
+++ b/server/views/pages/profile/strengths/index.njk
@@ -4,12 +4,12 @@
 {% from "../../../components/strengths-summary-card/macro.njk" import strengthsSummaryCard %}
 
 {% set pageId = 'profile-strengths' %}
-{% set pageTitle = "Support for additional needs - Strengths" %}
+{% set pageTitle = "Support for additional needs - Strengths and interests" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m">Strengths</h2>
+      <h2 class="govuk-heading-m">Strengths and interests</h2>
     </div>
   </div>
 
@@ -45,14 +45,14 @@
 
           {% else %}
             <p class="govuk-body" data-qa="no-active-strengths-message">
-              {{ prisonerSummary | formatFirst_name_Last_name }} has no current strengths.
+              {{ prisonerSummary | formatFirst_name_Last_name }} has no current strengths or interests.
             </p>
           {% endif %}
 
           <p class="govuk-body">
             {% if userHasPermissionTo('RECORD_STRENGTHS') %}
               <a class="govuk-link govuk-!-display-none-print" href="/strengths/{{ prisonerSummary.prisonNumber }}/create/select-category">
-                Add a strength
+                Add a strength or interest
               </a>
             {% endif %}
           </p>
@@ -76,7 +76,7 @@
 
           {% else %}
             <p class="govuk-body" data-qa="no-archived-strengths-message">
-              {{ prisonerSummary | formatFirst_name_Last_name }} has no previous strengths.
+              {{ prisonerSummary | formatFirst_name_Last_name }} has no previous strengths or interests.
             </p>
           {% endif %}
         {% endset %}

--- a/server/views/pages/strengths/delete/confirm/index.njk
+++ b/server/views/pages/strengths/delete/confirm/index.njk
@@ -1,13 +1,14 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'delete-strength-confirm' %}
-{% set pageTitle = 'Delete history strength are you sure' if mode == 'history' else 'Delete strength are you sure' %}
+{% set pageTitle = 'Delete history strength or interest are you sure' if mode == 'history' else 'Delete strength or interest are you sure' %}
+{% set strengthNoun = 'history strength or interest' if mode == 'history' else 'strength or interest' %}
 
 {% set deleteReasonLabel %}
   {% if dto.deleteReason == 'DATA_PROCESSING_OBJECTION' %}
     Prisoner objected to change in data processing
   {% elif dto.deleteReason == 'ENTERED_IN_ERROR' %}
-    {% if mode == 'history' %}History strength{% else %}Strength{% endif %} entered in error
+    {% if mode == 'history' %}History strength or interest{% else %}Strength or interest{% endif %} entered in error
   {% else %}
     {{ dto.deleteReason }}
   {% endif %}
@@ -17,7 +18,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Are you sure you want to delete {{ prisonerSummary | formatFirst_name_Last_name }}'s {% if mode == 'history' %}history {% endif %}strength?</h1>
+      <h1 class="govuk-heading-l">Are you sure you want to delete {{ prisonerSummary | formatFirst_name_Last_name }}'s {{ strengthNoun }}?</h1>
 
       <div class="govuk-summary-card app-summary-card--grey govuk-!-margin-bottom-6" data-qa="delete-reason-summary">
         <div class="govuk-summary-card__content">

--- a/server/views/pages/strengths/delete/reason/index.njk
+++ b/server/views/pages/strengths/delete/reason/index.njk
@@ -1,7 +1,8 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'delete-strength-reason' %}
-{% set pageTitle = 'Delete history strength reason' if mode == 'history' else 'Delete strength reason' %}
+{% set pageTitle = 'Delete history strength or interest reason' if mode == 'history' else 'Delete strength or interest reason' %}
+{% set strengthNoun = 'history strength or interest' if mode == 'history' else 'strength or interest' %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -10,8 +11,8 @@
       <form class="form" method="post" novalidate="">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {% set legendText = "Select a reason for deleting " + (prisonerSummary | formatFirst_name_Last_name) + ("'s history strength" if mode == 'history' else "'s strength") %}
-        {% set enteredInErrorText = "History strength entered in error" if mode == 'history' else "Strength entered in error" %}
+        {% set legendText = "Select a reason for deleting " + (prisonerSummary | formatFirst_name_Last_name) + "'s " + strengthNoun %}
+        {% set enteredInErrorText = ("History strength or interest" if mode == 'history' else "Strength or interest") + " entered in error" %}
         {{ govukRadios({
           name: "deleteReason",
           fieldset: {

--- a/server/views/pages/strengths/delete/review/index.njk
+++ b/server/views/pages/strengths/delete/review/index.njk
@@ -1,13 +1,14 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'delete-strength-review' %}
-{% set pageTitle = 'Delete history strength review' if mode == 'history' else 'Delete strength review' %}
+{% set pageTitle = 'Delete history strength or interest review' if mode == 'history' else 'Delete strength or interest review' %}
+{% set strengthNoun = 'history strength or interest' if mode == 'history' else 'strength or interest' %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Review the {% if mode == 'history' %}history {% endif %}strength for {{ prisonerSummary | formatFirst_name_Last_name }} that you want to delete</h1>
+      <h1 class="govuk-heading-l">Review the {{ strengthNoun }} for {{ prisonerSummary | formatFirst_name_Last_name }} that you want to delete</h1>
 
       <div class="govuk-summary-card app-summary-card--grey govuk-!-margin-bottom-8" data-qa="strength-to-delete-summary">
         <div class="govuk-summary-card__content">

--- a/server/views/pages/strengths/detail/create-journey/index.njk
+++ b/server/views/pages/strengths/detail/create-journey/index.njk
@@ -1,12 +1,12 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'strength-detail' %}
-{% set pageTitle = "Add strength - Add strength category" %}
+{% set pageTitle = "Add strength or interest - Add strength or interest category" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Add {{ category | formatStrengthTypeScreenValue | lower }} strength</h1>
+      <h1 class="govuk-heading-l">Add {{ category | formatStrengthTypeScreenValue | lower }} strength or interest for {{ prisonerSummary | formatFirst_name_Last_name }}</h1>
     </div>
   </div>
 
@@ -24,14 +24,14 @@
             value: form.description,
             type: "text",
             label: {
-              text: "Description of strength",
+              text: "Description of strength or interest",
               classes: "govuk-label--m",
               attributes: { "aria-live": "polite" }
             },
             hint: {
               text: "Note the things they are good at and enjoy."
             },
-            attributes: { "aria-label" : "Enter the description of the strength" },
+            attributes: { "aria-label" : "Enter the description of the strength or interest" },
             errorMessage: errors | findError('description')
           }) }}
 
@@ -46,7 +46,7 @@
                 attributes: { "aria-live": "polite" }
               },
               attributes: {
-                "aria-label" : "Give details as to how this strength was identified"
+                "aria-label" : "Give details as to how this strength or interest was identified"
               },
               errorMessage: errors | findError('howIdentifiedOther')
             }) }}
@@ -56,7 +56,7 @@
             name: "howIdentified",
             fieldset: {
               legend: {
-                text: "How was this strength identified?",
+                text: "How was this strength or interest identified?",
                 classes: "govuk-fieldset__legend--m"
               }
             },
@@ -111,7 +111,7 @@
 
         {{ govukButton({
           id: "submit-button",
-          text: "Add strength",
+          text: "Add strength or interest",
           type: "submit",
           attributes: {"data-qa": "submit-button"},
           preventDoubleClick: true

--- a/server/views/pages/strengths/detail/edit-journey/index.njk
+++ b/server/views/pages/strengths/detail/edit-journey/index.njk
@@ -1,18 +1,18 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'strength-detail' %}
-{% set pageTitle = "Edit strength - Edit strength details" %}
+{% set pageTitle = "Edit strength or interest - Edit strength or interest details" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Edit description of {{ prisonerSummary | formatFirst_name_Last_name }}'s strength</h1>
+      <h1 class="govuk-heading-l">Edit {{ category | formatStrengthTypeScreenValue | lower }} strength or interest for {{ prisonerSummary | formatFirst_name_Last_name }}</h1>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Category of strength</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Category of strength or interest</h2>
       <p class="govuk-body">{{ category | formatStrengthTypeScreenValue }}</p>
 
       <form class="form" method="post" novalidate="">
@@ -26,14 +26,14 @@
             value: form.description,
             type: "text",
             label: {
-              text: "Descripton of strength",
+              text: "Description of strength or interest",
               classes: "govuk-label--m",
               attributes: { "aria-live": "polite" }
             },
             hint: {
               text: "Note the things they are good at and enjoy"
             },
-            attributes: { "aria-label" : "Enter the description of the strength" },
+            attributes: { "aria-label" : "Enter the description of the strength or interest" },
             errorMessage: errors | findError('description')
           }) }}
 
@@ -48,7 +48,7 @@
                 attributes: { "aria-live": "polite" }
               },
               attributes: {
-                "aria-label" : "Give details as to how this strength was identified"
+                "aria-label" : "Give details as to how this strength or interest was identified"
               },
               errorMessage: errors | findError('howIdentifiedOther')
             }) }}
@@ -58,7 +58,7 @@
             name: "howIdentified",
             fieldset: {
               legend: {
-                text: "How was this strength identified?",
+                text: "How was this strength or interest identified?",
                 classes: "govuk-fieldset__legend--m"
               }
             },
@@ -116,7 +116,7 @@
 
         {{ govukButton({
           id: "submit-button",
-          text: "Update strength",
+          text: "Update strength or interest",
           type: "submit",
           attributes: {"data-qa": "submit-button"},
           preventDoubleClick: true

--- a/server/views/pages/strengths/layout.njk
+++ b/server/views/pages/strengths/layout.njk
@@ -10,11 +10,11 @@
   {% if errorRecordingStrength %}
     <div class="hmpps-api-error-banner govuk-!-margin-bottom-4" data-qa="api-error-banner">
       <p>Sorry, there is a problem with the service</p>
-      <p>There was a problem recording the strength. Try again later.</p>
+      <p>There was a problem recording the strength or interest. Try again later.</p>
     </div>
   {% endif %}
 
   {% if not mode == 'archive' %}
-    <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} strength</p>
+    <p class="govuk-body">{{ 'Edit' if mode == 'edit' else 'Add' }} strength or interest</p>
   {% endif %}
 {% endblock %}

--- a/server/views/pages/strengths/reason/archive-journey/index.njk
+++ b/server/views/pages/strengths/reason/archive-journey/index.njk
@@ -1,24 +1,24 @@
 {% extends "../../layout.njk" %}
 
 {% set pageId = 'archive-strength-reason' %}
-{% set pageTitle = "Move strength to history - Move strength to history reason" %}
+{% set pageTitle = "Move strength or interest to history - Move strength or interest to history reason" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Move {{ prisonerSummary | formatFirst_name_Last_name }}'s strength to the History</h1>
+      <h1 class="govuk-heading-l">Move {{ prisonerSummary | formatFirst_name_Last_name }}'s strength or interest to the History</h1>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <p class="govuk-hint">Strengths in the History tab are view only and cannot be reactivated.</p>
+      <p class="govuk-hint">Strengths or interests in the History tab are view only and cannot be reactivated.</p>
 
       {% set insetContent %}
         <h3 class="govuk-heading-m govuk-!-margin-bottom-2">{{ dto.strengthCategory | formatStrengthCategoryScreenValue | default(dto.strengthCategory, true) }}</h3>
         <p class="govuk-body app-u-multiline-text">{{ dto.symptoms }}</p>
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">How was this strength identified?</h2>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">How was this strength or interest identified?</h2>
         <ul class="govuk-list">
           {% for strengthIdentificationSource in dto.howIdentified %}
             <li>{{ strengthIdentificationSource | formatStrengthIdentificationSourceScreenValue if strengthIdentificationSource != 'OTHER' else dto.howIdentifiedOther }}</li>
@@ -47,7 +47,7 @@
             value: form.archiveReason,
             type: "text",
             label: {
-              text: "Add a reason for moving this strength to the History",
+              text: "Add a reason for moving this strength or interest to the History",
               classes: "govuk-label--s",
               attributes: { "aria-live": "polite" }
             },
@@ -59,7 +59,7 @@
 
         {{ govukButton({
           id: "submit-button",
-          text: "Move strength",
+          text: "Move strength or interest",
           type: "submit",
           attributes: {"data-qa": "submit-button"},
           preventDoubleClick: true

--- a/server/views/pages/strengths/select-category/index.njk
+++ b/server/views/pages/strengths/select-category/index.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% set pageId = 'create-strength-select-category' %}
-{% set pageTitle = "Add strength - Select a category" %}
+{% set pageTitle = "Add strength or interest - Select a category" %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -15,7 +15,7 @@
             name: "category",
             fieldset: {
               legend: {
-                text: "Select category",
+                text: "Select a category of strength or interest for " + (prisonerSummary | formatFirst_name_Last_name),
                 isPageHeading: true,
                 classes: "govuk-fieldset__legend--l"
               }


### PR DESCRIPTION
This commit updates user-facing copy across the application, changing references from 'strengths' to 'strengths and interests'.

This includes changes to page titles, headings, success messages, validation messages, and other labels in the Strengths and Interests section of the prisoner profile.
