### PR TITLE
RR-2811 - Corrected rendering of General category for Support Strategies

### DIFF
--- a/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.ts
+++ b/server/views/components/challenges-and-support-summary-card/challengesAndSupportSummaryCard.test.ts
@@ -623,4 +623,51 @@ describe('Tests for Challenges and Support Summary Card component', () => {
     expect(userHasPermissionTo).toHaveBeenCalledWith('EDIT_SUPPORT_STRATEGIES')
     expect(userHasPermissionTo).toHaveBeenCalledWith('ARCHIVE_SUPPORT_STRATEGIES')
   })
+
+  it('should not render anything to do with Challenges given the Support Strategies are in the category GENERAL', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      challengeAndSupportData: {
+        nonAlnChallenges: [] as Array<ChallengeResponseDto>,
+        latestAlnScreener: {},
+        supportStrategies: [
+          aValidSupportStrategyResponseDto({
+            supportStrategyCategoryTypeCode: SupportStrategyType.GENERAL,
+            details: 'John needs general help and support',
+            updatedByDisplayName: 'Person 4',
+            updatedAtPrison: 'BXI',
+            updatedAt: parseISO('2025-10-27'),
+          }),
+        ],
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('.govuk-summary-card__title').text().trim()).toEqual('Literacy skills')
+
+    // assert non-ALN challenges
+    const nonAlnChallenges = $('.govuk-summary-list__row.non-aln-challenge')
+    expect(nonAlnChallenges.length).toEqual(0)
+
+    // assert ALN challenges
+    const alnChallenges = $('.govuk-summary-list__row.aln-challenges li')
+    expect(alnChallenges.length).toEqual(0)
+
+    expect($('[data-qa=no-challenges]').length).toEqual(0)
+
+    // assert Support Strategies
+    const supportStrategies = $('.govuk-summary-list__row.support-strategy')
+    expect(supportStrategies.length).toEqual(1)
+    const firstSupportStrategy = supportStrategies.eq(0)
+    expect(firstSupportStrategy.find('p').eq(0).text().trim()).toEqual('John needs general help and support')
+    expect(firstSupportStrategy.find('[data-qa=support-strategy-audit]').text().trim()).toEqual(
+      'Last updated 27 Oct 2025 by Person 4, Brixton (HMP)',
+    )
+    expect($('[data-qa=no-support-strategies]').length).toEqual(0)
+  })
 })

--- a/server/views/components/challenges-and-support-summary-card/template.njk
+++ b/server/views/components/challenges-and-support-summary-card/template.njk
@@ -26,103 +26,108 @@
     <div class="govuk-summary-card__content govuk-!-padding-top-0">
       <div class="govuk-summary-list">
 
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Challenges</h3>
-        {% if nonAlnChallenges | length or challengesFromMostRecentAlnScreener | length %}
-          {# Render non-ALN challenges first #}
-          {% for challenge in nonAlnChallenges %}
-            <div class="govuk-summary-list__row non-aln-challenge" data-qa="non-aln-challenge-{{ challenge.challengeTypeCode }}">
-              <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="non-aln-challenge-symptoms">{{ challenge.symptoms }}</p>
+        {# If this component is being used to render one or more 'General' Support Strategies, there will be no Challenges of any type and we should not render anything to do with Challenges #}
+        {# The 'General' category can only be used for Support Strategies. It not possible to create a 'General' Challenge #}
+        {% set isGeneralSupportStrategy = (nonAlnChallenges | length === 0 ) and (challengesFromMostRecentAlnScreener | length === 0) and supportStrategies[0].supportStrategyTypeCode === 'GENERAL' %}
+        {% if not isGeneralSupportStrategy %}
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Challenges</h3>
+          {% if nonAlnChallenges | length or challengesFromMostRecentAlnScreener | length %}
+            {# Render non-ALN challenges first #}
+            {% for challenge in nonAlnChallenges %}
+              <div class="govuk-summary-list__row non-aln-challenge" data-qa="non-aln-challenge-{{ challenge.challengeTypeCode }}">
+                <p class="govuk-body govuk-!-margin-top-3 app-u-multiline-text" data-qa="non-aln-challenge-symptoms">{{ challenge.symptoms }}</p>
 
-              {% set howIdentifiedContent %}
-                <ul class="govuk-list govuk-!-font-size-16">
-                  {% for challengeIdentificationSource in challenge.howIdentified %}
-                    <li>{{ challengeIdentificationSource | formatChallengeIdentificationSourceScreenValue if challengeIdentificationSource != 'OTHER' else challenge.howIdentifiedOther }}</li>
+                {% set howIdentifiedContent %}
+                  <ul class="govuk-list govuk-!-font-size-16">
+                    {% for challengeIdentificationSource in challenge.howIdentified %}
+                      <li>{{ challengeIdentificationSource | formatChallengeIdentificationSourceScreenValue if challengeIdentificationSource != 'OTHER' else challenge.howIdentifiedOther }}</li>
+                    {% endfor %}
+                  </ul>
+                {% endset %}
+
+                {{ govukDetails({
+                  summaryText: "How was this identified",
+                  html: howIdentifiedContent,
+                  attributes: {
+                    "data-qa": "non-aln-challenge-how-identified"
+                  }
+                }) }}
+
+                <div class="actions-wrapper">
+                  <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="non-aln-challenge-audit">
+                    {% set prisonName = prisonNamesById[challenge.updatedAtPrison] | default(challenge.updatedAtPrison) %}
+                    Last updated {{ challenge.updatedAt | formatDate('d MMM yyyy') }} by {{ challenge.updatedByDisplayName }}, {{ prisonName }}
+                  </p>
+
+                  <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                    {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_CHALLENGES') %}
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/delete/reason" data-qa="delete-challenge-button">Delete</a>
+                      </li>
+                    {% endif %}
+                    {% if userHasPermissionTo('EDIT_CHALLENGES') %}
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/edit/detail" data-qa="edit-challenge-button">Edit</a>
+                      </li>
+                    {% endif %}
+                    {% if userHasPermissionTo('ARCHIVE_CHALLENGES') %}
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/archive/reason" data-qa="archive-challenge-button">Move to history</a>
+                      </li>
+                    {% endif %}
+                  </ul>
+                </div>
+              </div>
+            {% endfor %}
+
+            {# Render challenges from the most recent ALN Screener #}
+            {% if challengesFromMostRecentAlnScreener | length %}
+              <div class="govuk-summary-list__row aln-challenges">
+                <ul class="govuk-list govuk-!-margin-top-3">
+                  {% for challenge in challengesFromMostRecentAlnScreener %}
+                    {% set expanderContent %}
+                      <p class="app-u-multiline-text">{{ challenge.challengeTypeCode | challengeSupportTextLookup | default("Support strategy guidance not available") }}</p>
+                    {% endset %}
+                    <li>
+                      {{ govukDetails({
+                        summaryText: challenge.challengeTypeCode | formatChallengeTypeScreenValue,
+                        html: expanderContent,
+                        classes: "govuk-!-margin-top-3",
+                        attributes: {
+                          "data-qa": "aln-challenge-detail"
+                        }
+                      }) }}
+                    </li>
                   {% endfor %}
                 </ul>
-              {% endset %}
 
-              {{ govukDetails({
-                summaryText: "How was this identified",
-                html: howIdentifiedContent,
-                attributes: {
-                  "data-qa": "non-aln-challenge-how-identified"
-                }
-              }) }}
+                <div class="actions-wrapper">
+                  <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="aln-challenges-audit">
+                    {% set prisonName = prisonNamesById[latestAlnScreener.createdAtPrison] | default(latestAlnScreener.createdAtPrison) %}
+                    From Additional Learning Needs Screener completed on {{ latestAlnScreener.screenerDate | formatDate('d MMM yyyy') }}, {{ prisonName }}
+                  </p>
 
-              <div class="actions-wrapper">
-                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="non-aln-challenge-audit">
-                  {% set prisonName = prisonNamesById[challenge.updatedAtPrison] | default(challenge.updatedAtPrison) %}
-                  Last updated {{ challenge.updatedAt | formatDate('d MMM yyyy') }} by {{ challenge.updatedByDisplayName }}, {{ prisonName }}
-                </p>
-
-                <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_CHALLENGES') %}
-                    <li class="govuk-summary-card__action">
-                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/delete/reason" data-qa="delete-challenge-button">Delete</a>
-                    </li>
+                  {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_ALN_SCREENER') %}
+                    <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+                      <li class="govuk-summary-card__action">
+                        <a class="govuk-link govuk-!-font-weight-regular" href="/aln-screener/{{ params.prisonNumber }}/delete/reason?from=challenges" data-qa="delete-aln-screener-button">Delete</a>
+                      </li>
+                    </ul>
                   {% endif %}
-                  {% if userHasPermissionTo('EDIT_CHALLENGES') %}
-                    <li class="govuk-summary-card__action">
-                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/edit/detail" data-qa="edit-challenge-button">Edit</a>
-                    </li>
-                  {% endif %}
-                  {% if userHasPermissionTo('ARCHIVE_CHALLENGES') %}
-                    <li class="govuk-summary-card__action">
-                      <a class="govuk-link govuk-!-font-weight-regular" href="/challenges/{{ challenge.prisonNumber }}/{{ challenge.reference }}/archive/reason" data-qa="archive-challenge-button">Move to history</a>
-                    </li>
-                  {% endif %}
-                </ul>
+                </div>
               </div>
-            </div>
-          {% endfor %}
+            {% endif %}
 
-          {# Render challenges from the most recent ALN Screener #}
-          {% if challengesFromMostRecentAlnScreener | length %}
-            <div class="govuk-summary-list__row aln-challenges">
-              <ul class="govuk-list govuk-!-margin-top-3">
-                {% for challenge in challengesFromMostRecentAlnScreener %}
-                  {% set expanderContent %}
-                    <p class="app-u-multiline-text">{{ challenge.challengeTypeCode | challengeSupportTextLookup | default("Support strategy guidance not available") }}</p>
-                  {% endset %}
-                  <li>
-                    {{ govukDetails({
-                      summaryText: challenge.challengeTypeCode | formatChallengeTypeScreenValue,
-                      html: expanderContent,
-                      classes: "govuk-!-margin-top-3",
-                      attributes: {
-                        "data-qa": "aln-challenge-detail"
-                      }
-                    }) }}
-                  </li>
-                {% endfor %}
-              </ul>
-
-              <div class="actions-wrapper">
-                <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="aln-challenges-audit">
-                  {% set prisonName = prisonNamesById[latestAlnScreener.createdAtPrison] | default(latestAlnScreener.createdAtPrison) %}
-                  From Additional Learning Needs Screener completed on {{ latestAlnScreener.screenerDate | formatDate('d MMM yyyy') }}, {{ prisonName }}
-                </p>
-
-                {% if featureToggles.sanDataDeletionEnabled and userHasPermissionTo('DELETE_ALN_SCREENER') %}
-                  <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-                    <li class="govuk-summary-card__action">
-                      <a class="govuk-link govuk-!-font-weight-regular" href="/aln-screener/{{ params.prisonNumber }}/delete/reason?from=challenges" data-qa="delete-aln-screener-button">Delete</a>
-                    </li>
-                  </ul>
+          {% else %}
+            <div class="govuk-summary-list__row" data-qa="no-challenges">
+              <p class="govuk-body govuk-!-margin-top-3">
+                No {{ params.title | lower }} challenges recorded.
+                {% if userHasPermissionTo('RECORD_CHALLENGES') %}
+                  <a class="govuk-link govuk-!-display-none-print" href="/challenges/{{ params.prisonNumber }}/create/select-category">Add a challenge.</a>
                 {% endif %}
-              </div>
+              </p>
             </div>
           {% endif %}
-
-        {% else %}
-          <div class="govuk-summary-list__row" data-qa="no-challenges">
-            <p class="govuk-body govuk-!-margin-top-3">
-              No {{ params.title | lower }} challenges recorded.
-              {% if userHasPermissionTo('RECORD_CHALLENGES') %}
-                <a class="govuk-link govuk-!-display-none-print" href="/challenges/{{ params.prisonNumber }}/create/select-category">Add a challenge.</a>
-              {% endif %}
-            </p>
-          </div>
         {% endif %}
 
         <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-2">Support strategies</h3>

--- a/server/views/pages/profile/challenges-and-support/index.njk
+++ b/server/views/pages/profile/challenges-and-support/index.njk
@@ -60,12 +60,19 @@
 
           {% if activeCategoriesCount > 0 %}
             {% for challengeAndSupportCategory, challengeAndSupportData in activeChallengesAndSupportByCategory %}
+              {%- set summaryCardTitle -%}
+                {%- if challengeAndSupportCategory !== 'GENERAL' -%}
+                  {{ challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true) }}
+                {%- else -%}
+                  {{ challengeAndSupportCategory | formatSupportStrategyTypeScreenValue | default(challengeAndSupportCategory, true) }}
+                {%- endif -%}
+              {%- endset -%}
               {{ challengesAndSupportSummaryCard({
                 challengeAndSupportData: challengeAndSupportData,
                 prisonNamesById: prisonNamesById,
                 prisonNumber: prisonerSummary.prisonNumber,
                 userHasPermissionTo: userHasPermissionTo,
-                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true),
+                title: summaryCardTitle,
                 attributes: {
                   'data-qa': 'active-challenges-and-support-summary-card-' + challengeAndSupportCategory
                 }
@@ -79,12 +86,19 @@
             {% for challengeAndSupportCategory, challengeAndSupportData in archivedChallengesAndSupportByCategory %}
               {% set archivedChallenges = challengeAndSupportData.nonAlnChallenges %}
               {% set archivedSupportStrategies = challengeAndSupportData.supportStrategies %}
+              {%- set summaryCardTitle -%}
+                {%- if challengeAndSupportCategory !== 'GENERAL' -%}
+                  {{ challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true) }}
+                {%- else -%}
+                  {{ challengeAndSupportCategory | formatSupportStrategyTypeScreenValue | default(challengeAndSupportCategory, true) }}
+                {%- endif -%}
+              {%- endset -%}
               {{ archivedChallengesAndSupportSummaryCard({
                 archivedChallenges: archivedChallenges,
                 archivedSupportStrategies: archivedSupportStrategies,
                 prisonNamesById: prisonNamesById,
                 userHasPermissionTo: userHasPermissionTo,
-                title: challengeAndSupportCategory | formatChallengeCategoryScreenValue | default(challengeAndSupportCategory, true),
+                title: summaryCardTitle,
                 attributes: {
                   'data-qa': 'archived-challenges-and-support-summary-card_' + challengeCategory
                 }

--- a/server/views/pages/profile/challenges-and-support/index.test.ts
+++ b/server/views/pages/profile/challenges-and-support/index.test.ts
@@ -7,6 +7,7 @@ import { Result } from '../../../../utils/result/result'
 import formatChallengeCategoryScreenValueFilter from '../../../../filters/formatChallengeCategoryFilter'
 import formatChallengeIdentificationSourceScreenValueFilter from '../../../../filters/formatChallengeIdentificationSourceFilter'
 import { formatChallengeTypeScreenValueFilter } from '../../../../filters/formatChallengeTypeFilter'
+import { formatSupportStrategyTypeScreenValueFilter } from '../../../../filters/formatSupportStrategyTypeFilter'
 import aPlanLifecycleStatusDto from '../../../../testsupport/planLifecycleStatusDtoTestDataBuilder'
 import challengeStaffSupportTextLookupFilter from '../../../../filters/challengeStaffSupportTextLookupFilter'
 
@@ -28,6 +29,7 @@ njkEnv //
   .addFilter('formatChallengeCategoryScreenValue', formatChallengeCategoryScreenValueFilter)
   .addFilter('formatChallengeIdentificationSourceScreenValue', formatChallengeIdentificationSourceScreenValueFilter)
   .addFilter('formatChallengeTypeScreenValue', formatChallengeTypeScreenValueFilter)
+  .addFilter('formatSupportStrategyTypeScreenValue', formatSupportStrategyTypeScreenValueFilter)
   .addFilter('challengeSupportTextLookup', challengeStaffSupportTextLookupFilter)
 
 const prisonerSummary = aValidPrisonerSummary({


### PR DESCRIPTION
This PR fixes the rendering of General category for Support Strategies.

The page is the combined Challenges and Support Strategies page, showing both Challenges and Support Strategies grouped by category.
For the most part this works because Challenges and Support Strategies share a common set of categories ....

... except the Support Strategory category "General". IE. it is possible to create a Support Strategy with the category "General", but you cannot create a "General" Challenge.

When rendering the combined set of Challenges and Support Strategies, all Support Strategies that are in the General category must be rendered without any mention of Challenges.

IE. it is changing this:
<img width="832" height="383" alt="Screenshot 2026-08-06 at 11 37 54" src="https://github.com/user-attachments/assets/74650806-640e-4dac-ad3e-9b9ef0188d0e" />


to this:
<img width="853" height="298" alt="Screenshot 2026-08-06 at 11 38 04" src="https://github.com/user-attachments/assets/e63d4350-c581-40e1-9eea-d8d5bad12de9" />
