### PR TITLE
RR-2811 - Update mapper to return grouped data and summary counts

### DIFF
--- a/server/routes/utils/groupedChallengesAndSupportMapper.test.ts
+++ b/server/routes/utils/groupedChallengesAndSupportMapper.test.ts
@@ -104,52 +104,59 @@ describe('groupedChallengesAndSupportMapper', () => {
     it('should map active challenges and support to GroupedChallenges', () => {
       // Given
       const expectedGroupedChallengesAndSupport: GroupedChallengesAndSupport = {
-        ATTENTION_ORGANISING_TIME: {
-          nonAlnChallenges: [attentionChallenge],
-          latestAlnScreener: {
-            screenerDate,
-            createdAtPrison: prisonId,
-            challenges: [focussingChallenge, tidinessChallenge],
+        dataGroupedByCategory: {
+          ATTENTION_ORGANISING_TIME: {
+            nonAlnChallenges: [attentionChallenge],
+            latestAlnScreener: {
+              screenerDate,
+              createdAtPrison: prisonId,
+              challenges: [focussingChallenge, tidinessChallenge],
+            },
+            supportStrategies: [],
           },
-          supportStrategies: [],
-        },
-        LITERACY_SKILLS: {
-          nonAlnChallenges: [literacyChallenge],
-          latestAlnScreener: {
-            screenerDate,
-            createdAtPrison: prisonId,
-            challenges: [alphabetOrderingChallenge, readingChallenge, writingChallenge],
+          LITERACY_SKILLS: {
+            nonAlnChallenges: [literacyChallenge],
+            latestAlnScreener: {
+              screenerDate,
+              createdAtPrison: prisonId,
+              challenges: [alphabetOrderingChallenge, readingChallenge, writingChallenge],
+            },
+            supportStrategies: [],
           },
-          supportStrategies: [],
-        },
-        NUMERACY_SKILLS: {
-          nonAlnChallenges: [numeracy2Challenge, numeracyChallenge],
-          latestAlnScreener: {
-            screenerDate,
-            createdAtPrison: prisonId,
-            challenges: [arithmeticChallenge],
+          NUMERACY_SKILLS: {
+            nonAlnChallenges: [numeracy2Challenge, numeracyChallenge],
+            latestAlnScreener: {
+              screenerDate,
+              createdAtPrison: prisonId,
+              challenges: [arithmeticChallenge],
+            },
+            supportStrategies: [],
           },
-          supportStrategies: [],
+          LANGUAGE_COMM_SKILLS: {
+            nonAlnChallenges: [speakingChallenge],
+            latestAlnScreener: null,
+            supportStrategies: [],
+          },
+          MEMORY: {
+            nonAlnChallenges: [],
+            latestAlnScreener: null,
+            supportStrategies: [memoryActiveSupportStrategy],
+          },
+          GENERAL: {
+            nonAlnChallenges: [],
+            latestAlnScreener: null,
+            supportStrategies: [generalActiveSupportStrategy],
+          },
+          SENSORY: {
+            nonAlnChallenges: [],
+            latestAlnScreener: null,
+            supportStrategies: [recentActiveSensorySupportStrategy, oldestActiveSensorySupportStrategy],
+          },
         },
-        LANGUAGE_COMM_SKILLS: {
-          nonAlnChallenges: [speakingChallenge],
-          latestAlnScreener: null,
-          supportStrategies: [],
-        },
-        MEMORY: {
-          nonAlnChallenges: [],
-          latestAlnScreener: null,
-          supportStrategies: [memoryActiveSupportStrategy],
-        },
-        GENERAL: {
-          nonAlnChallenges: [],
-          latestAlnScreener: null,
-          supportStrategies: [generalActiveSupportStrategy],
-        },
-        SENSORY: {
-          nonAlnChallenges: [],
-          latestAlnScreener: null,
-          supportStrategies: [recentActiveSensorySupportStrategy, oldestActiveSensorySupportStrategy],
+        summary: {
+          supportStrategiesCount: 4,
+          challengesCount: 11,
+          categoryCount: 7,
         },
       }
       const expectedCategoryOrder = [
@@ -173,26 +180,33 @@ describe('groupedChallengesAndSupportMapper', () => {
       // Then
       expect(actual).toEqual(expected)
       const actualGroupedChallenges = actual.getOrThrow()
-      const actualCategoryOrder = Object.keys(actualGroupedChallenges)
+      const actualCategoryOrder = Object.keys(actualGroupedChallenges.dataGroupedByCategory)
       expect(actualCategoryOrder).toEqual(expectedCategoryOrder)
     })
 
     it('should map inactive challenges and support to GroupedChallenges', () => {
       // Given
       const expectedGroupedChallengesAndSupport: GroupedChallengesAndSupport = {
-        EMOTIONS_FEELINGS: {
-          nonAlnChallenges: [emotionsNonActiveChallenge],
-          latestAlnScreener: null,
-          supportStrategies: [],
-        },
-        LITERACY_SKILLS: {
-          nonAlnChallenges: [] as Array<ChallengeResponseDto>,
-          latestAlnScreener: {
-            screenerDate,
-            createdAtPrison: prisonId,
-            challenges: [wordFindingNonActiveChallenge],
+        dataGroupedByCategory: {
+          EMOTIONS_FEELINGS: {
+            nonAlnChallenges: [emotionsNonActiveChallenge],
+            latestAlnScreener: null,
+            supportStrategies: [],
           },
-          supportStrategies: [literacySkillsNonActiveSupportStrategy],
+          LITERACY_SKILLS: {
+            nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+            latestAlnScreener: {
+              screenerDate,
+              createdAtPrison: prisonId,
+              challenges: [wordFindingNonActiveChallenge],
+            },
+            supportStrategies: [literacySkillsNonActiveSupportStrategy],
+          },
+        },
+        summary: {
+          supportStrategiesCount: 1,
+          challengesCount: 2,
+          categoryCount: 2,
         },
       }
       const expectedCategoryOrder = ['EMOTIONS_FEELINGS', 'LITERACY_SKILLS']
@@ -213,7 +227,7 @@ describe('groupedChallengesAndSupportMapper', () => {
       // Then
       expect(actual).toEqual(expected)
       const actualGroupedChallenges = actual.getOrThrow()
-      const actualCategoryOrder = Object.keys(actualGroupedChallenges)
+      const actualCategoryOrder = Object.keys(actualGroupedChallenges.dataGroupedByCategory)
       expect(actualCategoryOrder).toEqual(expectedCategoryOrder)
     })
 

--- a/server/routes/utils/groupedChallengesAndSupportMapper.ts
+++ b/server/routes/utils/groupedChallengesAndSupportMapper.ts
@@ -5,7 +5,7 @@ import dateComparator from '../dateComparator'
 import enumComparator from '../enumComparator'
 import SupportStrategyType from '../../enums/supportStrategyType'
 
-export type GroupedChallengesAndSupport = Record<
+type ChallengesAndSupportGroupedByCategory = Record<
   string,
   {
     nonAlnChallenges: Array<ChallengeResponseDto>
@@ -17,6 +17,14 @@ export type GroupedChallengesAndSupport = Record<
     supportStrategies: Array<SupportStrategyResponseDto>
   }
 >
+export type GroupedChallengesAndSupport = {
+  dataGroupedByCategory: ChallengesAndSupportGroupedByCategory
+  summary: {
+    supportStrategiesCount: number
+    challengesCount: number
+    categoryCount: number
+  }
+}
 
 const toGroupedChallengesAndSupportPromise = (config: {
   challenges: Result<Array<ChallengeResponseDto>>
@@ -27,23 +35,39 @@ const toGroupedChallengesAndSupportPromise = (config: {
   const { challenges, alnScreeners, supportStrategies, active } = config
 
   if (alnScreeners.isFulfilled() && challenges.isFulfilled() && supportStrategies.isFulfilled()) {
-    const groupedChallengesAndSupport: GroupedChallengesAndSupport = {}
+    let groupedChallengesAndSupport: GroupedChallengesAndSupport = {
+      dataGroupedByCategory: {},
+      summary: { supportStrategiesCount: 0, challengesCount: 0, categoryCount: 0 },
+    }
 
-    processChallengesIntoGroupedChallengesAndSupport(groupedChallengesAndSupport, challenges, alnScreeners, active)
-    processSupportStrategiesIntoGroupedChallengesAndSupport(groupedChallengesAndSupport, supportStrategies, active)
+    groupedChallengesAndSupport = processChallengesIntoGroupedChallengesAndSupport(
+      groupedChallengesAndSupport,
+      challenges,
+      alnScreeners,
+      active,
+    )
+    groupedChallengesAndSupport = processSupportStrategiesIntoGroupedChallengesAndSupport(
+      groupedChallengesAndSupport,
+      supportStrategies,
+      active,
+    )
+
+    groupedChallengesAndSupport.summary.categoryCount = Object.keys(
+      groupedChallengesAndSupport.dataGroupedByCategory,
+    ).length
 
     // Finally we need to reduce into a new object in order to get the object keys sorted by category (with GENERAL always as the last), otherwise the order of the keys will be the order in which they were processed/added to the object
-    const groupedChallengesSortedByCategory = Object.keys(groupedChallengesAndSupport)
+    groupedChallengesAndSupport.dataGroupedByCategory = Object.keys(groupedChallengesAndSupport.dataGroupedByCategory)
       .toSorted((categoryA, categoryB) => {
         if (categoryA === 'GENERAL') return 1
         if (categoryB === 'GENERAL') return -1
         return categoryA.localeCompare(categoryB)
       })
       .reduce((acc, category) => {
-        acc[category] = groupedChallengesAndSupport[category]
+        acc[category] = groupedChallengesAndSupport.dataGroupedByCategory[category]
         return acc
-      }, {} as GroupedChallengesAndSupport)
-    return Result.fulfilled(groupedChallengesSortedByCategory)
+      }, {} as ChallengesAndSupportGroupedByCategory)
+    return Result.fulfilled(groupedChallengesAndSupport)
   }
 
   // At least one of the API calls has failed; we need data from all APIs in order to properly render the Challenges & Support page
@@ -57,7 +81,7 @@ const processChallengesIntoGroupedChallengesAndSupport = (
   challenges: Result<Array<ChallengeResponseDto>>,
   alnScreeners: Result<AlnScreenerList>,
   active: boolean,
-) => {
+): GroupedChallengesAndSupport => {
   const nonAlnChallenges = getNonAlnChallenges(challenges, active).toSorted((left, right) =>
     dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
   )
@@ -68,9 +92,8 @@ const processChallengesIntoGroupedChallengesAndSupport = (
   const screenerDate = latestAlnScreener?.screenerDate
   const prisonScreenerConductedAt = latestAlnScreener?.createdAtPrison
 
-  addNonAlnChallengesToGroupedChallengesAndSupport(groupedChallengesAndSupport, nonAlnChallenges)
-  addAlnChallengesToGroupedChallengesAndSupport(
-    groupedChallengesAndSupport,
+  return addAlnChallengesToGroupedChallengesAndSupport(
+    addNonAlnChallengesToGroupedChallengesAndSupport(groupedChallengesAndSupport, nonAlnChallenges),
     challengesFromLatestAlnScreener,
     screenerDate,
     prisonScreenerConductedAt,
@@ -80,21 +103,32 @@ const processChallengesIntoGroupedChallengesAndSupport = (
 const addNonAlnChallengesToGroupedChallengesAndSupport = (
   groupedChallengesAndSupport: GroupedChallengesAndSupport,
   nonAlnChallenges: Array<ChallengeResponseDto>,
-) => {
-  nonAlnChallenges.reduce((acc, challenge) => {
-    const category = challenge.challengeCategory
-    const currentEntry = acc[category] ?? {
-      nonAlnChallenges: [],
-      latestAlnScreener: null,
-      supportStrategies: [],
-    }
-    currentEntry.nonAlnChallenges.push({
-      ...challenge,
-      howIdentified: challenge.howIdentified?.toSorted(enumComparator),
-    })
-    acc[category] = currentEntry
-    return acc
-  }, groupedChallengesAndSupport)
+): GroupedChallengesAndSupport => {
+  const dataGroupedByCategory = nonAlnChallenges.reduce(
+    (acc, challenge) => {
+      const category = challenge.challengeCategory
+      const currentEntry = acc[category] ?? {
+        nonAlnChallenges: [],
+        latestAlnScreener: null,
+        supportStrategies: [],
+      }
+      currentEntry.nonAlnChallenges.push({
+        ...challenge,
+        howIdentified: challenge.howIdentified?.toSorted(enumComparator),
+      })
+      acc[category] = currentEntry
+      return acc
+    },
+    { ...groupedChallengesAndSupport.dataGroupedByCategory },
+  )
+
+  return {
+    dataGroupedByCategory,
+    summary: {
+      ...groupedChallengesAndSupport.summary,
+      challengesCount: groupedChallengesAndSupport.summary.challengesCount + nonAlnChallenges.length,
+    },
+  }
 }
 
 const addAlnChallengesToGroupedChallengesAndSupport = (
@@ -102,45 +136,71 @@ const addAlnChallengesToGroupedChallengesAndSupport = (
   alnChallenges: Array<ChallengeResponseDto>,
   screenerDate: Date,
   createdAtPrison: string,
-) => {
-  alnChallenges.reduce((acc, challenge) => {
-    const category = challenge.challengeCategory
-    const currentEntry = acc[category] ?? {
-      nonAlnChallenges: [],
-      latestAlnScreener: null,
-      supportStrategies: [],
-    }
-    currentEntry.latestAlnScreener = currentEntry.latestAlnScreener || { screenerDate, createdAtPrison, challenges: [] }
-    currentEntry.latestAlnScreener.challenges.push(challenge)
-    acc[category] = currentEntry
-    return acc
-  }, groupedChallengesAndSupport)
+): GroupedChallengesAndSupport => {
+  const dataGroupedByCategory = alnChallenges.reduce(
+    (acc, challenge) => {
+      const category = challenge.challengeCategory
+      const currentEntry = acc[category] ?? {
+        nonAlnChallenges: [],
+        latestAlnScreener: null,
+        supportStrategies: [],
+      }
+      currentEntry.latestAlnScreener = currentEntry.latestAlnScreener || {
+        screenerDate,
+        createdAtPrison,
+        challenges: [],
+      }
+      currentEntry.latestAlnScreener.challenges.push(challenge)
+      acc[category] = currentEntry
+      return acc
+    },
+    { ...groupedChallengesAndSupport.dataGroupedByCategory },
+  )
+
+  return {
+    dataGroupedByCategory,
+    summary: {
+      ...groupedChallengesAndSupport.summary,
+      challengesCount: groupedChallengesAndSupport.summary.challengesCount + alnChallenges.length,
+    },
+  }
 }
 
 const processSupportStrategiesIntoGroupedChallengesAndSupport = (
   groupedChallengesAndSupport: GroupedChallengesAndSupport,
   supportStrategies: Result<Array<SupportStrategyResponseDto>>,
   active: boolean,
-) => {
+): GroupedChallengesAndSupport => {
   const supportStrategiesSortedByDate = (
     supportStrategies.getOrNull()?.filter(supportStrategy => supportStrategy.active === active) ?? []
   ).toSorted((left: SupportStrategyResponseDto, right: SupportStrategyResponseDto) =>
     dateComparator(left.updatedAt, right.updatedAt, 'DESC'),
   )
-  supportStrategiesSortedByDate.reduce((acc, supportStrategy) => {
-    const category =
-      supportStrategy.supportStrategyTypeCode === SupportStrategyType.GENERAL
-        ? supportStrategy.supportStrategyTypeCode
-        : supportStrategy.supportStrategyCategory
-    const currentEntry = acc[category] ?? {
-      nonAlnChallenges: [],
-      latestAlnScreener: null,
-      supportStrategies: [],
-    }
-    currentEntry.supportStrategies.push(supportStrategy)
-    acc[category] = currentEntry
-    return acc
-  }, groupedChallengesAndSupport)
+  const dataGroupedByCategory = supportStrategiesSortedByDate.reduce(
+    (acc, supportStrategy) => {
+      const category =
+        supportStrategy.supportStrategyTypeCode === SupportStrategyType.GENERAL
+          ? supportStrategy.supportStrategyTypeCode
+          : supportStrategy.supportStrategyCategory
+      const currentEntry = acc[category] ?? {
+        nonAlnChallenges: [],
+        latestAlnScreener: null,
+        supportStrategies: [],
+      }
+      currentEntry.supportStrategies.push(supportStrategy)
+      acc[category] = currentEntry
+      return acc
+    },
+    { ...groupedChallengesAndSupport.dataGroupedByCategory },
+  )
+
+  return {
+    dataGroupedByCategory,
+    summary: {
+      ...groupedChallengesAndSupport.summary,
+      supportStrategiesCount: supportStrategiesSortedByDate.length,
+    },
+  }
 }
 
 export default toGroupedChallengesAndSupportPromise

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -20,36 +20,69 @@
 
       {% if activeChallengesAndSupport.isFulfilled() and archivedChallengesAndSupport.isFulfilled() %}
         {# The active and archived Challenges and Support Strategies are already grouped by category #}
-        {% set activeChallengesAndSupport = activeChallengesAndSupport.value %}
-        {% set archivedChallengesAndSupport = archivedChallengesAndSupport.value %}
+        {% set activeChallengesAndSupportByCategory = activeChallengesAndSupport.value.dataGroupedByCategory %}
+        {% set archivedChallengesAndSupportByCategory = archivedChallengesAndSupport.value.dataGroupedByCategory %}
 
-        {# Get the count of active and archived Challenges and Support Strategies groupings (ie. their categories) #}
-        {% set activeGroupCount = activeChallengesAndSupport | length %}
-        {% set archivedGroupCount = archivedChallengesAndSupport | length %}
+        {# Get the summary counts  #}
+        {% set activeCategoriesCount = activeChallengesAndSupport.value.summary.categoryCount %}
+        {% set activeChallengesCount = activeChallengesAndSupport.value.summary.challengesCount %}
+        {% set activeSupportStrategiesCount = activeChallengesAndSupport.value.summary.supportStrategiesCount %}
+        {% set archivedCategoriesCount = archivedChallengesAndSupport.value.summary.categoryCount %}
+        {% set archivedChallengesCount = archivedChallengesAndSupport.value.summary.challengesCount %}
+        {% set archivedSupportStrategiesCount = archivedChallengesAndSupport.value.summary.supportStrategiesCount %}
 
         {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
+
+        {% set activeChallengesAndSupportContent %}
+          {% if activeChallengesCount === 0 %}
+            <p class="govuk-body" data-qa="no-active-challenges-message">
+              {{ prisonerSummary | formatFirst_name_Last_name }} has no current challenges.
+            </p>
+          {% endif %}
+
+          {% if activeSupportStrategiesCount === 0 %}
+            <p class="govuk-body" data-qa="no-active-support-strategies-message">
+              {{ prisonerSummary | formatFirst_name_Last_name }} has no current support strategies.
+            </p>
+          {% endif %}
+
+          {% if activeCategoriesCount > 0 %}
+            {# tab content grouped by Category goes here #}
+          {% endif %}
+        {% endset %}
+
+        {% set archivedChallengesAndSupportContent %}
+          {% if archivedCategoriesCount > 0 %}
+            {# tab content grouped by Category goes here #}
+          {% else %}
+            <p class="govuk-body" data-qa="no-archived-challenges-or-support-message">
+              {{ prisonerSummary | formatFirst_name_Last_name }} has no previous challenges or support strategies.
+            </p>
+          {% endif %}
+        {% endset %}
+
 
         {{ govukTabs({
           items: [
             {
-              label: 'Current (' + activeGroupCount + ')',
+              label: 'Current (' + activeCategoriesCount + ')',
               id: 'current-challenges-and-support',
               panel: {
-                html: ''
+                html: activeChallengesAndSupportContent
               }
             },
             {
-              label: 'History (' + archivedGroupCount + ')',
+              label: 'History (' + archivedCategoriesCount + ')',
               id: 'archived-challenges-and-support',
               panel: {
-                html: ''
+                html: archivedChallengesAndSupportContent
               }
             }
           ]
         }) }}
 
       {% else %}
-        <h3 class="govuk-heading-s" data-qa="challenges-unavailable-message">We cannot show these details right now</h3>
+        <h3 class="govuk-heading-s" data-qa="challenges-and-support-unavailable-message">We cannot show these details right now</h3>
         <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
       {% endif %}
     </div>

--- a/server/views/pages/profile/challenges-and-support/index.test.ts
+++ b/server/views/pages/profile/challenges-and-support/index.test.ts
@@ -58,47 +58,29 @@ describe('Profile challenges and support page', () => {
     userHasPermissionTo.mockReturnValue(true)
   })
 
-  it.each([
-    {
-      activeChallengesAndSupport: [],
-      archivedChallengesAndSupport: [],
-      expectedActiveCount: 0,
-      expectedArchivedCount: 0,
-    },
-    {
-      activeChallengesAndSupport: ['SENSORY'],
-      archivedChallengesAndSupport: ['EMOTIONS_FEELINGS'],
-      expectedActiveCount: 1,
-      expectedArchivedCount: 1,
-    },
-    {
-      activeChallengesAndSupport: ['LITERACY_SKILLS', 'PHYSICAL_SKILLS', 'SENSORY'],
-      archivedChallengesAndSupport: ['EMOTIONS_FEELINGS', 'MEMORY'],
-      expectedActiveCount: 3,
-      expectedArchivedCount: 2,
-    },
-  ])('should render the profile challenges and support page with the correct tab heading counts', spec => {
+  it('should render the profile challenges and support page with the correct tab heading counts', () => {
     // Given
     const params = {
       ...templateParams,
-      activeChallengesAndSupport: Result.fulfilled(
-        spec.activeChallengesAndSupport.reduce(
-          (acc, category) => {
-            acc[category] = {}
-            return acc
-          },
-          {} as Record<string, unknown>,
-        ),
-      ),
-      archivedChallengesAndSupport: Result.fulfilled(
-        spec.archivedChallengesAndSupport.reduce(
-          (acc, category) => {
-            acc[category] = {}
-            return acc
-          },
-          {} as Record<string, unknown>,
-        ),
-      ),
+      activeChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {
+          LITERACY_SKILLS: {/* Controller and mapper would populate this field - not required for this test */},
+          PHYSICAL_SKILLS: {/* Controller and mapper would populate this field - not required for this test */},
+          SENSORY: {/* Controller and mapper would populate this field - not required for this test */},
+        },
+        summary: {
+          categoryCount: 3,
+        },
+      }),
+      archivedChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {
+          EMOTIONS_FEELINGS: {/* Controller and mapper would populate this field - not required for this test */},
+          MEMORY: {/* Controller and mapper would populate this field - not required for this test */},
+        },
+        summary: {
+          categoryCount: 2,
+        },
+      }),
     }
 
     // When
@@ -106,8 +88,106 @@ describe('Profile challenges and support page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('.govuk-tabs__list-item').eq(0).text().trim()).toEqual(`Current (${spec.expectedActiveCount})`)
-    expect($('.govuk-tabs__list-item').eq(1).text().trim()).toEqual(`History (${spec.expectedArchivedCount})`)
+    expect($('.govuk-tabs__list-item').eq(0).text().trim()).toEqual(`Current (3)`)
+    expect($('.govuk-tabs__list-item').eq(1).text().trim()).toEqual(`History (2)`)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+  })
+
+  it('should render the profile challenges and support page given there are no active challenges', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {/* Controller and mapper would populate this field - not required for this test */},
+        summary: {
+          challengesCount: 0,
+          supportStrategiesCount: 1,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-active-challenges-message]').length).toEqual(1)
+    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+  })
+
+  it('should render the profile challenges and support page given there are no active support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      activeChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {/* Controller and mapper would populate this field - not required for this test */},
+        summary: {
+          challengesCount: 1,
+          supportStrategiesCount: 0,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=no-active-challenges-message]').length).toEqual(0)
+    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(1)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+  })
+
+  it('should render the profile challenges and support page given there are some archived challenges or support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {
+          EMOTIONS_FEELINGS: {/* Controller and mapper would populate this field - not required for this test */},
+          MEMORY: {/* Controller and mapper would populate this field - not required for this test */},
+        },
+        summary: {
+          categoryCount: 2,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-tabs__list-item').eq(1).text().trim()).toEqual(`History (2)`)
+    expect($('[data-qa=no-archived-challenges-or-support-message]').length).toEqual(0)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+  })
+
+  it('should render the profile challenges and support page given there are no archived challenges or support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {},
+        summary: {
+          categoryCount: 0,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-tabs__list-item').eq(1).text().trim()).toEqual(`History (0)`)
+    expect($('[data-qa=no-archived-challenges-or-support-message]').length).toEqual(1)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
@@ -142,6 +222,7 @@ describe('Profile challenges and support page', () => {
 
     // Then
     expect($('[data-qa=no-challenges-and-support-summary-card]').length).toEqual(0)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(1)
     expect($('[data-qa=api-error-banner]').length).toEqual(1)
   })
 })


### PR DESCRIPTION
PR to update the mapper that groups the `challenges` and `support strategies` by `category`, to also include a `summary` property with counts of the number of challenges, support strategies, and categories.
This is so that we do not need to try to work this out in the template as nunjucks logic/variables.