### PR TITLE
RR-2811 - Update links and redirects to new combined route/page

### DIFF
--- a/server/routes/additional-learning-needs-screener/delete/reason/reasonController.test.ts
+++ b/server/routes/additional-learning-needs-screener/delete/reason/reasonController.test.ts
@@ -4,6 +4,10 @@ import ReasonController from './reasonController'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidAlnScreenerResponseDto } from '../../../../testsupport/alnScreenerDtoTestDataBuilder'
 
+jest.mock('../../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
+
 describe('delete/reason/reasonController (ALN screener)', () => {
   const controller = new ReasonController()
 
@@ -80,7 +84,7 @@ describe('delete/reason/reasonController (ALN screener)', () => {
       await controller.getReasonView(req, res, next)
 
       const renderedDto = (res.render as jest.Mock).mock.calls[0][1].dto as ScreenerDeletionDto
-      expect(renderedDto.returnTo).toEqual(`/profile/${prisonNumber}/challenges`)
+      expect(renderedDto.returnTo).toEqual(`/profile/${prisonNumber}/challenges-and-support`)
     })
 
     it('does not overwrite returnTo once it has been set', async () => {

--- a/server/routes/additional-learning-needs-screener/delete/reason/reasonController.ts
+++ b/server/routes/additional-learning-needs-screener/delete/reason/reasonController.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import type { ScreenerDeletionDto } from 'dto'
+import config from '../../../../config'
 
 export default class ReasonController {
   getReasonView = async (req: Request, res: Response, _next: NextFunction) => {
@@ -40,6 +41,9 @@ const resolveReturnTo = (req: Request): string => {
   const { prisonNumber } = req.params
   const from = typeof req.query.from === 'string' ? req.query.from : undefined
   if (from === 'strengths') return `/profile/${prisonNumber}/strengths`
-  if (from === 'challenges') return `/profile/${prisonNumber}/challenges`
+  if (from === 'challenges')
+    return config.featureToggles.displayChallengesAndSupportStrategiesCombined
+      ? `/profile/${prisonNumber}/challenges-and-support`
+      : `/profile/${prisonNumber}/challenges`
   return `/profile/${prisonNumber}/overview`
 }

--- a/server/routes/challenges/create/detail/detailController.test.ts
+++ b/server/routes/challenges/create/detail/detailController.test.ts
@@ -9,6 +9,9 @@ import AuditService from '../../../../services/auditService'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/challengeService')
+jest.mock('../../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('detailController', () => {
   const mockedChallengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
@@ -122,7 +125,7 @@ describe('detailController', () => {
       howIdentified: [ChallengeIdentificationSource.CONVERSATIONS, ChallengeIdentificationSource.OTHER],
       howIdentifiedOther: 'It has been mentioned to me in passing',
     })
-    const expectedNextRoute = `/profile/${prisonNumber}/challenges`
+    const expectedNextRoute = `/profile/${prisonNumber}/challenges-and-support`
 
     // When
     await controller.submitDetailForm(req, res, next)

--- a/server/routes/challenges/create/detail/detailController.ts
+++ b/server/routes/challenges/create/detail/detailController.ts
@@ -5,6 +5,7 @@ import { Result } from '../../../../utils/result/result'
 import { AuditService, ChallengeService } from '../../../../services'
 import { asArray } from '../../../../utils/utils'
 import { BaseAuditData } from '../../../../services/auditService'
+import config from '../../../../config'
 
 export default class DetailController {
   constructor(
@@ -49,7 +50,12 @@ export default class DetailController {
     const { prisonNumber } = challengeDto
     req.journeyData.challengeDto = undefined
     this.auditService.logCreateChallenge(this.createChallengesAuditData(req)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/challenges`, 'Challenge added')
+    return res.redirectWithSuccess(
+      config.featureToggles.displayChallengesAndSupportStrategiesCombined
+        ? `/profile/${prisonNumber}/challenges-and-support`
+        : `/profile/${prisonNumber}/challenges`,
+      'Challenge added',
+    )
   }
 
   private updateDtoFromForm = (

--- a/server/routes/challenges/edit/detail/detailController.test.ts
+++ b/server/routes/challenges/edit/detail/detailController.test.ts
@@ -8,6 +8,9 @@ import AuditService from '../../../../services/auditService'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/challengeService')
+jest.mock('../../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('detailController', () => {
   const mockedChallengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
@@ -205,7 +208,7 @@ describe('detailController', () => {
       howIdentified: [ChallengeIdentificationSource.CONVERSATIONS, ChallengeIdentificationSource.OTHER],
       howIdentifiedOther: 'Other prisoners often mention this to me in passing',
     }
-    const expectedNextRoute = `/profile/${prisonNumber}/challenges`
+    const expectedNextRoute = `/profile/${prisonNumber}/challenges-and-support`
 
     // When
     await controller.submitDetailForm(req, res, next)

--- a/server/routes/challenges/edit/detail/detailController.ts
+++ b/server/routes/challenges/edit/detail/detailController.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../utils/identificationSourceConsolidation'
 import { BaseAuditData } from '../../../../services/auditService'
 import { PrisonUser } from '../../../../interfaces/hmppsUser'
+import config from '../../../../config'
 
 export default class DetailController {
   constructor(
@@ -61,7 +62,12 @@ export default class DetailController {
     const { prisonNumber } = challengeResponseDto
     req.journeyData.challengeDto = undefined
     this.auditService.logEditChallenge(this.editChallengesAuditData(req, challengeResponseDto)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/challenges`, 'Challenge updated')
+    return res.redirectWithSuccess(
+      config.featureToggles.displayChallengesAndSupportStrategiesCombined
+        ? `/profile/${prisonNumber}/challenges-and-support`
+        : `/profile/${prisonNumber}/challenges`,
+      'Challenge updated',
+    )
   }
 
   private updateDtoFromForm = (

--- a/server/routes/challenges/middleware/retrieveChallengeResponseDtoIfNotInJourneyData.test.ts
+++ b/server/routes/challenges/middleware/retrieveChallengeResponseDtoIfNotInJourneyData.test.ts
@@ -5,6 +5,9 @@ import retrieveChallengeResponseDtoIfNotInJourneyData from './retrieveChallengeR
 import aValidChallengeResponseDto from '../../../testsupport/challengeResponseDtoTestDataBuilder'
 
 jest.mock('../../../services/challengeService')
+jest.mock('../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('retrieveChallengeResponseDtoIfNotInJourneyData', () => {
   const challengeService = new ChallengeService(null) as jest.Mocked<ChallengeService>
@@ -131,6 +134,6 @@ describe('retrieveChallengeResponseDtoIfNotInJourneyData', () => {
     expect(challengeService.getChallenge).toHaveBeenCalledWith(username, prisonNumber, challengeReference)
     expect(next).not.toHaveBeenCalled()
     expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
-    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/challenges`)
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/challenges-and-support`)
   })
 })

--- a/server/routes/challenges/middleware/retrieveChallengeResponseDtoIfNotInJourneyData.ts
+++ b/server/routes/challenges/middleware/retrieveChallengeResponseDtoIfNotInJourneyData.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { ChallengeResponseDto } from 'dto'
 import { ChallengeService } from '../../../services'
+import config from '../../../config'
 
 /**
  * Middleware function to check whether a [ChallengeResponseDto] exists in the journeyData for the prisoner and challenge reference in the request URL.
@@ -23,7 +24,11 @@ const retrieveChallengeResponseDtoIfNotInJourneyData = (challengeService: Challe
         }
       } catch {
         req.flash('pageHasApiErrors', 'true')
-        return res.redirect(`/profile/${prisonNumber}/challenges`)
+        return res.redirect(
+          config.featureToggles.displayChallengesAndSupportStrategiesCombined
+            ? `/profile/${prisonNumber}/challenges-and-support`
+            : `/profile/${prisonNumber}/challenges`,
+        )
       }
     }
 

--- a/server/routes/support-strategies/create/detail/detailController.test.ts
+++ b/server/routes/support-strategies/create/detail/detailController.test.ts
@@ -7,6 +7,9 @@ import AuditService from '../../../../services/auditService'
 
 jest.mock('../../../../services/supportStrategyService')
 jest.mock('../../../../services/auditService')
+jest.mock('../../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('detailController', () => {
   const supportStrategyService = new SupportStrategyService(null) as jest.Mocked<SupportStrategyService>
@@ -134,7 +137,7 @@ describe('detailController', () => {
       supportStrategyTypeCode: SupportStrategyType.MEMORY,
       supportStrategyDetails: 'A description of the support strategy',
     })
-    const expectedNextRoute = `/profile/${prisonNumber}/support-strategies`
+    const expectedNextRoute = `/profile/${prisonNumber}/challenges-and-support`
 
     // When
     await controller.submitDetailForm(req, res, next)

--- a/server/routes/support-strategies/create/detail/detailController.ts
+++ b/server/routes/support-strategies/create/detail/detailController.ts
@@ -3,6 +3,7 @@ import type { SupportStrategyDto } from 'dto'
 import { SupportStrategyService } from '../../../../services'
 import { Result } from '../../../../utils/result/result'
 import AuditService, { BaseAuditData } from '../../../../services/auditService'
+import config from '../../../../config'
 
 export default class DetailController {
   constructor(
@@ -42,7 +43,12 @@ export default class DetailController {
     const { prisonNumber } = supportStrategyDto
     req.journeyData.supportStrategyDto = undefined
     this.auditService.logCreateSupportStrategy(this.createSupportStrategyAuditData(req)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/support-strategies`, 'Support strategy added')
+    return res.redirectWithSuccess(
+      config.featureToggles.displayChallengesAndSupportStrategiesCombined
+        ? `/profile/${prisonNumber}/challenges-and-support`
+        : `/profile/${prisonNumber}/support-strategies`,
+      'Support strategy added',
+    )
   }
 
   private populateFormFromDto = (dto: SupportStrategyDto) => {

--- a/server/routes/support-strategies/edit/detail/detailController.test.ts
+++ b/server/routes/support-strategies/edit/detail/detailController.test.ts
@@ -7,6 +7,9 @@ import aValidSupportStrategyResponseDto from '../../../../testsupport/supportStr
 
 jest.mock('../../../../services/supportStrategyService')
 jest.mock('../../../../services/auditService')
+jest.mock('../../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('detailController', () => {
   const supportStrategyService = new SupportStrategyService(null) as jest.Mocked<SupportStrategyService>
@@ -134,7 +137,7 @@ describe('detailController', () => {
       prisonId,
       supportStrategyDetails: 'A description of the support strategy',
     }
-    const expectedNextRoute = `/profile/${prisonNumber}/support-strategies`
+    const expectedNextRoute = `/profile/${prisonNumber}/challenges-and-support`
 
     // When
     await controller.submitDetailForm(req, res, next)

--- a/server/routes/support-strategies/edit/detail/detailController.ts
+++ b/server/routes/support-strategies/edit/detail/detailController.ts
@@ -4,6 +4,7 @@ import { SupportStrategyService } from '../../../../services'
 import { Result } from '../../../../utils/result/result'
 import AuditService, { BaseAuditData } from '../../../../services/auditService'
 import { PrisonUser } from '../../../../interfaces/hmppsUser'
+import config from '../../../../config'
 
 export default class DetailController {
   constructor(
@@ -49,7 +50,12 @@ export default class DetailController {
     const { prisonNumber } = supportStrategyDto
     req.journeyData.supportStrategyDto = undefined
     this.auditService.logEditSupportStrategy(this.editSupportStrategyAuditData(req, supportStrategyDto)) // no need to wait for response
-    return res.redirectWithSuccess(`/profile/${prisonNumber}/support-strategies`, 'Support strategy updated')
+    return res.redirectWithSuccess(
+      config.featureToggles.displayChallengesAndSupportStrategiesCombined
+        ? `/profile/${prisonNumber}/challenges-and-support`
+        : `/profile/${prisonNumber}/support-strategies`,
+      'Support strategy updated',
+    )
   }
 
   private populateFormFromDto = (dto: SupportStrategyResponseDto) => {

--- a/server/routes/support-strategies/middleware/retrieveSupportStrategyResponseDtoIfNotInJourneyData.test.ts
+++ b/server/routes/support-strategies/middleware/retrieveSupportStrategyResponseDtoIfNotInJourneyData.test.ts
@@ -5,6 +5,9 @@ import retrieveSupportStrategyResponseDtoIfNotInJourneyData from './retrieveSupp
 import aValidSupportStrategyResponseDto from '../../../testsupport/supportStrategyResponseDtoTestDataBuilder'
 
 jest.mock('../../../services/supportStrategyService')
+jest.mock('../../../config', () => ({
+  featureToggles: { displayChallengesAndSupportStrategiesCombined: true },
+}))
 
 describe('retrieveSupportStrategyResponseDtoIfNotInJourneyData', () => {
   const supportStrategyService = new SupportStrategyService(null) as jest.Mocked<SupportStrategyService>
@@ -169,6 +172,6 @@ describe('retrieveSupportStrategyResponseDtoIfNotInJourneyData', () => {
     )
     expect(next).not.toHaveBeenCalled()
     expect(flash).toHaveBeenCalledWith('pageHasApiErrors', 'true')
-    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/support-strategies`)
+    expect(res.redirect).toHaveBeenCalledWith(`/profile/${prisonNumber}/challenges-and-support`)
   })
 })

--- a/server/routes/support-strategies/middleware/retrieveSupportStrategyResponseDtoIfNotInJourneyData.ts
+++ b/server/routes/support-strategies/middleware/retrieveSupportStrategyResponseDtoIfNotInJourneyData.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { SupportStrategyResponseDto } from 'dto'
 import { SupportStrategyService } from '../../../services'
+import config from '../../../config'
 
 /**
  * Middleware function to check whether a [SupportStrategyResponseDto] exists in the journeyData for the prisoner and support strategy reference in the request URL.
@@ -35,7 +36,11 @@ const retrieveSupportStrategyResponseDtoIfNotInJourneyData = (
         }
       } catch {
         req.flash('pageHasApiErrors', 'true')
-        return res.redirect(`/profile/${prisonNumber}/support-strategies`)
+        return res.redirect(
+          config.featureToggles.displayChallengesAndSupportStrategiesCombined
+            ? `/profile/${prisonNumber}/challenges-and-support`
+            : `/profile/${prisonNumber}/support-strategies`,
+        )
       }
     }
 

--- a/server/views/pages/challenges/delete/confirm/index.njk
+++ b/server/views/pages/challenges/delete/confirm/index.njk
@@ -44,9 +44,10 @@
             preventDoubleClick: true
           }) }}
 
+          {% set setNoButtonHref = "/profile/" + prisonerSummary.prisonNumber + ("/challenges-and-support" if featureToggles.displayChallengesAndSupportStrategiesCombined else "/challenges") + ("#archived-challenges" if mode == 'history' else "#current-challenges") %}
           {{ govukButton({
             text: "No, go back to overview",
-            href: "/profile/" + prisonerSummary.prisonNumber + "/challenges" + ("#archived-challenges" if mode == 'history' else "#current-challenges"),
+            href: setNoButtonHref,
             classes: "govuk-button--secondary",
             attributes: {"data-qa": "no-delete-link"}
           }) }}

--- a/server/views/pages/support-strategies/delete/confirm/index.njk
+++ b/server/views/pages/support-strategies/delete/confirm/index.njk
@@ -44,9 +44,10 @@
             preventDoubleClick: true
           }) }}
 
+          {% set setNoButtonHref = "/profile/" + prisonerSummary.prisonNumber + ("/challenges-and-support" if featureToggles.displayChallengesAndSupportStrategiesCombined else "/support-strategies") + ("#archived-support-strategies" if mode == 'history' else "#current-support-strategies") %}
           {{ govukButton({
             text: "No, go back to overview",
-            href: "/profile/" + prisonerSummary.prisonNumber + "/support-strategies" + ("#archived-support-strategies" if mode == 'history' else "#current-support-strategies"),
+            href: setNoButtonHref,
             classes: "govuk-button--secondary",
             attributes: {"data-qa": "no-delete-link"}
           }) }}


### PR DESCRIPTION
PR to update all the links and redirects from the previous separate routes of `/profile/${prisonNumber}/challenges` and `/profile/${prisonNumber}/support-strategies` to the new combined route `/profile/${prisonNumber}/challenges-and-support`
(all dependent on the feature toggle)
