### PR TITLE
RR-2811 - Added the challengesAndSupportSummaryCard component

### DIFF
--- a/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.njk
+++ b/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.njk
@@ -1,0 +1,12 @@
+{% from "./macro.njk" import challengesAndSupportSummaryCard %}
+
+{{ challengesAndSupportSummaryCard({
+  challengeAndSupportData: challengeAndSupportData,
+  prisonNamesById: prisonNamesById,
+  showActions: showActions,
+  userHasPermissionTo: userHasPermissionTo,
+  title: title,
+  id: id,
+  classes: classes,
+  attributes: attributes
+}) }}

--- a/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.ts
+++ b/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.ts
@@ -1,0 +1,626 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { parseISO, startOfToday } from 'date-fns'
+import type { ChallengeResponseDto, SupportStrategyResponseDto } from 'dto'
+import formatDateFilter from '../../../filters/formatDateFilter'
+import formatChallengeIdentificationSourceScreenValueFilter from '../../../filters/formatChallengeIdentificationSourceFilter'
+import { formatChallengeTypeScreenValueFilter } from '../../../filters/formatChallengeTypeFilter'
+import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
+import ChallengeType from '../../../enums/challengeType'
+import ChallengeCategory from '../../../enums/challengeCategory'
+import ChallengeIdentificationSource from '../../../enums/challengeIdentificationSource'
+import challengeStaffSupportTextLookupFilter from '../../../filters/challengeStaffSupportTextLookupFilter'
+import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+import SupportStrategyType from '../../../enums/supportStrategyType'
+import SupportStrategyCategory from '../../../enums/supportStrategyCategory'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('formatDate', formatDateFilter)
+  .addFilter('formatChallengeTypeScreenValue', formatChallengeTypeScreenValueFilter)
+  .addFilter('formatChallengeIdentificationSourceScreenValue', formatChallengeIdentificationSourceScreenValueFilter)
+  .addFilter('challengeSupportTextLookup', challengeStaffSupportTextLookupFilter)
+  .addGlobal('featureToggles', { sanDataDeletionEnabled: true })
+
+const prisonNamesById = {
+  BXI: 'Brixton (HMP)',
+  LEI: 'Leeds (HMP)',
+}
+const userHasPermissionTo = jest.fn()
+const templateParams = {
+  title: 'Literacy skills',
+  challengeAndSupportData: {
+    nonAlnChallenges: [aValidChallengeResponseDto()],
+    latestAlnScreener: {
+      createdAtPrison: 'BXI',
+      screenerDate: startOfToday(),
+      challenges: [
+        aValidChallengeResponseDto({
+          challengeTypeCode: ChallengeType.SENSORY,
+          challengeCategory: ChallengeCategory.SENSORY,
+        }),
+      ],
+    },
+    supportStrategies: [aValidSupportStrategyResponseDto()],
+  },
+  prisonNamesById,
+  userHasPermissionTo,
+}
+
+const template = 'challengesAndSupportSummaryCard.test.njk'
+
+describe('Tests for Challenges and Support Summary Card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the component given non-ALN, ALN challenges, and Support Strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [
+          aValidChallengeResponseDto({
+            challengeTypeCode: ChallengeType.WRITING,
+            challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+            symptoms: 'Hand-written text is not neat and hard to read',
+            howIdentified: [ChallengeIdentificationSource.COLLEAGUE_INFO, ChallengeIdentificationSource.OTHER],
+            howIdentifiedOther: `I have seen and experienced John's written text before`,
+            fromALNScreener: false,
+            updatedByDisplayName: 'Person 1',
+            updatedAtPrison: 'LEI',
+            updatedAt: parseISO('2025-02-10T09:01:00'),
+          }),
+          aValidChallengeResponseDto({
+            challengeTypeCode: ChallengeType.READING,
+            challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+            symptoms: 'Is very slow at reading',
+            howIdentified: [ChallengeIdentificationSource.EDUCATION_SKILLS_WORK],
+            howIdentifiedOther: null,
+            fromALNScreener: false,
+            updatedByDisplayName: 'Person 1',
+            updatedAtPrison: 'LEI',
+            updatedAt: parseISO('2025-02-10T09:00:00'),
+          }),
+        ],
+        latestAlnScreener: {
+          createdAtPrison: 'BXI',
+          screenerDate: parseISO('2025-06-13'),
+          challenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.SENSORY,
+              challengeCategory: ChallengeCategory.SENSORY,
+              symptoms: null,
+              howIdentified: null,
+              howIdentifiedOther: null,
+              fromALNScreener: true,
+              createdByDisplayName: 'Person 3',
+              createdAtPrison: 'BXI',
+              createdAt: parseISO('2025-06-13'),
+            }),
+          ],
+        },
+        supportStrategies: [
+          aValidSupportStrategyResponseDto({
+            supportStrategyCategoryTypeCode: SupportStrategyType.MEMORY,
+            supportStrategyCategory: SupportStrategyCategory.MEMORY,
+            details: 'John needs to use flash cards to help with recalling fact',
+            updatedByDisplayName: 'Person 4',
+            updatedAtPrison: 'BXI',
+            updatedAt: parseISO('2025-10-27'),
+          }),
+        ],
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    // assert non-ALN challenges
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(2)
+
+    const firstChallenge = nonAlnChallenges.eq(0)
+    expect(firstChallenge.find('p').eq(0).text().trim()).toEqual('Hand-written text is not neat and hard to read')
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').length).toEqual(2)
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Based on information shared by colleagues or other professionals',
+    ) // COLLEAGUE_INFO
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').eq(1).text().trim()).toEqual(
+      `I have seen and experienced John's written text before`,
+    ) // 'other' text
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-audit]').text().trim()).toEqual(
+      'Last updated 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+
+    const secondChallenge = nonAlnChallenges.eq(1)
+    expect(secondChallenge.find('p').eq(0).text().trim()).toEqual('Is very slow at reading')
+    expect(secondChallenge.find('[data-qa=non-aln-challenge-how-identified] li').length).toEqual(1)
+    expect(secondChallenge.find('[data-qa=non-aln-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Observed in education, skills and work',
+    ) // EDUCATION_SKILLS_WORK
+    expect(secondChallenge.find('[data-qa=non-aln-challenge-audit]').text().trim()).toEqual(
+      'Last updated 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+
+    // assert ALN challenges
+    const alnChallenges = $('.govuk-summary-list__row.aln-challenges li')
+    expect(alnChallenges.length).toEqual(1)
+    expect(alnChallenges.eq(0).find('summary').text().trim()).toEqual('Sensory') // SENSORY
+    expect($('[data-qa=aln-challenges-audit]').text().trim()).toEqual(
+      'From Additional Learning Needs Screener completed on 13 Jun 2025, Brixton (HMP)',
+    )
+
+    expect($('[data-qa=no-challenges]').length).toEqual(0)
+
+    // assert Support Strategies
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    const firstSupportStrategy = supportStrategies.eq(0)
+    expect(firstSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'John needs to use flash cards to help with recalling fact',
+    )
+    expect(firstSupportStrategy.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
+      'Last updated 27 Oct 2025 by Person 4, Brixton (HMP)',
+    )
+    expect($('[data-qa=no-support-strategies]').length).toEqual(0)
+  })
+
+  it('should render the component given only non-ALN challenges and no ALN Screener or Support Strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [
+          aValidChallengeResponseDto({
+            challengeTypeCode: ChallengeType.WRITING,
+            challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+            symptoms: 'Hand-written text is well written and easy to read',
+            howIdentified: [ChallengeIdentificationSource.COLLEAGUE_INFO, ChallengeIdentificationSource.OTHER],
+            howIdentifiedOther: `I have seen and experienced John's written text before`,
+            fromALNScreener: false,
+            updatedByDisplayName: 'Person 1',
+            updatedAtPrison: 'LEI',
+            updatedAt: parseISO('2025-02-10T09:01:00'),
+          }),
+        ],
+        latestAlnScreener: {},
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    // assert non-ALN challenges
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+
+    const firstChallenge = nonAlnChallenges.eq(0)
+    expect(firstChallenge.find('p').eq(0).text().trim()).toEqual('Hand-written text is well written and easy to read')
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').length).toEqual(2)
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Based on information shared by colleagues or other professionals',
+    ) // COLLEAGUE_INFO
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-how-identified] li').eq(1).text().trim()).toEqual(
+      `I have seen and experienced John's written text before`,
+    ) // 'other' text
+    expect(firstChallenge.find('[data-qa=non-aln-challenge-audit]').text().trim()).toEqual(
+      'Last updated 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+
+    expect($('[data-qa=no-challenges]').length).toEqual(0)
+
+    // assert ALN challenges
+    const alnChallenges = $('.govuk-summary-list__row.aln-challenges li')
+    expect(alnChallenges.length).toEqual(0)
+
+    // assert Support Strategies
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(0)
+    expect($('[data-qa=no-support-strategies]').length).toEqual(1)
+  })
+
+  it('should render the component given only ALN challenges and no non-ALN challenges or Support Strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {
+          createdAtPrison: 'BXI',
+          screenerDate: parseISO('2025-06-13'),
+          challenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.SENSORY,
+              challengeCategory: ChallengeCategory.SENSORY,
+              symptoms: null,
+              howIdentified: null,
+              howIdentifiedOther: null,
+              fromALNScreener: true,
+              createdByDisplayName: 'Person 3',
+              createdAtPrison: 'BXI',
+              createdAt: parseISO('2025-06-13'),
+            }),
+          ],
+        },
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    // assert non-ALN challenges
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(0)
+
+    // assert ALN challenges
+    const alnChallenges = $('.govuk-summary-list__row.aln-challenges li')
+    expect(alnChallenges.length).toEqual(1)
+    expect(alnChallenges.eq(0).find('summary').text().trim()).toEqual('Sensory') // SENSORY
+    expect($('[data-qa=aln-challenges-audit]').text().trim()).toEqual(
+      'From Additional Learning Needs Screener completed on 13 Jun 2025, Brixton (HMP)',
+    )
+
+    expect($('[data-qa=no-challenges]').length).toEqual(0)
+
+    // assert Support Strategies
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(0)
+    expect($('[data-qa=no-support-strategies]').length).toEqual(1)
+  })
+
+  it('should render the component given prisonNamesById does not contain the prison', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {
+          createdAtPrison: 'BXI',
+          screenerDate: parseISO('2025-06-13'),
+          challenges: [
+            aValidChallengeResponseDto({
+              challengeTypeCode: ChallengeType.SENSORY,
+              challengeCategory: ChallengeCategory.SENSORY,
+              symptoms: null,
+              howIdentified: null,
+              howIdentifiedOther: null,
+              fromALNScreener: true,
+              createdByDisplayName: 'Person 3',
+              createdAtPrison: 'BXI',
+              createdAt: parseISO('2025-06-13'),
+            }),
+          ],
+        },
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+      prisonNamesById: {},
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    // assert non-ALN challenges
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(0)
+
+    // assert ALN challenges
+    const alnChallenges = $('.govuk-summary-list__row.aln-challenges li')
+    expect(alnChallenges.length).toEqual(1)
+    expect(alnChallenges.eq(0).find('summary').text().trim()).toEqual('Sensory') // SENSORY
+    expect($('[data-qa=aln-challenges-audit]').text().trim()).toEqual(
+      'From Additional Learning Needs Screener completed on 13 Jun 2025, BXI',
+    )
+
+    // assert Support Strategies
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(0)
+    expect($('[data-qa=no-support-strategies]').length).toEqual(1)
+  })
+
+  it('should not render the component given no challenges and no support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {
+          createdAtPrison: 'BXI',
+          screenerDate: startOfToday(),
+          challenges: [] as Array<ChallengeResponseDto>,
+        },
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+
+    // Then
+    expect(content.trim()).toEqual('')
+  })
+
+  it('should not render any actions given the user does not have any permissions', () => {
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=edit-challenge-button]').length).toEqual(0)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=archive-challenge-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render delete challenge action given the user only has permission to delete challenges', () => {
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=delete-challenge-button]').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=edit-challenge-button]').length).toEqual(0)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=archive-challenge-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_CHALLENGES')
+  })
+
+  it('should render edit challenge action given the user only has permission to edit challenges', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=delete-challenge-button]').length).toEqual(0)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=edit-challenge-button]').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=archive-challenge-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_CHALLENGES')
+  })
+
+  it('should render archive challenge action given the user only has permission to archive challenges', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=delete-challenge-button]').length).toEqual(0)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=edit-challenge-button]').length).toEqual(0)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=archive-challenge-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_CHALLENGES')
+  })
+
+  it('should render all 3 challenge actions given the user has permissions to delete, edit and archive challenges', () => {
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        supportStrategies: [] as Array<SupportStrategyResponseDto>,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=delete-challenge-button]').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=edit-challenge-button]').length).toEqual(1)
+    expect(nonAlnChallenges.eq(0).find('[data-qa=archive-challenge-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_CHALLENGES')
+  })
+
+  it('should render delete support strategy action given the user only has permission to delete support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {},
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=delete-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render edit support strategy given the user only has permission to edit support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {},
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=delete-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render archive support strategy given the user only has permission to archive support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {},
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=delete-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(0)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render all 3 support strategy actions given the user has permissions to delete, edit and archive support strategies', () => {
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        ...templateParams.challengeAndSupportData,
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {},
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    expect(supportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=delete-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=edit-support-strategy-button]').length).toEqual(1)
+    expect(supportStrategies.eq(0).find('[data-qa=archive-support-strategy-button]').length).toEqual(1)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
+  })
+})

--- a/server/views/components/challenges-and-support-summary-card/macro.njk
+++ b/server/views/components/challenges-and-support-summary-card/macro.njk
@@ -1,0 +1,25 @@
+{# Challenges & Support Summary Card macro
+
+Data supplied to this macro:
+  params: {
+    challengeAndSupportData: {
+      nonAlnChallenges: Array<ChallengeResponseDto> - Array of non-ALN Screener challenges
+      latestAlnScreener: {
+        screenerDate: Date - the Date of the latest ALN Screener
+        createdAtPrison: string - the prisonId where the latest ALN Screener was recorded
+        challenges: Array<ChallengeResponseDto> - Array of challenges on the latest ALN Screener
+      }
+      supportStrategies: Array<SupportStrategyResponseDto> - Array of Support Strategies
+    }
+    prisonNamesById: Object of key value pairs, where the key is the prison ID, and the value is the prison name
+    prisonNumber: string - the prisoner's prison number, used to build action links
+    userHasPermissionTo: function that determines user permissions
+    title: string - Summary Card title
+    id: string
+    classes: string
+    attributes: Object of key value pairs of additonal attributes to add the to the component
+  }
+#}
+{% macro challengesAndSupportSummaryCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/challenges-and-support-summary-card/template.njk
+++ b/server/views/components/challenges-and-support-summary-card/template.njk
@@ -1,0 +1,174 @@
+{% from "govuk/macros/attributes.njk" import govukAttributes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{#- Set classes for this component #}
+{%- set classNames = "govuk-summary-card" -%}
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{#- Define component attributes #}
+{%- set componentAttributes %} class="{{ classNames }}" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
+
+{% set nonAlnChallenges = params.challengeAndSupportData.nonAlnChallenges %}
+{% set latestAlnScreener = params.challengeAndSupportData.latestAlnScreener %}
+{% set challengesFromMostRecentAlnScreener = latestAlnScreener.challenges %}
+{% set supportStrategies = params.challengeAndSupportData.supportStrategies %}
+{% set prisonNamesById = params.prisonNamesById %}
+{% set userHasPermissionTo = params.userHasPermissionTo %}
+
+{% if nonAlnChallenges | length or challengesFromMostRecentAlnScreener | length or supportStrategies | length %}
+  <div {{ componentAttributes | safe }}>
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">{{ params.title }}</h2>
+    </div>
+
+    <div class="govuk-summary-card__content govuk-!-padding-top-0">
+      <div class="govuk-summary-list">
+
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Challenges</h3>
+        {% if nonAlnChallenges | length or challengesFromMostRecentAlnScreener | length %}
+          {# Render non-ALN challenges first #}
+          {% for challenge in nonAlnChallenges %}
+            <div class="govuk-summary-list__row non-aln-challenge" data-qa="non-aln-challenge-{{ challenge.challengeTypeCode }}">
+              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="non-aln-challenge-symptoms">{{ challenge.symptoms }}</p>
+
+              {% set howIdentifiedContent %}
+                <ul class="govuk-list govuk-!-font-size-16">
+                  {% for challengeIdentificationSource in challenge.howIdentified %}
+                    <li>{{ challengeIdentificationSource | formatChallengeIdentificationSourceScreenValue if challengeIdentificationSource != 'OTHER' else challenge.howIdentifiedOther }}</li>
+                  {% endfor %}
+                </ul>
+              {% endset %}
+
+              {{ govukDetails({
+                summaryText: "How was this identified",
+                html: howIdentifiedContent,
+                attributes: {
+                  "data-qa": "non-aln-challenge-how-identified"
+                }
+              }) }}
+
+              <div class="actions-wrapper">
+                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="non-aln-challenge-audit">
+                  {% set prisonName = prisonNamesById[challenge.updatedAtPrison] | default(challenge.updatedAtPrison) %}
+                  Last updated {{ challenge.updatedAt | formatDate('d MMM yyyy') }} by {{ challenge.updatedByDisplayName }}, {{ prisonName }}
+                </p>
+
+                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_CHALLENGES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/delete/reason" data-qa="delete-challenge-button">Delete</a>
+                    </li>
+                  {% endif %}
+                  {% if userHasPermissionTo('EDIT_CHALLENGES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/edit/detail" data-qa="edit-challenge-button">Edit</a>
+                    </li>
+                  {% endif %}
+                  {% if userHasPermissionTo('ARCHIVE_CHALLENGES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/archive/reason" data-qa="archive-challenge-button">Move to history</a>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
+            </div>
+          {% endfor %}
+
+          {# Render challenges from the most recent ALN Screener #}
+          {% if challengesFromMostRecentAlnScreener | length %}
+            <div class="govuk-summary-list__row aln-challenges">
+              <ul class="govuk-list govuk-!-margin-top-3">
+                {% for challenge in challengesFromMostRecentAlnScreener %}
+                  {% set expanderContent %}
+                    <p class="app-u-multiline-text">{{ challenge.challengeTypeCode | challengeSupportTextLookup | default("Support strategy guidance not available") }}</p>
+                  {% endset %}
+                  <li>
+                    {{ govukDetails({
+                      summaryText: challenge.challengeTypeCode | formatChallengeTypeScreenValue,
+                      html: expanderContent,
+                      classes: "govuk-!-margin-top-3",
+                      attributes: {
+                        "data-qa": "aln-challenge-detail"
+                      }
+                    }) }}
+                  </li>
+                {% endfor %}
+              </ul>
+
+              <div class="actions-wrapper">
+                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="aln-challenges-audit">
+                  {% set prisonName = prisonNamesById[latestAlnScreener.createdAtPrison] | default(latestAlnScreener.createdAtPrison) %}
+                  From Additional Learning Needs Screener completed on {{ latestAlnScreener.screenerDate | formatDate('d MMM yyyy') }}, {{ prisonName }}
+                </p>
+
+                {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_ALN_SCREENER') %}
+                  <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/aln-screener/{{ params.prisonNumber }}/delete/reason?from=challenges" data-qa="delete-aln-screener-button">Delete</a>
+                    </li>
+                  </ul>
+                {% endif %}
+              </div>
+            </div>
+          {% endif %}
+
+        {% else %}
+          <div class="govuk-summary-list__row" data-qa="no-challenges">
+            <p class="govuk-body govuk-!-margin-top-3">
+              No {{ params.title | lower }} challenges recorded.
+              {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+                <a class="govuk-link govuk-!-display-none-print" href="/challenges/{{ params.prisonNumber }}/create/select-category">Add a challenge.</a>
+              {% endif %}
+            </p>
+          </div>
+        {% endif %}
+
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Support strategies</h3>
+        {% if supportStrategies | length %}
+          {% for supportStrategy in supportStrategies %}
+            <div class="govuk-summary-list__row support-strategy" data-qa="support-strategy-{{ supportStrategy.supportStrategyTypeCode }}">
+              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}</p>
+
+              <div class="actions-wrapper">
+                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="support-strategy-audit">
+                  {% set prisonName = params.prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
+                  Last updated {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}</span>
+                </p>
+
+                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_SUPPORT_STRATEGIES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/delete/reason" data-qa="delete-support-strategy-button">Delete</a>
+                    </li>
+                  {% endif %}
+                  {% if userHasPermissionTo('EDIT_SUPPORT_STRATEGIES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/edit/detail" data-qa="edit-support-strategy-button">Edit</a>
+                    </li>
+                  {% endif %}
+                  {% if userHasPermissionTo('ARCHIVE_SUPPORT_STRATEGIES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/archive/reason" data-qa="archive-support-strategy-button">Move to history</a>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
+            </div>
+          {% endfor %}
+
+        {% else %}
+          <div class="govuk-summary-list__row" data-qa="no-support-strategies">
+            <p class="govuk-body govuk-!-margin-top-3">
+              No {{ params.title | lower }} support strategies recorded.
+              {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
+                <a class="govuk-link govuk-!-display-none-print" href="/support-strategies/{{ params.prisonNumber }}/create/select-category">Add a support strategy.</a>
+              {% endif %}
+            </p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.ts
+++ b/server/views/components/support-strategies-summary-card/supportStrategiesSummaryCard.test.ts
@@ -3,8 +3,6 @@ import * as cheerio from 'cheerio'
 import { parseISO } from 'date-fns'
 import type { SupportStrategyResponseDto } from 'dto'
 import formatDateFilter from '../../../filters/formatDateFilter'
-import { formatStrengthTypeScreenValueFilter } from '../../../filters/formatStrengthTypeFilter'
-import formatStrengthIdentificationSourceScreenValueFilter from '../../../filters/formatStrengthIdentificationSourceFilter'
 import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
@@ -16,8 +14,6 @@ const njkEnv = nunjucks.configure([
 
 njkEnv //
   .addFilter('formatDate', formatDateFilter)
-  .addFilter('formatStrengthTypeScreenValue', formatStrengthTypeScreenValueFilter)
-  .addFilter('formatStrengthIdentificationSourceScreenValue', formatStrengthIdentificationSourceScreenValueFilter)
 
 const prisonNamesById = {
   BXI: 'Brixton (HMP)',
@@ -168,7 +164,7 @@ describe('Tests for Support Strategies Summary Card component', () => {
     expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
   })
 
-  it('should render edit strength action given the showActions flag is true and the user only has permission to edit support strategies', () => {
+  it('should render edit support strategy action given the showActions flag is true and the user only has permission to edit support strategies', () => {
     userHasPermissionTo.mockReturnValueOnce(true)
     userHasPermissionTo.mockReturnValueOnce(false)
 
@@ -191,7 +187,7 @@ describe('Tests for Support Strategies Summary Card component', () => {
     expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
   })
 
-  it('should render archive strength action given the showActions flag is true and the user only has permission to archive support strategies', () => {
+  it('should render archive support strategy action given the showActions flag is true and the user only has permission to archive support strategies', () => {
     userHasPermissionTo.mockReturnValueOnce(false)
     userHasPermissionTo.mockReturnValueOnce(true)
 
@@ -214,7 +210,7 @@ describe('Tests for Support Strategies Summary Card component', () => {
     expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
   })
 
-  it('should render both strength actions given the showActions flag is true and the user has permissions to edit and archive support strategies', () => {
+  it('should render both support strategy actions given the showActions flag is true and the user has permissions to edit and archive support strategies', () => {
     userHasPermissionTo.mockReturnValue(true)
 
     const params = {

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -1,5 +1,6 @@
 {% extends "../layout.njk" %}
 {% from "../components/actions-card/macro.njk" import actionsCard %}
+{% from "../../../components/challenges-and-support-summary-card/macro.njk" import challengesAndSupportSummaryCard %}
 
 {% set pageId = 'profile-challenges-and-support' %}
 {% set pageTitle = "Support for additional needs - Challenges and support" %}
@@ -38,16 +39,37 @@
             <p class="govuk-body" data-qa="no-active-challenges-message">
               {{ prisonerSummary | formatFirst_name_Last_name }} has no current challenges.
             </p>
+            {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+              <p class="govuk-body">
+                <a class="govuk-link" href="/challenges/{{ prisonerSummary.prisonNumber }}/create/select-category" data-qa="add-challenge-button">Add a challenge</a>
+              </p>
+            {% endif %}
           {% endif %}
 
           {% if activeSupportStrategiesCount === 0 %}
             <p class="govuk-body" data-qa="no-active-support-strategies-message">
               {{ prisonerSummary | formatFirst_name_Last_name }} has no current support strategies.
             </p>
+            {% if userHasPermissionTo('RECORD_SUPPORT_STRATEGIES') %}
+              <p class="govuk-body">
+                <a class="govuk-link" href="/support-strategies/{{ prisonerSummary.prisonNumber }}/create/select-category" data-qa="add-support-strategy-button">Add support strategy</a>
+              </p>
+            {% endif %}
           {% endif %}
 
           {% if activeCategoriesCount > 0 %}
-            {# tab content grouped by Category goes here #}
+            {% for challengeAndSupportCategory, challengeAndSupportData in activeChallengesAndSupportByCategory %}
+              {{ challengesAndSupportSummaryCard({
+                challengeAndSupportData: challengeAndSupportData,
+                prisonNamesById: prisonNamesById,
+                prisonNumber: prisonerSummary.prisonNumber,
+                userHasPermissionTo: userHasPermissionTo,
+                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue,
+                attributes: {
+                  'data-qa': 'active-challenges-and-support-summary-card-' + challengeCategory
+                }
+              }) }}
+            {% endfor %}
           {% endif %}
         {% endset %}
 

--- a/server/views/pages/profile/challenges-and-support/index.test.ts
+++ b/server/views/pages/profile/challenges-and-support/index.test.ts
@@ -94,8 +94,10 @@ describe('Profile challenges and support page', () => {
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
   })
 
-  it('should render the profile challenges and support page given there are no active challenges', () => {
+  it('should render the profile challenges and support page given there are no active challenges and the user has permission to create challenges', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
+
     const params = {
       ...templateParams,
       activeChallengesAndSupport: Result.fulfilled({
@@ -112,14 +114,50 @@ describe('Profile challenges and support page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=no-active-challenges-message]').length).toEqual(1)
-    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
+    const parentTab = $('#current-challenges-and-support')
+    expect(parentTab.find('[data-qa=no-active-challenges-message]').length).toEqual(1)
+    expect(parentTab.find('[data-qa=add-challenge-button]').length).toEqual(1)
+    expect(parentTab.find('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=add-support-strategy-button]').length).toEqual(0)
     expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
   })
 
-  it('should render the profile challenges and support page given there are no active support strategies', () => {
+  it('should render the profile challenges and support page given there are no active challenges and the user does not have permission to create challenges', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = {
+      ...templateParams,
+      activeChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {/* Controller and mapper would populate this field - not required for this test */},
+        summary: {
+          challengesCount: 0,
+          supportStrategiesCount: 1,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const parentTab = $('#current-challenges-and-support')
+    expect(parentTab.find('[data-qa=no-active-challenges-message]').length).toEqual(1)
+    expect(parentTab.find('[data-qa=add-challenge-button]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=no-active-support-strategies-message]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=add-support-strategy-button]').length).toEqual(0)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_CHALLENGES')
+  })
+
+  it('should render the profile challenges and support page given there are no active support strategies and the user has permission to create support strategies', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+
     const params = {
       ...templateParams,
       activeChallengesAndSupport: Result.fulfilled({
@@ -136,10 +174,44 @@ describe('Profile challenges and support page', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=no-active-challenges-message]').length).toEqual(0)
-    expect($('[data-qa=no-active-support-strategies-message]').length).toEqual(1)
+    const parentTab = $('#current-challenges-and-support')
+    expect(parentTab.find('[data-qa=no-active-challenges-message]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=add-challenge-button]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=no-active-support-strategies-message]').length).toEqual(1)
+    expect(parentTab.find('[data-qa=add-support-strategy-button]').length).toEqual(1)
     expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
     expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
+  })
+
+  it('should render the profile challenges and support page given there are no active support strategies and the user does not have permission to create support strategies', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(false)
+
+    const params = {
+      ...templateParams,
+      activeChallengesAndSupport: Result.fulfilled({
+        dataGroupedByCategory: {/* Controller and mapper would populate this field - not required for this test */},
+        summary: {
+          challengesCount: 1,
+          supportStrategiesCount: 0,
+        },
+      }),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const parentTab = $('#current-challenges-and-support')
+    expect(parentTab.find('[data-qa=no-active-challenges-message]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=add-challenge-button]').length).toEqual(0)
+    expect(parentTab.find('[data-qa=no-active-support-strategies-message]').length).toEqual(1)
+    expect(parentTab.find('[data-qa=add-support-strategy-button]').length).toEqual(0)
+    expect($('[data-qa=challenges-and-support-unavailable-message]').length).toEqual(0)
+    expect($('[data-qa=api-error-banner]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_SUPPORT_STRATEGIES')
   })
 
   it('should render the profile challenges and support page given there are some archived challenges or support strategies', () => {


### PR DESCRIPTION
PR to add and wire in the `challengesAndSupportSummaryCard` component, which displays the combined Challenges and Support on the "Current" tab (ie. those records that are active):

<img width="812" height="1257" alt="Screenshot 2026-08-05 at 12 09 12" src="https://github.com/user-attachments/assets/6518124f-856b-4fc8-afeb-9bbf81ebc719" />
