### PR TITLE
RR-2811 - Added the archivedChallengesAndSupportSummaryCard component

### DIFF
--- a/server/views/components/archived-challenges-and-support-summary-card/archivedChallengesAndSupportSummaryCard.test.njk
+++ b/server/views/components/archived-challenges-and-support-summary-card/archivedChallengesAndSupportSummaryCard.test.njk
@@ -1,0 +1,12 @@
+{% from "./macro.njk" import archivedChallengesAndSupportSummaryCard %}
+
+{{ archivedChallengesAndSupportSummaryCard({
+  archivedChallenges: archivedChallenges,
+  archivedSupportStrategies: archivedSupportStrategies,
+  prisonNamesById: prisonNamesById,
+  userHasPermissionTo: userHasPermissionTo,
+  title: title,
+  id: id,
+  classes: classes,
+  attributes: attributes
+}) }}

--- a/server/views/components/archived-challenges-and-support-summary-card/archivedChallengesAndSupportSummaryCard.test.ts
+++ b/server/views/components/archived-challenges-and-support-summary-card/archivedChallengesAndSupportSummaryCard.test.ts
@@ -1,0 +1,407 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { parseISO } from 'date-fns'
+import type { ChallengeResponseDto, SupportStrategyResponseDto } from 'dto'
+import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
+import formatDateFilter from '../../../filters/formatDateFilter'
+import { formatChallengeTypeScreenValueFilter } from '../../../filters/formatChallengeTypeFilter'
+import ChallengeType from '../../../enums/challengeType'
+import ChallengeCategory from '../../../enums/challengeCategory'
+import ChallengeIdentificationSource from '../../../enums/challengeIdentificationSource'
+import formatChallengeIdentificationSourceScreenValueFilter from '../../../filters/formatChallengeIdentificationSourceFilter'
+import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
+import SupportStrategyType from '../../../enums/supportStrategyType'
+import SupportStrategyCategory from '../../../enums/supportStrategyCategory'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv //
+  .addFilter('formatDate', formatDateFilter)
+  .addFilter('formatChallengeTypeScreenValue', formatChallengeTypeScreenValueFilter)
+  .addFilter('formatChallengeIdentificationSourceScreenValue', formatChallengeIdentificationSourceScreenValueFilter)
+  .addGlobal('featureToggles', { sanDataDeletionEnabled: true })
+
+const userHasPermissionTo = jest.fn()
+const prisonNamesById = {
+  BXI: 'Brixton (HMP)',
+  LEI: 'Leeds (HMP)',
+}
+const templateParams = {
+  title: 'Literacy skills',
+  archivedChallenges: [aValidChallengeResponseDto()],
+  archivedSupportStrategies: [aValidSupportStrategyResponseDto()],
+  prisonNamesById,
+  userHasPermissionTo,
+}
+
+const template = 'archivedChallengesAndSupportSummaryCard.test.njk'
+
+describe('Tests for Archived Challenges and Support Summary Card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the component given only archived challenges and no archived support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedChallenges: [
+        aValidChallengeResponseDto({
+          challengeTypeCode: ChallengeType.WRITING,
+          challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+          symptoms: 'Hand-written text is well written and easy to read',
+          howIdentified: [ChallengeIdentificationSource.COLLEAGUE_INFO, ChallengeIdentificationSource.OTHER],
+          howIdentifiedOther: `I have seen and experienced John's written text before`,
+          fromALNScreener: false,
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:01:00'),
+          active: false,
+          archiveReason: 'Challenge added for the wrong prisoner by mistake',
+        }),
+        aValidChallengeResponseDto({
+          challengeTypeCode: ChallengeType.READING,
+          challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+          symptoms: 'Can read at speed',
+          howIdentified: [ChallengeIdentificationSource.EDUCATION_SKILLS_WORK],
+          howIdentifiedOther: null,
+          fromALNScreener: false,
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:00:00'),
+          active: false,
+          archiveReason: 'Challenge added in error',
+        }),
+      ],
+      archivedSupportStrategies: [] as Array<SupportStrategyResponseDto>,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(2)
+
+    const firstChallenge = archivedChallenges.eq(0)
+    expect(firstChallenge.find('p').eq(0).text().trim()).toEqual('Hand-written text is well written and easy to read')
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').length).toEqual(2)
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Based on information shared by colleagues or other professionals',
+    ) // COLLEAGUE_INFO
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(1).text().trim()).toEqual(
+      `I have seen and experienced John's written text before`,
+    ) // 'other' text
+    expect(firstChallenge.find('[data-qa=archived-challenge-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(firstChallenge.find('[data-qa=archived-challenge-reason]').text().trim()).toEqual(
+      'Challenge added for the wrong prisoner by mistake',
+    )
+
+    const secondChallenge = archivedChallenges.eq(1)
+    expect(secondChallenge.find('p').eq(0).text().trim()).toEqual('Can read at speed')
+    expect(secondChallenge.find('[data-qa=archived-challenge-how-identified] li').length).toEqual(1)
+    expect(secondChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Observed in education, skills and work',
+    ) // EDUCATION_SKILLS_WORK
+    expect(secondChallenge.find('[data-qa=archived-challenge-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(secondChallenge.find('[data-qa=archived-challenge-reason]').text().trim()).toEqual(
+      'Challenge added in error',
+    )
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(0)
+  })
+
+  it('should render the component given only archived support strategies and no archived challenges', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedSupportStrategies: [
+        aValidSupportStrategyResponseDto({
+          supportStrategyCategoryTypeCode: SupportStrategyType.LITERACY_SKILLS_DEFAULT,
+          supportStrategyCategory: SupportStrategyCategory.LITERACY_SKILLS,
+          details: 'John needs help to read and understand written text',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:01:00'),
+          active: false,
+          archiveReason: 'Support Strategy added for the wrong prisoner by mistake',
+        }),
+        aValidSupportStrategyResponseDto({
+          supportStrategyCategoryTypeCode: SupportStrategyType.LITERACY_SKILLS_DEFAULT,
+          supportStrategyCategory: SupportStrategyCategory.LITERACY_SKILLS,
+          details: 'John needs books with large print and simplified language',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:00:00'),
+          active: false,
+          archiveReason: 'Support Strategy added in error',
+        }),
+      ],
+      archivedChallenges: [] as Array<ChallengeResponseDto>,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(0)
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(2)
+
+    const firstSupportStrategy = archivedSupportStrategies.eq(0)
+    expect(firstSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'John needs help to read and understand written text',
+    )
+    expect(firstSupportStrategy.find('[data-qa=archived-support-strategy-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(firstSupportStrategy.find('[data-qa=archived-support-strategy-reason]').text().trim()).toEqual(
+      'Support Strategy added for the wrong prisoner by mistake',
+    )
+
+    const secondSupportStrategy = archivedSupportStrategies.eq(1)
+    expect(secondSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'John needs books with large print and simplified language',
+    )
+    expect(secondSupportStrategy.find('[data-qa=archived-support-strategy-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(secondSupportStrategy.find('[data-qa=archived-support-strategy-reason]').text().trim()).toEqual(
+      'Support Strategy added in error',
+    )
+  })
+
+  it('should render the component given archived challenges and archived support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedChallenges: [
+        aValidChallengeResponseDto({
+          challengeTypeCode: ChallengeType.WRITING,
+          challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+          symptoms: 'Hand-written text is well written and easy to read',
+          howIdentified: [ChallengeIdentificationSource.COLLEAGUE_INFO, ChallengeIdentificationSource.OTHER],
+          howIdentifiedOther: `I have seen and experienced John's written text before`,
+          fromALNScreener: false,
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:01:00'),
+          active: false,
+          archiveReason: 'Challenge added for the wrong prisoner by mistake',
+        }),
+        aValidChallengeResponseDto({
+          challengeTypeCode: ChallengeType.READING,
+          challengeCategory: ChallengeCategory.LITERACY_SKILLS,
+          symptoms: 'Can read at speed',
+          howIdentified: [ChallengeIdentificationSource.EDUCATION_SKILLS_WORK],
+          howIdentifiedOther: null,
+          fromALNScreener: false,
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:00:00'),
+          active: false,
+          archiveReason: 'Challenge added in error',
+        }),
+      ],
+      archivedSupportStrategies: [
+        aValidSupportStrategyResponseDto({
+          supportStrategyCategoryTypeCode: SupportStrategyType.LITERACY_SKILLS_DEFAULT,
+          supportStrategyCategory: SupportStrategyCategory.LITERACY_SKILLS,
+          details: 'John needs help to read and understand written text',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:01:00'),
+          active: false,
+          archiveReason: 'Support Strategy added for the wrong prisoner by mistake',
+        }),
+        aValidSupportStrategyResponseDto({
+          supportStrategyCategoryTypeCode: SupportStrategyType.LITERACY_SKILLS_DEFAULT,
+          supportStrategyCategory: SupportStrategyCategory.LITERACY_SKILLS,
+          details: 'John needs books with large print and simplified language',
+          updatedByDisplayName: 'Person 1',
+          updatedAtPrison: 'LEI',
+          updatedAt: parseISO('2025-02-10T09:00:00'),
+          active: false,
+          archiveReason: 'Support Strategy added in error',
+        }),
+      ],
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(2)
+
+    const firstChallenge = archivedChallenges.eq(0)
+    expect(firstChallenge.find('p').eq(0).text().trim()).toEqual('Hand-written text is well written and easy to read')
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').length).toEqual(2)
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Based on information shared by colleagues or other professionals',
+    ) // COLLEAGUE_INFO
+    expect(firstChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(1).text().trim()).toEqual(
+      `I have seen and experienced John's written text before`,
+    ) // 'other' text
+    expect(firstChallenge.find('[data-qa=archived-challenge-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(firstChallenge.find('[data-qa=archived-challenge-reason]').text().trim()).toEqual(
+      'Challenge added for the wrong prisoner by mistake',
+    )
+
+    const secondChallenge = archivedChallenges.eq(1)
+    expect(secondChallenge.find('p').eq(0).text().trim()).toEqual('Can read at speed')
+    expect(secondChallenge.find('[data-qa=archived-challenge-how-identified] li').length).toEqual(1)
+    expect(secondChallenge.find('[data-qa=archived-challenge-how-identified] li').eq(0).text().trim()).toEqual(
+      'Observed in education, skills and work',
+    ) // EDUCATION_SKILLS_WORK
+    expect(secondChallenge.find('[data-qa=archived-challenge-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(secondChallenge.find('[data-qa=archived-challenge-reason]').text().trim()).toEqual(
+      'Challenge added in error',
+    )
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(2)
+
+    const firstSupportStrategy = archivedSupportStrategies.eq(0)
+    expect(firstSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'John needs help to read and understand written text',
+    )
+    expect(firstSupportStrategy.find('[data-qa=archived-support-strategy-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(firstSupportStrategy.find('[data-qa=archived-support-strategy-reason]').text().trim()).toEqual(
+      'Support Strategy added for the wrong prisoner by mistake',
+    )
+
+    const secondSupportStrategy = archivedSupportStrategies.eq(1)
+    expect(secondSupportStrategy.find('p').eq(0).text().trim()).toEqual(
+      'John needs books with large print and simplified language',
+    )
+    expect(secondSupportStrategy.find('[data-qa=archived-support-strategy-audit]').text().trim()).toEqual(
+      'Moved to history on 10 Feb 2025 by Person 1, Leeds (HMP)',
+    )
+    expect(secondSupportStrategy.find('[data-qa=archived-support-strategy-reason]').text().trim()).toEqual(
+      'Support Strategy added in error',
+    )
+  })
+
+  it('should render delete challenge action given the user only has permission to delete challenges', () => {
+    userHasPermissionTo.mockReturnValueOnce(true)
+    userHasPermissionTo.mockReturnValueOnce(false)
+
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('[data-qa=delete-archived-challenge-button]').length).toEqual(1)
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('[data-qa=delete-archived-support-strategy-button]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render delete support strategy action given the user only has permission to delete support strategies', () => {
+    userHasPermissionTo.mockReturnValueOnce(false)
+    userHasPermissionTo.mockReturnValueOnce(true)
+
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('[data-qa=delete-archived-challenge-button]').length).toEqual(0)
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('[data-qa=delete-archived-support-strategy-button]').length).toEqual(1)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+  })
+
+  it('should render both delete actions given the user has permission to delete both challenges and support strategies', () => {
+    userHasPermissionTo.mockReturnValue(true)
+
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    const archivedChallenges = $('.govuk-summary-list__row.archived-challenge')
+    expect(archivedChallenges.length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedChallenges.eq(0).find('[data-qa=delete-archived-challenge-button]').length).toEqual(1)
+
+    const archivedSupportStrategies = $('.govuk-summary-list__row.archived-support-strategy')
+    expect(archivedSupportStrategies.length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('.govuk-summary-card__actions').length).toEqual(1)
+    expect(archivedSupportStrategies.eq(0).find('[data-qa=delete-archived-support-strategy-button]').length).toEqual(1)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_CHALLENGES')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('DELETE_SUPPORT_STRATEGIES')
+  })
+
+  it('should not render the component given no challenges or support strategies', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      archivedChallenges: [] as Array<ChallengeResponseDto>,
+      archivedSupportStrategies: [] as Array<SupportStrategyResponseDto>,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+
+    // Then
+    expect(content.trim()).toEqual('')
+  })
+})

--- a/server/views/components/archived-challenges-and-support-summary-card/macro.njk
+++ b/server/views/components/archived-challenges-and-support-summary-card/macro.njk
@@ -1,0 +1,17 @@
+{# Archived Challenges & Support Summary Card macro
+
+Data supplied to this macro:
+  params: {
+    archivedChallenges: Array<ChallengeResponseDto> - Array of archived challenges
+    archivedSupportStrategies: Array<SupportStrategyResponseDto> - Array of Support Strategies
+    prisonNamesById: Object of key value pairs, where the key is the prison ID, and the value is the prison name
+    title: string - Summary Card title
+    userHasPermissionTo: function - RBAC helper function
+    id: string
+    classes: string
+    attributes: Object of key value pairs of additonal attributes to add the to the component
+  }
+#}
+{% macro archivedChallengesAndSupportSummaryCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/archived-challenges-and-support-summary-card/template.njk
+++ b/server/views/components/archived-challenges-and-support-summary-card/template.njk
@@ -1,0 +1,104 @@
+{% from "govuk/macros/attributes.njk" import govukAttributes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{#- Set classes for this component #}
+{%- set classNames = "govuk-summary-card" -%}
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{#- Define component attributes #}
+{%- set componentAttributes %} class="{{ classNames }}" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
+
+{% set archivedChallenges = params.archivedChallenges %}
+{% set archivedSupportStrategies = params.archivedSupportStrategies %}
+{% set userHasPermissionTo = params.userHasPermissionTo %}
+
+{% if archivedChallenges | length or archivedSupportStrategies | length %}
+  <div {{ componentAttributes | safe }}>
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">{{ params.title }}</h2>
+    </div>
+
+    <div class="govuk-summary-card__content govuk-!-padding-top-0">
+      <div class="govuk-summary-list">
+
+        {# Render archived challenges first #}
+        {% if archivedChallenges | length %}
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Challenges</h3>
+
+          {% for challenge in archivedChallenges %}
+            <div class="govuk-summary-list__row archived-challenge" data-qa="{{ challenge.challengeTypeCode }}">
+              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="archived-symptoms">{{ challenge.symptoms }}</p>
+
+              {% set expanderContent %}
+                <ul class="govuk-list govuk-!-font-size-16">
+                  {% for challengeIdentificationSource in challenge.howIdentified %}
+                    <li>{{ challengeIdentificationSource | formatChallengeIdentificationSourceScreenValue if challengeIdentificationSource != 'OTHER' else challenge.howIdentifiedOther }}</li>
+                  {% endfor %}
+                </ul>
+              {% endset %}
+              {{ govukDetails({
+                summaryText: "How was this identified?",
+                html: expanderContent,
+                classes: "govuk-!-font-size-16",
+                attributes: {
+                  "data-qa": "archived-challenge-how-identified"
+                }
+              }) }}
+
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Reason for moving to History</h3>
+              <p class="govuk-body app-u-multiline-text" data-qa="archived-challenge-reason">{{ challenge.archiveReason }}</p>
+
+              <div class="actions-wrapper">
+                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="archived-challenge-audit">
+                  {% set prisonName = params.prisonNamesById[challenge.updatedAtPrison] | default(challenge.updatedAtPrison) %}
+                  Moved to history on {{ challenge.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ challenge.updatedByDisplayName }}, {{ prisonName }}</span>
+                </p>
+
+                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_CHALLENGES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/history-delete/reason" data-qa="delete-archived-challenge-button">Delete</a>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
+
+            </div>
+          {% endfor %}
+        {% endif %}
+
+        {# Render archived support strategies next #}
+        {% if archivedSupportStrategies | length %}
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Support strategies</h3>
+
+          {% for supportStrategy in archivedSupportStrategies %}
+            <div class="govuk-summary-list__row archived-support-strategy">
+              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="support-strategy-details">{{ supportStrategy.supportStrategyDetails }}</p>
+
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Reason for moving to the History</h3>
+              <p class="govuk-body app-u-multiline-text" data-qa="archived-support-strategy-reason">{{ supportStrategy.archiveReason }}</p>
+
+              <div class="actions-wrapper">
+                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="archived-support-strategy-audit">
+                  {% set prisonName = params.prisonNamesById[supportStrategy.updatedAtPrison] | default(supportStrategy.updatedAtPrison) %}
+                  Moved to history on {{ supportStrategy.updatedAt | formatDate('d MMM yyyy') }}<span class="govuk-!-display-none-print"> by {{ supportStrategy.updatedByDisplayName }}, {{ prisonName }}</span>
+                </p>
+
+                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_SUPPORT_STRATEGIES') %}
+                    <li class="govuk-summary-card__action">
+                      <a class="govuk-link govuk-!-font-weight-regular" href="/support-strategies/{{ supportStrategy.prisonNumber }}/{{ supportStrategy.reference }}/history-delete/reason" data-qa="delete-archived-support-strategy-button">Delete</a>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
+            </div>
+          {% endfor %}
+        {% endif %}
+
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.njk
+++ b/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.njk
@@ -3,7 +3,6 @@
 {{ challengesAndSupportSummaryCard({
   challengeAndSupportData: challengeAndSupportData,
   prisonNamesById: prisonNamesById,
-  showActions: showActions,
   userHasPermissionTo: userHasPermissionTo,
   title: title,
   id: id,

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -1,6 +1,7 @@
 {% extends "../layout.njk" %}
 {% from "../components/actions-card/macro.njk" import actionsCard %}
 {% from "../../../components/challenges-and-support-summary-card/macro.njk" import challengesAndSupportSummaryCard %}
+{% from "../../../components/archived-challenges-and-support-summary-card/macro.njk" import archivedChallengesAndSupportSummaryCard %}
 
 {% set pageId = 'profile-challenges-and-support' %}
 {% set pageTitle = "Support for additional needs - Challenges and support" %}
@@ -64,9 +65,9 @@
                 prisonNamesById: prisonNamesById,
                 prisonNumber: prisonerSummary.prisonNumber,
                 userHasPermissionTo: userHasPermissionTo,
-                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue,
+                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true),
                 attributes: {
-                  'data-qa': 'active-challenges-and-support-summary-card-' + challengeCategory
+                  'data-qa': 'active-challenges-and-support-summary-card-' + challengeAndSupportCategory
                 }
               }) }}
             {% endfor %}
@@ -75,7 +76,20 @@
 
         {% set archivedChallengesAndSupportContent %}
           {% if archivedCategoriesCount > 0 %}
-            {# tab content grouped by Category goes here #}
+            {% for challengeAndSupportCategory, challengeAndSupportData in archivedChallengesAndSupportByCategory %}
+              {% set archivedChallenges = challengeAndSupportData.nonAlnChallenges %}
+              {% set archivedSupportStrategies = challengeAndSupportData.supportStrategies %}
+              {{ archivedChallengesAndSupportSummaryCard({
+                archivedChallenges: archivedChallenges,
+                archivedSupportStrategies: archivedSupportStrategies,
+                prisonNamesById: prisonNamesById,
+                userHasPermissionTo: userHasPermissionTo,
+                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true),
+                attributes: {
+                  'data-qa': 'archived-challenges-and-support-summary-card_' + challengeCategory
+                }
+              }) }}
+            {% endfor %}
           {% else %}
             <p class="govuk-body" data-qa="no-archived-challenges-or-support-message">
               {{ prisonerSummary | formatFirst_name_Last_name }} has no previous challenges or support strategies.


### PR DESCRIPTION
PR to add and wire in the `archivedChallengesAndSupportSummaryCard` component, which displays the combined Challenges and Support on the "History" tab (ie. those records that are archived):

<img width="908" height="1263" alt="Screenshot 2026-08-05 at 14 54 08" src="https://github.com/user-attachments/assets/e764dc47-6ab8-46be-9f9e-ff7b21599ec3" />
