### PR TITLE
RR-2811 - Call services to get data as part of route

### DIFF
--- a/server/routes/profile/challenges-and-support/challengesAndSupportController.test.ts
+++ b/server/routes/profile/challenges-and-support/challengesAndSupportController.test.ts
@@ -1,0 +1,84 @@
+import { Request, Response } from 'express'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../utils/result/result'
+import { aValidAlnScreenerList } from '../../../testsupport/alnScreenerDtoTestDataBuilder'
+import aPlanLifecycleStatusDto from '../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
+import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
+import ChallengesAndSupportController from './challengesAndSupportController'
+import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+import SupportStrategyType from '../../../enums/supportStrategyType'
+
+describe('challengesAndSupportController', () => {
+  const controller = new ChallengesAndSupportController()
+
+  const prisonerSummary = aValidPrisonerSummary()
+  const challenges = Result.fulfilled([aValidChallengeResponseDto()])
+  const alnScreeners = Result.fulfilled(aValidAlnScreenerList())
+  const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
+  const educationSupportPlanLifecycleStatus = Result.fulfilled(aPlanLifecycleStatusDto())
+  const memorySupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.MEMORY,
+    active: true,
+  })
+  const sensorySupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.SENSORY,
+    active: false,
+  })
+  const supportStrategies = Result.fulfilled([memorySupportStrategy, sensorySupportStrategy])
+
+  const req = {} as unknown as Request
+  const res = {
+    render: jest.fn(),
+    locals: {
+      prisonerSummary,
+      challenges,
+      alnScreeners,
+      supportStrategies,
+      prisonNamesById,
+      educationSupportPlanLifecycleStatus,
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the view', async () => {
+    // Given
+    const expectedViewTemplate = 'pages/profile/challenges-and-support/index'
+    const expectedActiveGroupedSupportStrategies = {
+      MEMORY: [memorySupportStrategy],
+    }
+    const expectedArchivedGroupedSupportStrategies = {
+      SENSORY: [sensorySupportStrategy],
+    }
+
+    const expectedViewModel = {
+      prisonNamesById,
+      prisonerSummary,
+      educationSupportPlanLifecycleStatus,
+      tab: 'challenges-and-support',
+      activeChallenges: expect.objectContaining({
+        status: 'fulfilled',
+      }),
+      archivedChallenges: expect.objectContaining({
+        status: 'fulfilled',
+      }),
+      activeSupportStrategies: expect.objectContaining({
+        status: 'fulfilled',
+        value: expectedActiveGroupedSupportStrategies,
+      }),
+      archivedSupportStrategies: expect.objectContaining({
+        status: 'fulfilled',
+        value: expectedArchivedGroupedSupportStrategies,
+      }),
+    }
+
+    // When
+    await controller.getChallengesAndSupportView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(expectedViewTemplate, expectedViewModel)
+  })
+})

--- a/server/routes/profile/challenges-and-support/challengesAndSupportController.test.ts
+++ b/server/routes/profile/challenges-and-support/challengesAndSupportController.test.ts
@@ -47,31 +47,17 @@ describe('challengesAndSupportController', () => {
   it('should render the view', async () => {
     // Given
     const expectedViewTemplate = 'pages/profile/challenges-and-support/index'
-    const expectedActiveGroupedSupportStrategies = {
-      MEMORY: [memorySupportStrategy],
-    }
-    const expectedArchivedGroupedSupportStrategies = {
-      SENSORY: [sensorySupportStrategy],
-    }
 
     const expectedViewModel = {
       prisonNamesById,
       prisonerSummary,
       educationSupportPlanLifecycleStatus,
       tab: 'challenges-and-support',
-      activeChallenges: expect.objectContaining({
+      activeChallengesAndSupport: expect.objectContaining({
         status: 'fulfilled',
       }),
-      archivedChallenges: expect.objectContaining({
+      archivedChallengesAndSupport: expect.objectContaining({
         status: 'fulfilled',
-      }),
-      activeSupportStrategies: expect.objectContaining({
-        status: 'fulfilled',
-        value: expectedActiveGroupedSupportStrategies,
-      }),
-      archivedSupportStrategies: expect.objectContaining({
-        status: 'fulfilled',
-        value: expectedArchivedGroupedSupportStrategies,
       }),
     }
 

--- a/server/routes/profile/challenges-and-support/challengesAndSupportController.ts
+++ b/server/routes/profile/challenges-and-support/challengesAndSupportController.ts
@@ -1,12 +1,27 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import toGroupedChallengesPromise from '../../utils/groupedChallengesMapper'
+import toGroupedSupportStrategiesPromise from '../../utils/groupedSupportStrategiesMapper'
 
 export default class ChallengesAndSupportController {
   getChallengesAndSupportView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    const { prisonerSummary } = res.locals
+    const {
+      prisonerSummary,
+      supportStrategies,
+      challenges,
+      alnScreeners,
+      prisonNamesById,
+      educationSupportPlanLifecycleStatus,
+    } = res.locals
 
     const viewRenderArgs = {
+      prisonNamesById,
       prisonerSummary,
+      educationSupportPlanLifecycleStatus,
       tab: 'challenges-and-support',
+      activeChallenges: toGroupedChallengesPromise({ challenges, alnScreeners, active: true }),
+      archivedChallenges: toGroupedChallengesPromise({ challenges, alnScreeners, active: false }),
+      activeSupportStrategies: toGroupedSupportStrategiesPromise({ supportStrategies, active: true }),
+      archivedSupportStrategies: toGroupedSupportStrategiesPromise({ supportStrategies, active: false }),
     }
     return res.render('pages/profile/challenges-and-support/index', viewRenderArgs)
   }

--- a/server/routes/profile/challenges-and-support/challengesAndSupportController.ts
+++ b/server/routes/profile/challenges-and-support/challengesAndSupportController.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import toGroupedChallengesPromise from '../../utils/groupedChallengesMapper'
-import toGroupedSupportStrategiesPromise from '../../utils/groupedSupportStrategiesMapper'
+import toGroupedChallengesAndSupportPromise from '../../utils/groupedChallengesAndSupportMapper'
 
 export default class ChallengesAndSupportController {
   getChallengesAndSupportView: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -18,10 +17,18 @@ export default class ChallengesAndSupportController {
       prisonerSummary,
       educationSupportPlanLifecycleStatus,
       tab: 'challenges-and-support',
-      activeChallenges: toGroupedChallengesPromise({ challenges, alnScreeners, active: true }),
-      archivedChallenges: toGroupedChallengesPromise({ challenges, alnScreeners, active: false }),
-      activeSupportStrategies: toGroupedSupportStrategiesPromise({ supportStrategies, active: true }),
-      archivedSupportStrategies: toGroupedSupportStrategiesPromise({ supportStrategies, active: false }),
+      activeChallengesAndSupport: toGroupedChallengesAndSupportPromise({
+        challenges,
+        alnScreeners,
+        supportStrategies,
+        active: true,
+      }),
+      archivedChallengesAndSupport: toGroupedChallengesAndSupportPromise({
+        challenges,
+        alnScreeners,
+        supportStrategies,
+        active: false,
+      }),
     }
     return res.render('pages/profile/challenges-and-support/index', viewRenderArgs)
   }

--- a/server/routes/profile/challenges-and-support/index.ts
+++ b/server/routes/profile/challenges-and-support/index.ts
@@ -2,12 +2,32 @@ import { Router } from 'express'
 import { Services } from '../../../services'
 import ChallengesAndSupportController from './challengesAndSupportController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import retrieveEducationSupportPlanLifecycleStatus from '../middleware/retrieveEducationSupportPlanLifecycleStatus'
+import retrievePrisonsLookup from '../../middleware/retrievePrisonsLookup'
+import retrieveChallenges from '../../middleware/retrieveChallenges'
+import retrieveSupportStrategies from '../../middleware/retrieveSupportStrategies'
+import retrieveAlnScreeners from '../../middleware/retrieveAlnScreeners'
 
-const challengesAndSupportRoutes = (_services: Services): Router => {
+const challengesAndSupportRoutes = (services: Services): Router => {
+  const {
+    additionalLearningNeedsService,
+    challengeService,
+    educationSupportPlanService,
+    prisonService,
+    supportStrategyService,
+  } = services
   const controller = new ChallengesAndSupportController()
 
   return Router({ mergeParams: true }) //
-    .get('/', [asyncMiddleware(controller.getChallengesAndSupportView)])
+    .get('/', [
+      retrieveEducationSupportPlanLifecycleStatus(educationSupportPlanService),
+      retrievePrisonsLookup(prisonService),
+      retrieveChallenges(challengeService),
+      retrieveAlnScreeners(additionalLearningNeedsService),
+      retrieveSupportStrategies(supportStrategyService),
+
+      asyncMiddleware(controller.getChallengesAndSupportView),
+    ])
 }
 
 export default challengesAndSupportRoutes

--- a/server/routes/utils/groupedChallengesAndSupportMapper.test.ts
+++ b/server/routes/utils/groupedChallengesAndSupportMapper.test.ts
@@ -1,0 +1,320 @@
+import { parseISO, startOfToday } from 'date-fns'
+import type { AlnScreenerList, ChallengeResponseDto, SupportStrategyResponseDto } from 'dto'
+import toGroupedChallengesAndSupportPromise, { GroupedChallengesAndSupport } from './groupedChallengesAndSupportMapper'
+import { Result } from '../../utils/result/result'
+import {
+  setupAlnChallenges,
+  setupAlnScreenersPromise,
+  setupNonAlnChallenges,
+  setupNonAlnChallengesPromise,
+} from '../profile/profileTestSupportFunctions'
+import { aValidAlnScreenerResponseDto } from '../../testsupport/alnScreenerDtoTestDataBuilder'
+import aValidSupportStrategyResponseDto from '../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+import SupportStrategyType from '../../enums/supportStrategyType'
+import SupportStrategyCategory from '../../enums/supportStrategyCategory'
+
+describe('groupedChallengesAndSupportMapper', () => {
+  const prisonId = 'MDI'
+
+  // Non-ALN challenges
+  const {
+    numeracyChallenge,
+    numeracy2Challenge,
+    literacyChallenge,
+    emotionsNonActiveChallenge,
+    attentionChallenge,
+    speakingChallenge,
+  } = setupNonAlnChallenges()
+  const challenges = setupNonAlnChallengesPromise([
+    numeracyChallenge,
+    numeracy2Challenge,
+    literacyChallenge,
+    emotionsNonActiveChallenge,
+    attentionChallenge,
+    speakingChallenge,
+  ])
+
+  // Latest ALN challenges
+  const {
+    readingChallenge,
+    writingChallenge,
+    alphabetOrderingChallenge,
+    wordFindingNonActiveChallenge,
+    arithmeticChallenge,
+    focussingChallenge,
+    tidinessChallenge,
+  } = setupAlnChallenges()
+  const screenerDate = startOfToday()
+  const latestScreener = aValidAlnScreenerResponseDto({
+    screenerDate,
+    createdAtPrison: prisonId,
+    challenges: [
+      readingChallenge,
+      writingChallenge,
+      wordFindingNonActiveChallenge,
+      arithmeticChallenge,
+      focussingChallenge,
+      tidinessChallenge,
+      alphabetOrderingChallenge,
+    ],
+  })
+  const alnScreeners = setupAlnScreenersPromise({ latestScreener })
+
+  // Support strategies
+  const oldestActiveSensorySupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.SENSORY,
+    supportStrategyCategory: SupportStrategyCategory.SENSORY,
+    updatedAt: parseISO('2021-01-01T00:00:00.000Z'),
+    createdAt: parseISO('2021-01-01T00:00:00.000Z'),
+    details: 'This is the oldest entry',
+    active: true,
+  })
+  const recentActiveSensorySupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.SENSORY,
+    supportStrategyCategory: SupportStrategyCategory.SENSORY,
+    updatedAt: parseISO('2021-01-02T00:00:00.000Z'),
+    createdAt: parseISO('2021-01-02T00:00:00.000Z'),
+    details: 'This is the newer entry',
+    active: true,
+  })
+  const memoryActiveSupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.MEMORY,
+    supportStrategyCategory: SupportStrategyCategory.MEMORY,
+    active: true,
+  })
+  const generalActiveSupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.GENERAL,
+    active: true,
+  })
+  const literacySkillsNonActiveSupportStrategy = aValidSupportStrategyResponseDto({
+    supportStrategyCategoryTypeCode: SupportStrategyType.LITERACY_SKILLS_DEFAULT,
+    supportStrategyCategory: SupportStrategyCategory.LITERACY_SKILLS,
+    active: false,
+  })
+
+  const supportStrategies: Result<Array<SupportStrategyResponseDto>, Error> = Result.fulfilled([
+    oldestActiveSensorySupportStrategy,
+    recentActiveSensorySupportStrategy,
+    memoryActiveSupportStrategy,
+    generalActiveSupportStrategy,
+    literacySkillsNonActiveSupportStrategy,
+  ])
+
+  describe('toGroupedChallengesAndSupportPromise', () => {
+    it('should map active challenges and support to GroupedChallenges', () => {
+      // Given
+      const expectedGroupedChallengesAndSupport: GroupedChallengesAndSupport = {
+        ATTENTION_ORGANISING_TIME: {
+          nonAlnChallenges: [attentionChallenge],
+          latestAlnScreener: {
+            screenerDate,
+            createdAtPrison: prisonId,
+            challenges: [focussingChallenge, tidinessChallenge],
+          },
+          supportStrategies: [],
+        },
+        LITERACY_SKILLS: {
+          nonAlnChallenges: [literacyChallenge],
+          latestAlnScreener: {
+            screenerDate,
+            createdAtPrison: prisonId,
+            challenges: [alphabetOrderingChallenge, readingChallenge, writingChallenge],
+          },
+          supportStrategies: [],
+        },
+        NUMERACY_SKILLS: {
+          nonAlnChallenges: [numeracy2Challenge, numeracyChallenge],
+          latestAlnScreener: {
+            screenerDate,
+            createdAtPrison: prisonId,
+            challenges: [arithmeticChallenge],
+          },
+          supportStrategies: [],
+        },
+        LANGUAGE_COMM_SKILLS: {
+          nonAlnChallenges: [speakingChallenge],
+          latestAlnScreener: null,
+          supportStrategies: [],
+        },
+        MEMORY: {
+          nonAlnChallenges: [],
+          latestAlnScreener: null,
+          supportStrategies: [memoryActiveSupportStrategy],
+        },
+        GENERAL: {
+          nonAlnChallenges: [],
+          latestAlnScreener: null,
+          supportStrategies: [generalActiveSupportStrategy],
+        },
+        SENSORY: {
+          nonAlnChallenges: [],
+          latestAlnScreener: null,
+          supportStrategies: [recentActiveSensorySupportStrategy, oldestActiveSensorySupportStrategy],
+        },
+      }
+      const expectedCategoryOrder = [
+        'ATTENTION_ORGANISING_TIME',
+        'LANGUAGE_COMM_SKILLS',
+        'LITERACY_SKILLS',
+        'MEMORY',
+        'NUMERACY_SKILLS',
+        'SENSORY',
+        'GENERAL',
+      ]
+
+      const expected = expect.objectContaining({
+        status: 'fulfilled',
+        value: expectedGroupedChallengesAndSupport,
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({ challenges, alnScreeners, supportStrategies, active: true })
+
+      // Then
+      expect(actual).toEqual(expected)
+      const actualGroupedChallenges = actual.getOrThrow()
+      const actualCategoryOrder = Object.keys(actualGroupedChallenges)
+      expect(actualCategoryOrder).toEqual(expectedCategoryOrder)
+    })
+
+    it('should map inactive challenges and support to GroupedChallenges', () => {
+      // Given
+      const expectedGroupedChallengesAndSupport: GroupedChallengesAndSupport = {
+        EMOTIONS_FEELINGS: {
+          nonAlnChallenges: [emotionsNonActiveChallenge],
+          latestAlnScreener: null,
+          supportStrategies: [],
+        },
+        LITERACY_SKILLS: {
+          nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+          latestAlnScreener: {
+            screenerDate,
+            createdAtPrison: prisonId,
+            challenges: [wordFindingNonActiveChallenge],
+          },
+          supportStrategies: [literacySkillsNonActiveSupportStrategy],
+        },
+      }
+      const expectedCategoryOrder = ['EMOTIONS_FEELINGS', 'LITERACY_SKILLS']
+
+      const expected = expect.objectContaining({
+        status: 'fulfilled',
+        value: expectedGroupedChallengesAndSupport,
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({
+        challenges,
+        alnScreeners,
+        supportStrategies,
+        active: false,
+      })
+
+      // Then
+      expect(actual).toEqual(expected)
+      const actualGroupedChallenges = actual.getOrThrow()
+      const actualCategoryOrder = Object.keys(actualGroupedChallenges)
+      expect(actualCategoryOrder).toEqual(expectedCategoryOrder)
+    })
+
+    it('should map to GroupedChallenges given the challenges promise is not resolved', () => {
+      // Given
+      const rejectedChallengesPromise: Result<Array<ChallengeResponseDto>> = Result.rejected(
+        new Error('Some error retrieving challenges'),
+      )
+
+      const expected = expect.objectContaining({
+        status: 'rejected',
+        reason: new Error('Some error retrieving challenges'),
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({
+        challenges: rejectedChallengesPromise,
+        alnScreeners,
+        supportStrategies,
+        active: true,
+      })
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to GroupedChallenges given the ALN Screeners promise is not resolved', () => {
+      // Given
+      const rejectedAlnScreenersPromise: Result<AlnScreenerList> = Result.rejected(
+        new Error('Some error retrieving ALN Screeners'),
+      )
+
+      const expected = expect.objectContaining({
+        status: 'rejected',
+        reason: new Error('Some error retrieving ALN Screeners'),
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({
+        challenges,
+        alnScreeners: rejectedAlnScreenersPromise,
+        supportStrategies,
+        active: true,
+      })
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to GroupedChallenges given the Support Strategies promise is not resolved', () => {
+      // Given
+      const rejectedSupportStrategiesPromise: Result<Array<SupportStrategyResponseDto>> = Result.rejected(
+        new Error('Some error retrieving Support Strategies'),
+      )
+
+      const expected = expect.objectContaining({
+        status: 'rejected',
+        reason: new Error('Some error retrieving Support Strategies'),
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({
+        challenges,
+        alnScreeners,
+        supportStrategies: rejectedSupportStrategiesPromise,
+        active: true,
+      })
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to GroupedChallenges given none of the promises are resolved', () => {
+      // Given
+      const rejectedChallengesPromise: Result<Array<ChallengeResponseDto>> = Result.rejected(
+        new Error('Some error retrieving challenges'),
+      )
+      const rejectedAlnScreenersPromise: Result<AlnScreenerList> = Result.rejected(
+        new Error('Some error retrieving ALN Screeners'),
+      )
+      const rejectedSupportStrategiesPromise: Result<Array<SupportStrategyResponseDto>> = Result.rejected(
+        new Error('Some error retrieving Support Strategies'),
+      )
+
+      const expected = expect.objectContaining({
+        status: 'rejected',
+        reason: new Error(
+          'Some error retrieving ALN Screeners, Some error retrieving challenges, Some error retrieving Support Strategies',
+        ),
+      })
+
+      // When
+      const actual = toGroupedChallengesAndSupportPromise({
+        challenges: rejectedChallengesPromise,
+        alnScreeners: rejectedAlnScreenersPromise,
+        supportStrategies: rejectedSupportStrategiesPromise,
+        active: true,
+      })
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/server/routes/utils/groupedChallengesAndSupportMapper.ts
+++ b/server/routes/utils/groupedChallengesAndSupportMapper.ts
@@ -1,0 +1,146 @@
+import type { AlnScreenerList, ChallengeResponseDto, SupportStrategyResponseDto } from 'dto'
+import { Result } from '../../utils/result/result'
+import { getChallengesFromAlnScreener, getLatestAlnScreener, getNonAlnChallenges } from './index'
+import dateComparator from '../dateComparator'
+import enumComparator from '../enumComparator'
+import SupportStrategyType from '../../enums/supportStrategyType'
+
+export type GroupedChallengesAndSupport = Record<
+  string,
+  {
+    nonAlnChallenges: Array<ChallengeResponseDto>
+    latestAlnScreener: {
+      screenerDate: Date
+      createdAtPrison: string
+      challenges: Array<ChallengeResponseDto>
+    }
+    supportStrategies: Array<SupportStrategyResponseDto>
+  }
+>
+
+const toGroupedChallengesAndSupportPromise = (config: {
+  challenges: Result<Array<ChallengeResponseDto>>
+  alnScreeners: Result<AlnScreenerList>
+  supportStrategies: Result<Array<SupportStrategyResponseDto>>
+  active: boolean
+}): Result<GroupedChallengesAndSupport, Error> => {
+  const { challenges, alnScreeners, supportStrategies, active } = config
+
+  if (alnScreeners.isFulfilled() && challenges.isFulfilled() && supportStrategies.isFulfilled()) {
+    const groupedChallengesAndSupport: GroupedChallengesAndSupport = {}
+
+    processChallengesIntoGroupedChallengesAndSupport(groupedChallengesAndSupport, challenges, alnScreeners, active)
+    processSupportStrategiesIntoGroupedChallengesAndSupport(groupedChallengesAndSupport, supportStrategies, active)
+
+    // Finally we need to reduce into a new object in order to get the object keys sorted by category (with GENERAL always as the last), otherwise the order of the keys will be the order in which they were processed/added to the object
+    const groupedChallengesSortedByCategory = Object.keys(groupedChallengesAndSupport)
+      .toSorted((categoryA, categoryB) => {
+        if (categoryA === 'GENERAL') return 1
+        if (categoryB === 'GENERAL') return -1
+        return categoryA.localeCompare(categoryB)
+      })
+      .reduce((acc, category) => {
+        acc[category] = groupedChallengesAndSupport[category]
+        return acc
+      }, {} as GroupedChallengesAndSupport)
+    return Result.fulfilled(groupedChallengesSortedByCategory)
+  }
+
+  // At least one of the API calls has failed; we need data from all APIs in order to properly render the Challenges & Support page
+  // Return a rejected Result containing the error message(s) from the original rejected promise(s)
+  return Result.rewrapRejected(alnScreeners, challenges, supportStrategies)
+}
+
+// Group and sort the data from the prisoner's non-ALN Challenges, and the Challenges from their latest ALN Screener
+const processChallengesIntoGroupedChallengesAndSupport = (
+  groupedChallengesAndSupport: GroupedChallengesAndSupport,
+  challenges: Result<Array<ChallengeResponseDto>>,
+  alnScreeners: Result<AlnScreenerList>,
+  active: boolean,
+) => {
+  const nonAlnChallenges = getNonAlnChallenges(challenges, active).toSorted((left, right) =>
+    dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
+  )
+  const latestAlnScreener = getLatestAlnScreener(alnScreeners)
+  const challengesFromLatestAlnScreener = getChallengesFromAlnScreener(latestAlnScreener, active).toSorted(
+    (left, right) => enumComparator(left.challengeTypeCode, right.challengeTypeCode),
+  )
+  const screenerDate = latestAlnScreener?.screenerDate
+  const prisonScreenerConductedAt = latestAlnScreener?.createdAtPrison
+
+  addNonAlnChallengesToGroupedChallengesAndSupport(groupedChallengesAndSupport, nonAlnChallenges)
+  addAlnChallengesToGroupedChallengesAndSupport(
+    groupedChallengesAndSupport,
+    challengesFromLatestAlnScreener,
+    screenerDate,
+    prisonScreenerConductedAt,
+  )
+}
+
+const addNonAlnChallengesToGroupedChallengesAndSupport = (
+  groupedChallengesAndSupport: GroupedChallengesAndSupport,
+  nonAlnChallenges: Array<ChallengeResponseDto>,
+) => {
+  nonAlnChallenges.reduce((acc, challenge) => {
+    const category = challenge.challengeCategory
+    const currentEntry = acc[category] ?? {
+      nonAlnChallenges: [],
+      latestAlnScreener: null,
+      supportStrategies: [],
+    }
+    currentEntry.nonAlnChallenges.push({
+      ...challenge,
+      howIdentified: challenge.howIdentified?.toSorted(enumComparator),
+    })
+    acc[category] = currentEntry
+    return acc
+  }, groupedChallengesAndSupport)
+}
+
+const addAlnChallengesToGroupedChallengesAndSupport = (
+  groupedChallengesAndSupport: GroupedChallengesAndSupport,
+  alnChallenges: Array<ChallengeResponseDto>,
+  screenerDate: Date,
+  createdAtPrison: string,
+) => {
+  alnChallenges.reduce((acc, challenge) => {
+    const category = challenge.challengeCategory
+    const currentEntry = acc[category] ?? {
+      nonAlnChallenges: [],
+      latestAlnScreener: null,
+      supportStrategies: [],
+    }
+    currentEntry.latestAlnScreener = currentEntry.latestAlnScreener || { screenerDate, createdAtPrison, challenges: [] }
+    currentEntry.latestAlnScreener.challenges.push(challenge)
+    acc[category] = currentEntry
+    return acc
+  }, groupedChallengesAndSupport)
+}
+
+const processSupportStrategiesIntoGroupedChallengesAndSupport = (
+  groupedChallengesAndSupport: GroupedChallengesAndSupport,
+  supportStrategies: Result<Array<SupportStrategyResponseDto>>,
+  active: boolean,
+) => {
+  const supportStrategiesSortedByDate = (
+    supportStrategies.getOrNull()?.filter(supportStrategy => supportStrategy.active === active) ?? []
+  ).toSorted((left: SupportStrategyResponseDto, right: SupportStrategyResponseDto) =>
+    dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
+  )
+  supportStrategiesSortedByDate.reduce((acc, supportStrategy) => {
+    const category =
+      supportStrategy.supportStrategyTypeCode === SupportStrategyType.GENERAL
+        ? supportStrategy.supportStrategyTypeCode
+        : supportStrategy.supportStrategyCategory
+    const currentEntry = acc[category] ?? {
+      nonAlnChallenges: [],
+      latestAlnScreener: null,
+      supportStrategies: [],
+    }
+    currentEntry.supportStrategies.push(supportStrategy)
+    acc[category] = currentEntry
+    return acc
+  }, groupedChallengesAndSupport)
+}
+
+export default toGroupedChallengesAndSupportPromise

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../components/actions-card/macro.njk" import actionsCard %}
 
 {% set pageId = 'profile-challenges-and-support' %}
 {% set pageTitle = "Support for additional needs - Challenges and support" %}
@@ -12,12 +13,29 @@
 
   <div class="govuk-grid-row">
 
+    {% set educationSupportPlanLifecycleStatusFulFilled = educationSupportPlanLifecycleStatus.isFulfilled() %}
+    {% set educationSupportPlanLifecycleStatus = educationSupportPlanLifecycleStatus.value if educationSupportPlanLifecycleStatusFulFilled else {} %}
+
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
-      {# Main page content to go here #}
+
+      {% if activeChallenges.isFulfilled() and archivedChallenges.isFulfilled() and activeSupportStrategies.isFulfilled() and archivedSupportStrategies.isFulfilled() %}
+        {# Main page content to go here #}
+
+
+      {% else %}
+        <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
+        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+      {% endif %}
     </div>
 
     <div class="govuk-grid-column-one-third app-u-print-full-width">
-      {# Action bar componenent to go here #}
+      {{ actionsCard({
+        userHasPermissionTo: userHasPermissionTo,
+        prisonerSummary: prisonerSummary,
+        planStatus: educationSupportPlanLifecycleStatus.status,
+        planCreationDeadlineDate: educationSupportPlanLifecycleStatus.planCreationDeadlineDate,
+        planReviewDeadlineDate: educationSupportPlanLifecycleStatus.reviewDeadlineDate
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -18,9 +18,35 @@
 
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
-      {% if activeChallenges.isFulfilled() and archivedChallenges.isFulfilled() and activeSupportStrategies.isFulfilled() and archivedSupportStrategies.isFulfilled() %}
-        {# Main page content to go here #}
+      {% if activeChallengesAndSupport.isFulfilled() and archivedChallengesAndSupport.isFulfilled() %}
+        {# The active and archived Challenges and Support Strategies are already grouped by category #}
+        {% set activeChallengesAndSupport = activeChallengesAndSupport.value %}
+        {% set archivedChallengesAndSupport = archivedChallengesAndSupport.value %}
 
+        {# Get the count of active and archived Challenges and Support Strategies groupings (ie. their categories) #}
+        {% set activeGroupCount = activeChallengesAndSupport | length %}
+        {% set archivedGroupCount = archivedChallengesAndSupport | length %}
+
+        {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+
+        {{ govukTabs({
+          items: [
+            {
+              label: 'Current (' + activeGroupCount + ')',
+              id: 'current-challenges-and-support',
+              panel: {
+                html: ''
+              }
+            },
+            {
+              label: 'History (' + archivedGroupCount + ')',
+              id: 'archived-challenges-and-support',
+              panel: {
+                html: ''
+              }
+            }
+          ]
+        }) }}
 
       {% else %}
         <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>

--- a/server/views/pages/profile/challenges-and-support/index.test.ts
+++ b/server/views/pages/profile/challenges-and-support/index.test.ts
@@ -1,0 +1,118 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import formatDate from '../../../../filters/formatDateFilter'
+import formatPrisonerNameFilter, { NameFormat } from '../../../../filters/formatPrisonerNameFilter'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { Result } from '../../../../utils/result/result'
+import formatChallengeCategoryScreenValueFilter from '../../../../filters/formatChallengeCategoryFilter'
+import formatChallengeIdentificationSourceScreenValueFilter from '../../../../filters/formatChallengeIdentificationSourceFilter'
+import { formatChallengeTypeScreenValueFilter } from '../../../../filters/formatChallengeTypeFilter'
+import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
+import challengeStaffSupportTextLookupFilter from '../../../../filters/challengeStaffSupportTextLookupFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('assetMap', () => '')
+  .addFilter('formatDate', formatDate)
+  .addFilter('formatFirst_name_Last_name', formatPrisonerNameFilter(NameFormat.First_name_Last_name))
+  .addFilter('formatLast_name_comma_First_name', formatPrisonerNameFilter(NameFormat.Last_name_comma_First_name))
+  .addFilter('formatChallengeCategoryScreenValue', formatChallengeCategoryScreenValueFilter)
+  .addFilter('formatChallengeIdentificationSourceScreenValue', formatChallengeIdentificationSourceScreenValueFilter)
+  .addFilter('formatChallengeTypeScreenValue', formatChallengeTypeScreenValueFilter)
+  .addFilter('challengeSupportTextLookup', challengeStaffSupportTextLookupFilter)
+
+const prisonerSummary = aValidPrisonerSummary({
+  firstName: 'IFEREECA',
+  lastName: 'PEIGH',
+})
+const prisonNamesById = {
+  BXI: 'Brixton (HMP)',
+  LEI: 'Leeds (HMP)',
+}
+const template = 'index.njk'
+
+const userHasPermissionTo = jest.fn()
+const templateParams = {
+  prisonerSummary,
+  userHasPermissionTo,
+  tab: 'challenges-and-support',
+  activeChallenges: Result.fulfilled({}),
+  archivedChallenges: Result.fulfilled({}),
+  activeSupportStrategies: Result.fulfilled({}),
+  archivedSupportStrategies: Result.fulfilled({}),
+  prisonNamesById: Result.fulfilled(prisonNamesById),
+  educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
+  pageHasApiErrors: false,
+}
+
+describe('Profile challenges and support page', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
+  it('should render the profile challenges and support page given the Challenges service API promise is not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeChallenges: Result.rejected(new Error('Failed to get challenges')),
+      archivedChallenges: Result.rejected(new Error('Failed to get challenges')),
+      pageHasApiErrors: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-challenges-and-support-summary-card]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(1)
+  })
+
+  it('should render the profile challenges and support page given the Support Strategies service API promise is not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
+      archivedSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
+      pageHasApiErrors: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-challenges-and-support-summary-card]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(1)
+  })
+
+  it('should render the profile challenges and support page given both the Challenges and Support Strategies service APIs promises are not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeChallenges: Result.rejected(new Error('Failed to get challenges')),
+      archivedChallenges: Result.rejected(new Error('Failed to get challenges')),
+      activeSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
+      archivedSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
+      pageHasApiErrors: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-challenges-and-support-summary-card]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(1)
+  })
+})

--- a/server/views/pages/profile/challenges-and-support/index.test.ts
+++ b/server/views/pages/profile/challenges-and-support/index.test.ts
@@ -45,10 +45,8 @@ const templateParams = {
   prisonerSummary,
   userHasPermissionTo,
   tab: 'challenges-and-support',
-  activeChallenges: Result.fulfilled({}),
-  archivedChallenges: Result.fulfilled({}),
-  activeSupportStrategies: Result.fulfilled({}),
-  archivedSupportStrategies: Result.fulfilled({}),
+  activeChallengesAndSupport: Result.fulfilled({}),
+  archivedChallengesAndSupport: Result.fulfilled({}),
   prisonNamesById: Result.fulfilled(prisonNamesById),
   educationSupportPlanLifecycleStatus: Result.fulfilled(aPlanLifecycleStatusDto()),
   pageHasApiErrors: false,
@@ -60,12 +58,64 @@ describe('Profile challenges and support page', () => {
     userHasPermissionTo.mockReturnValue(true)
   })
 
-  it('should render the profile challenges and support page given the Challenges service API promise is not resolved', () => {
+  it.each([
+    {
+      activeChallengesAndSupport: [],
+      archivedChallengesAndSupport: [],
+      expectedActiveCount: 0,
+      expectedArchivedCount: 0,
+    },
+    {
+      activeChallengesAndSupport: ['SENSORY'],
+      archivedChallengesAndSupport: ['EMOTIONS_FEELINGS'],
+      expectedActiveCount: 1,
+      expectedArchivedCount: 1,
+    },
+    {
+      activeChallengesAndSupport: ['LITERACY_SKILLS', 'PHYSICAL_SKILLS', 'SENSORY'],
+      archivedChallengesAndSupport: ['EMOTIONS_FEELINGS', 'MEMORY'],
+      expectedActiveCount: 3,
+      expectedArchivedCount: 2,
+    },
+  ])('should render the profile challenges and support page with the correct tab heading counts', spec => {
     // Given
     const params = {
       ...templateParams,
-      activeChallenges: Result.rejected(new Error('Failed to get challenges')),
-      archivedChallenges: Result.rejected(new Error('Failed to get challenges')),
+      activeChallengesAndSupport: Result.fulfilled(
+        spec.activeChallengesAndSupport.reduce(
+          (acc, category) => {
+            acc[category] = {}
+            return acc
+          },
+          {} as Record<string, unknown>,
+        ),
+      ),
+      archivedChallengesAndSupport: Result.fulfilled(
+        spec.archivedChallengesAndSupport.reduce(
+          (acc, category) => {
+            acc[category] = {}
+            return acc
+          },
+          {} as Record<string, unknown>,
+        ),
+      ),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-tabs__list-item').eq(0).text().trim()).toEqual(`Current (${spec.expectedActiveCount})`)
+    expect($('.govuk-tabs__list-item').eq(1).text().trim()).toEqual(`History (${spec.expectedArchivedCount})`)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+  })
+
+  it('should render the profile challenges and support page given the Active Challenges and Support promise is not resolved', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeChallengesAndSupport: Result.rejected(new Error('Failed to get active challenges and support')),
       pageHasApiErrors: true,
     }
 
@@ -78,32 +128,11 @@ describe('Profile challenges and support page', () => {
     expect($('[data-qa=api-error-banner]').length).toEqual(1)
   })
 
-  it('should render the profile challenges and support page given the Support Strategies service API promise is not resolved', () => {
+  it('should render the profile challenges and support page given the Archived Challenges and Support promise is not resolved', () => {
     // Given
     const params = {
       ...templateParams,
-      activeSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
-      archivedSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
-      pageHasApiErrors: true,
-    }
-
-    // When
-    const content = njkEnv.render(template, params)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa=no-challenges-and-support-summary-card]').length).toEqual(0)
-    expect($('[data-qa=api-error-banner]').length).toEqual(1)
-  })
-
-  it('should render the profile challenges and support page given both the Challenges and Support Strategies service APIs promises are not resolved', () => {
-    // Given
-    const params = {
-      ...templateParams,
-      activeChallenges: Result.rejected(new Error('Failed to get challenges')),
-      archivedChallenges: Result.rejected(new Error('Failed to get challenges')),
-      activeSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
-      archivedSupportStrategies: Result.rejected(new Error('Failed to get support strategies')),
+      archivedChallengesAndSupport: Result.rejected(new Error('Failed to get active challenges and support')),
       pageHasApiErrors: true,
     }
 


### PR DESCRIPTION
This PR updates the new `challenges-and-support` route so that it calls the service middleware functions to get `challenges` and `support-strategies`. It also updates the controller so that it groups `challenges` and `support-strategies` by category and whether they are active or not.
The changes to the route are what the current separate `challenges` and `support-strategies` routes currently do - I've basically just copied what both routes do into the new combined route.

The changes to the controller are similar to what the current `challenges` and `support-strategies` controllers do, but they use a new mapper, which combines the `challenges` and `support-strategies`, and groups them on category code.

I've also started fleshing out the view by providing the basic check that all the various promises are resolved, and displaying the error content if not. Also display the counts in the tab headings. Includes the unit tests for all of this 👍 

The next PR will start to address the happy path by rendering the challenges and support strategies on screen as per the designs.